### PR TITLE
Perf hunt round 22: ten random-sample hot-path fixes

### DIFF
--- a/src/libse/Common/ConvertColorsToDialogUtils.cs
+++ b/src/libse/Common/ConvertColorsToDialogUtils.cs
@@ -30,8 +30,8 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 while (index < p.Text.Length)
                 {
-                    bool isHtmlColor = index + "<font color".Length <= p.Text.Length && p.Text.SafeSubstring(index, "<font color".Length).ToLowerInvariant() == "<font color";
-                    bool isVttColor = index + "<c.".Length <= p.Text.Length && p.Text.SafeSubstring(index, "<c.".Length).ToLowerInvariant() == "<c.";
+                    bool isHtmlColor = IsAt(p.Text, index, "<font color", StringComparison.OrdinalIgnoreCase);
+                    bool isVttColor = IsAt(p.Text, index, "<c.", StringComparison.OrdinalIgnoreCase);
 
                     if (isHtmlColor || isVttColor)
                     {
@@ -52,8 +52,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                         else if (currentColor != newColor)
                         {
                             // Don't insert dash if there is already a dash, but DO insert a dash if it is an interruption
-                            if (p.Text.SafeSubstring(index, 1) != "-" && p.Text.SafeSubstring(index - 1, 1) != "-"
-                                && (p.Text.SafeSubstring(index - 2, 2) != "- " || p.Text.SafeSubstring(index - 3, 3) == "-- "))
+                            if (!CharAt(p.Text, index, '-') && !CharAt(p.Text, index - 1, '-')
+                                && (!IsAt(p.Text, index - 2, "- ", StringComparison.Ordinal) || IsAt(p.Text, index - 3, "-- ", StringComparison.Ordinal)))
                             {
                                 if (dashFirstLine && !firstLineAdded)
                                 {
@@ -75,12 +75,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                                     firstLineAdded = true;
                                 }
 
-                                if (!addNewLines && p.Text.SafeSubstring(index - 1, 1) != " " && p.Text.SafeSubstring(index - 1, 1) != "\r" && p.Text.SafeSubstring(index - 1, 1) != "\n")
+                                if (!addNewLines && !CharAt(p.Text, index - 1, ' ') && !CharAt(p.Text, index - 1, '\r') && !CharAt(p.Text, index - 1, '\n'))
                                 {
                                     p.Text = p.Text.SafeSubstring(0, index) + " " + p.Text.SafeSubstring(index);
                                     index += 1;
                                 }
-                                else if (addNewLines && p.Text.SafeSubstring(index - 1, 1) != "\r" && p.Text.SafeSubstring(index - 1, 1) != "\n")
+                                else if (addNewLines && !CharAt(p.Text, index - 1, '\r') && !CharAt(p.Text, index - 1, '\n'))
                                 {
                                     p.Text = p.Text.SafeSubstring(0, index) + Environment.NewLine + p.Text.SafeSubstring(index);
                                     index += Environment.NewLine.Length;
@@ -106,21 +106,21 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                         endOfColor = false;
                     }
-                    else if (index + "</font>".Length <= p.Text.Length && p.Text.SafeSubstring(index, "</font>".Length).ToLowerInvariant() == "</font>")
+                    else if (IsAt(p.Text, index, "</font>", StringComparison.OrdinalIgnoreCase))
                     {
                         // End of HTML color
                         endOfColor = true;
 
                         index += "</font>".Length;
                     }
-                    else if (index + "</c>".Length <= p.Text.Length && p.Text.SafeSubstring(index, "</c>".Length).ToLowerInvariant() == "</c>")
+                    else if (IsAt(p.Text, index, "</c>", StringComparison.OrdinalIgnoreCase))
                     {
                         // End of VTT color
                         endOfColor = true;
 
                         index += "</c>".Length;
                     }
-                    else if (index + "{".Length <= p.Text.Length && p.Text.SafeSubstring(index, "{".Length) == "{")
+                    else if (CharAt(p.Text, index, '{'))
                     {
                         // ASS tag, jump over. Same trap as the '>' search above: an unclosed
                         // '{' has no '}', and "-1 + 1" restarted the scan at 0 forever.
@@ -132,7 +132,7 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                         index = assaTagEnd + 1;
                     }
-                    else if (index + 1 <= p.Text.Length && p.Text.SafeSubstring(index, 1) == " " || p.Text.SafeSubstring(index, 1) == "\r" || p.Text.SafeSubstring(index, 1) == "\n")
+                    else if (CharAt(p.Text, index, ' ') || CharAt(p.Text, index, '\r') || CharAt(p.Text, index, '\n'))
                     {
                         // Whitespace, ignore
                         index += 1;
@@ -153,8 +153,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                                 if (currentColor != newColor)
                                 {
                                     // Don't insert dash if there is already a dash, but DO insert a dash if it is an interruption
-                                    if (p.Text.SafeSubstring(index, 1) != "-" && p.Text.SafeSubstring(index - 1, 1) != "-"
-                                        && (p.Text.SafeSubstring(index - 2, 2) != "- " || p.Text.SafeSubstring(index - 3, 3) == "-- "))
+                                    if (!CharAt(p.Text, index, '-') && !CharAt(p.Text, index - 1, '-')
+                                        && (!IsAt(p.Text, index - 2, "- ", StringComparison.Ordinal) || IsAt(p.Text, index - 3, "-- ", StringComparison.Ordinal)))
                                     {
                                         if (dashFirstLine && !firstLineAdded)
                                         {
@@ -173,9 +173,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                             firstLineAdded = true;
                                         }
 
-                                        if (!addNewLines && p.Text.SafeSubstring(index - 1, 1) != " " && p.Text.SafeSubstring(index - 1, 1) != "\r" && p.Text.SafeSubstring(index - 1, 1) != "\n")
+                                        if (!addNewLines && !CharAt(p.Text, index - 1, ' ') && !CharAt(p.Text, index - 1, '\r') && !CharAt(p.Text, index - 1, '\n'))
                                         {
-                                            if (p.Text.SafeSubstring(index, 1) == ".")
+                                            if (CharAt(p.Text, index, '.'))
                                             {
                                                 index++;
                                             }
@@ -183,9 +183,9 @@ namespace Nikse.SubtitleEdit.Core.Common
                                             p.Text = p.Text.SafeSubstring(0, index) + " " + p.Text.SafeSubstring(index);
                                             index += 1;
                                         }
-                                        else if (addNewLines && p.Text.SafeSubstring(index - 1, 1) != "\r" && p.Text.SafeSubstring(index - 1, 1) != "\n")
+                                        else if (addNewLines && !CharAt(p.Text, index - 1, '\r') && !CharAt(p.Text, index - 1, '\n'))
                                         {
-                                            if (p.Text.SafeSubstring(index + 1, 1) != "\r" && p.Text.SafeSubstring(index + 1, 1) != "\n" &&
+                                            if (!CharAt(p.Text, index + 1, '\r') && !CharAt(p.Text, index + 1, '\n') &&
                                                 index < p.Text.Length-1)
                                             {
                                                 p.Text = p.Text.SafeSubstring(0, index) + Environment.NewLine + p.Text.SafeSubstring(index);
@@ -193,7 +193,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                                             }
                                         }
 
-                                        if (p.Text.SafeSubstring(index + 1, 1) != "\r" && p.Text.SafeSubstring(index + 1, 1) != "\n" &&
+                                        if (!CharAt(p.Text, index + 1, '\r') && !CharAt(p.Text, index + 1, '\n') &&
                                                 index < p.Text.Length - 1)
                                         {
                                             p.Text = p.Text.SafeSubstring(0, index) + dash + p.Text.SafeSubstring(index);
@@ -235,6 +235,26 @@ namespace Nikse.SubtitleEdit.Core.Common
                     p.Text = Utilities.AutoBreakLine(p.Text, language);
                 }
             }
+        }
+
+        /// <summary>
+        /// True when <paramref name="value"/> has <paramref name="c"/> at <paramref name="index"/>;
+        /// false when the index is out of range, which is what the one-char SafeSubstring probes
+        /// it replaces answered ("" never equals a one-char string). No string per probe - the
+        /// scan probes every position of every paragraph.
+        /// </summary>
+        private static bool CharAt(string value, int index, char c)
+        {
+            return index >= 0 && index < value.Length && value[index] == c;
+        }
+
+        /// <summary>
+        /// True when <paramref name="prefix"/> occurs at <paramref name="index"/>; false when the
+        /// window falls outside the string, matching the SafeSubstring-equals probes it replaces.
+        /// </summary>
+        private static bool IsAt(string value, int index, string prefix, StringComparison comparison)
+        {
+            return index >= 0 && index <= value.Length && value.AsSpan(index).StartsWith(prefix.AsSpan(), comparison);
         }
 
         private static string SafeSubstring(this string value, int startIndex, int length = -1, string defaultValue = "")

--- a/src/libse/Common/FixCasing.cs
+++ b/src/libse/Common/FixCasing.cs
@@ -102,11 +102,11 @@ namespace Nikse.SubtitleEdit.Core.Common
             {
                 if (indexOfI == 0 || pre.Contains(text[indexOfI - 1]))
                 {
-                    if (text.Substring(indexOfI).StartsWith("i-i ", StringComparison.Ordinal))
+                    if (text.AsSpan(indexOfI).StartsWith("i-i ".AsSpan(), StringComparison.Ordinal))
                     {
                         text = text.Remove(indexOfI, 3).Insert(indexOfI, "I-I");
                     }
-                    else if (text.Substring(indexOfI).StartsWith("i-if ", StringComparison.Ordinal))
+                    else if (text.AsSpan(indexOfI).StartsWith("i-if ".AsSpan(), StringComparison.Ordinal))
                     {
                         text = text.Remove(indexOfI, 4).Insert(indexOfI, "I-If");
                     }
@@ -123,7 +123,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     text = text.Remove(indexOfI, 1).Insert(indexOfI, "I");
                 }
-                else if (indexOfI > 1 && "\r\n ".Contains(text[indexOfI - 1]) && text.Substring(indexOfI).StartsWith("i-i ", StringComparison.Ordinal))
+                else if (indexOfI > 1 && "\r\n ".Contains(text[indexOfI - 1]) && text.AsSpan(indexOfI).StartsWith("i-i ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI, 3).Insert(indexOfI, "I-I");
                 }
@@ -131,27 +131,27 @@ namespace Nikse.SubtitleEdit.Core.Common
                 {
                     text = text.Remove(indexOfI, 1).Insert(indexOfI, "I");
                 }
-                else if (indexOfI > 2 && text.Substring(indexOfI - 2).StartsWith("I-i ", StringComparison.Ordinal))
+                else if (indexOfI > 2 && text.AsSpan(indexOfI - 2).StartsWith("I-i ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI - 2, 3).Insert(indexOfI - 2, "I-I");
                 }
-                else if (indexOfI > 2 && text.Substring(indexOfI - 2).StartsWith("I-it's ", StringComparison.Ordinal))
+                else if (indexOfI > 2 && text.AsSpan(indexOfI - 2).StartsWith("I-it's ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI - 2, 3).Insert(indexOfI - 2, "I-I");
                 }
-                else if (text.Substring(indexOfI).StartsWith("i'll ", StringComparison.Ordinal))
+                else if (text.AsSpan(indexOfI).StartsWith("i'll ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI, 1).Insert(indexOfI, "I");
                 }
-                else if (text.Substring(indexOfI).StartsWith("i've ", StringComparison.Ordinal))
+                else if (text.AsSpan(indexOfI).StartsWith("i've ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI, 1).Insert(indexOfI, "I");
                 }
-                else if (text.Substring(indexOfI).StartsWith("i'm ", StringComparison.Ordinal))
+                else if (text.AsSpan(indexOfI).StartsWith("i'm ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI, 1).Insert(indexOfI, "I");
                 }
-                else if (text.Substring(indexOfI).StartsWith("i'd ", StringComparison.Ordinal))
+                else if (text.AsSpan(indexOfI).StartsWith("i'd ".AsSpan(), StringComparison.Ordinal))
                 {
                     text = text.Remove(indexOfI, 1).Insert(indexOfI, "I");
                 }

--- a/src/libse/Common/StringBuilderExtensions.cs
+++ b/src/libse/Common/StringBuilderExtensions.cs
@@ -37,6 +37,50 @@ namespace Nikse.SubtitleEdit.Core.Common
             return sb.Length > 0 && sb[sb.Length - 1] == c;
         }
 
+        // Ordinal "sb.ToString().EndsWith(value)" without materializing the builder.
+        public static bool EndsWith(this StringBuilder sb, string value)
+        {
+            var offset = sb.Length - value.Length;
+            if (offset < 0)
+            {
+                return false;
+            }
+
+            for (var i = value.Length - 1; i >= 0; i--)
+            {
+                if (sb[offset + i] != value[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Same answer as string.IsNullOrWhiteSpace(sb.ToString()) without the copy.
+        // Walks the chunks directly: the StringBuilder indexer locates the chunk on every call,
+        // which is cheap at the tail but quadratic when scanning from the front.
+        public static bool IsNullOrWhiteSpace(this StringBuilder sb)
+        {
+#if NETSTANDARD2_1
+            return string.IsNullOrWhiteSpace(sb.ToString());
+#else
+            foreach (var chunk in sb.GetChunks())
+            {
+                var span = chunk.Span;
+                for (var i = 0; i < span.Length; i++)
+                {
+                    if (!char.IsWhiteSpace(span[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+#endif
+        }
+
         // Same count as scanning sb.ToString() without materializing the whole
         // accumulated text into a fresh string.
         public static int CountChar(this StringBuilder sb, char c)

--- a/src/libse/Common/TextLengthCalculator/CalcCJK.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcCJK.cs
@@ -1,4 +1,9 @@
-﻿using System.Globalization;
+﻿#if NET8_0_OR_GREATER
+using System.Buffers;
+#else
+using System.Collections.Generic;
+#endif
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
@@ -16,67 +21,122 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
             }
 
             var s = HtmlUtil.RemoveHtmlTags(text, true);
+            return Count(s, skipSpace: false, includeJapaneseFullWidth: true);
+        }
 
-            const char zeroWidthSpace = '\u200B';
-            const char zeroWidthNoBreakSpace = '\uFEFF';
+        /// <summary>
+        /// Shared body of the CJK calculators. Runs per grid-row repaint, per keystroke and per
+        /// waveform frame, so the common case - every char its own text element - counts the
+        /// chars directly instead of walking StringInfo.GetTextElementEnumerator (an enumerator
+        /// plus one string per element), and set membership is a SearchValues lookup rather than
+        /// a linear scan over each literal per character.
+        /// </summary>
+        /// <param name="s">Text to measure.</param>
+        /// <param name="skipSpace">CalcCjkNoSpace: ' ' scores 0.</param>
+        /// <param name="includeJapaneseFullWidth">CalcCjk also scores <see cref="JapaneseFullWidthCharacters"/> as full width (single-char elements only, as before).</param>
+        internal static decimal Count(string s, bool skipSpace, bool includeJapaneseFullWidth)
+        {
             decimal length = 0;
+
+            if (TextElements.AreAllSingleChar(s, out var crLfCount))
+            {
+                foreach (var c in s)
+                {
+                    length += CharWeight(c, skipSpace, includeJapaneseFullWidth);
+                }
+
+                // "\r\n" is the one multi-char element that survives the probe. Its chars are
+                // controls, so the loop above added nothing for them - but the element walk
+                // below scores the pair like any other unknown multi-char element: 0.5.
+                for (var i = 0; i < crLfCount; i++)
+                {
+                    length += 0.5m;
+                }
+
+                return length;
+            }
+
             for (var en = StringInfo.GetTextElementEnumerator(s); en.MoveNext();)
             {
                 var element = en.GetTextElement();
                 if (element.Length == 1)
                 {
-                    var ch = element[0];
-                    if (!char.IsControl(ch) &&
-                        ch != zeroWidthSpace &&
-                        ch != zeroWidthNoBreakSpace &&
-                        ch != '\u200E' &&
-                        ch != '\u200F' &&
-                        ch != '\u202A' &&
-                        ch != '\u202B' &&
-                        ch != '\u202C' &&
-                        ch != '\u202D' &&
-                        ch != '\u202E')
-                    {
-                        if (JapaneseHalfWidthCharacters.Contains(ch))
-                        {
-                            length += 0.5m;
-                        }
-                        else if (ChineseFullWidthPunctuations.Contains(ch) ||
-                                 JapaneseFullWidthCharacters.Contains(ch) ||
-                                 LanguageAutoDetect.Letters.Japanese.Contains(ch) ||
-                                 LanguageAutoDetect.Letters.Korean.Contains(ch) ||
-                                 IsCjk(ch))
-                        {
-                            length++;
-                        }
-                        else
-                        {
-                            length += 0.5m;
-                        }
-                    }
+                    length += CharWeight(element[0], skipSpace, includeJapaneseFullWidth);
                 }
                 else
                 {
-                    if (JapaneseHalfWidthCharacters.Contains(element))
-                    {
-                        length += 0.5m;
-                    }
-                    else if (ChineseFullWidthPunctuations.Contains(element) ||
-                             LanguageAutoDetect.Letters.Japanese.Contains(element) ||
-                             LanguageAutoDetect.Letters.Korean.Contains(element) ||
-                             CjkCharRegex.IsMatch(element))
-                    {
-                        length++;
-                    }
-                    else
-                    {
-                        length += 0.5m;
-                    }
+                    length += ElementWeight(element);
                 }
             }
 
             return length;
         }
+
+        private static decimal CharWeight(char ch, bool skipSpace, bool includeJapaneseFullWidth)
+        {
+            const char zeroWidthSpace = '\u200B';
+            const char zeroWidthNoBreakSpace = '\uFEFF';
+            if (char.IsControl(ch) ||
+                skipSpace && ch == ' ' ||
+                ch == zeroWidthSpace ||
+                ch == zeroWidthNoBreakSpace ||
+                ch == '\u200E' ||
+                ch == '\u200F' ||
+                ch == '\u202A' ||
+                ch == '\u202B' ||
+                ch == '\u202C' ||
+                ch == '\u202D' ||
+                ch == '\u202E')
+            {
+                return 0;
+            }
+
+            if (JapaneseHalfWidthSet.Contains(ch))
+            {
+                return 0.5m;
+            }
+
+            // Pure OR, so the cheap range test goes first.
+            if (IsCjk(ch) || (includeJapaneseFullWidth ? FullWidthWithJapaneseSet : FullWidthSet).Contains(ch))
+            {
+                return 1;
+            }
+
+            return 0.5m;
+        }
+
+        /// <summary>
+        /// Multi-char text element (grapheme cluster). Kept as the substring probes it always was
+        /// (<c>string.Contains(string)</c>) - this is the rare path.
+        /// </summary>
+        private static decimal ElementWeight(string element)
+        {
+            if (JapaneseHalfWidthCharacters.Contains(element))
+            {
+                return 0.5m;
+            }
+
+            if (ChineseFullWidthPunctuations.Contains(element) ||
+                LanguageAutoDetect.Letters.Japanese.Contains(element) ||
+                LanguageAutoDetect.Letters.Korean.Contains(element) ||
+                CjkCharRegex.IsMatch(element))
+            {
+                return 1;
+            }
+
+            return 0.5m;
+        }
+
+#if NET8_0_OR_GREATER
+        private static readonly SearchValues<char> JapaneseHalfWidthSet = SearchValues.Create(JapaneseHalfWidthCharacters);
+        private static readonly SearchValues<char> FullWidthSet = SearchValues.Create(ChineseFullWidthPunctuations + LanguageAutoDetect.Letters.Japanese + LanguageAutoDetect.Letters.Korean);
+        private static readonly SearchValues<char> FullWidthWithJapaneseSet = SearchValues.Create(ChineseFullWidthPunctuations + JapaneseFullWidthCharacters + LanguageAutoDetect.Letters.Japanese + LanguageAutoDetect.Letters.Korean);
+#else
+        // netstandard2.1 has no SearchValues; a HashSet still beats the linear scan per character.
+        private static readonly HashSet<char> JapaneseHalfWidthSet = new HashSet<char>(JapaneseHalfWidthCharacters);
+        private static readonly HashSet<char> FullWidthSet = new HashSet<char>(ChineseFullWidthPunctuations + LanguageAutoDetect.Letters.Japanese + LanguageAutoDetect.Letters.Korean);
+        private static readonly HashSet<char> FullWidthWithJapaneseSet = new HashSet<char>(ChineseFullWidthPunctuations + JapaneseFullWidthCharacters + LanguageAutoDetect.Letters.Japanese + LanguageAutoDetect.Letters.Korean);
+#endif
 
         public const string JapaneseHalfWidthCharacters = "｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞﾟ";
         public const string JapaneseFullWidthCharacters = "ぁあぃいぅうぇえぉおァアィイゥウェエォオㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹ一二三四五六七八九十学校日本、。・「」々〆〇";

--- a/src/libse/Common/TextLengthCalculator/CalcCJKNoSpace.cs
+++ b/src/libse/Common/TextLengthCalculator/CalcCJKNoSpace.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
+﻿namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
 {
     public class CalcCjkNoSpace : ICalcLength
     {
@@ -15,66 +13,7 @@ namespace Nikse.SubtitleEdit.Core.Common.TextLengthCalculator
             }
 
             var s = HtmlUtil.RemoveHtmlTags(text, true);
-
-            const char zeroWidthSpace = '\u200B';
-            const char zeroWidthNoBreakSpace = '\uFEFF';
-            decimal length = 0;
-            for (var en = StringInfo.GetTextElementEnumerator(s); en.MoveNext();)
-            {
-                var element = en.GetTextElement();
-                if (element.Length == 1)
-                {
-                    var ch = element[0];
-                    if (!char.IsControl(ch) &&
-                        ch != ' ' &&
-                        ch != zeroWidthSpace &&
-                        ch != zeroWidthNoBreakSpace &&
-                        ch != '\u200E' &&
-                        ch != '\u200F' &&
-                        ch != '\u202A' &&
-                        ch != '\u202B' &&
-                        ch != '\u202C' &&
-                        ch != '\u202D' &&
-                        ch != '\u202E')
-                    {
-                        if (CalcCjk.JapaneseHalfWidthCharacters.Contains(ch))
-                        {
-                            length += 0.5m;
-                        }
-                        else if (CalcCjk.ChineseFullWidthPunctuations.Contains(ch) ||
-                                 LanguageAutoDetect.Letters.Japanese.Contains(ch) ||
-                                 LanguageAutoDetect.Letters.Korean.Contains(ch) ||
-                                 CalcCjk.IsCjk(ch))
-                        {
-                            length++;
-                        }
-                        else
-                        {
-                            length += 0.5m;
-                        }
-                    }
-                }
-                else
-                {
-                    if (CalcCjk.JapaneseHalfWidthCharacters.Contains(element))
-                    {
-                        length += 0.5m;
-                    }
-                    else if (CalcCjk.ChineseFullWidthPunctuations.Contains(element) ||
-                             LanguageAutoDetect.Letters.Japanese.Contains(element) ||
-                             LanguageAutoDetect.Letters.Korean.Contains(element) ||
-                             CalcCjk.CjkCharRegex.IsMatch(element))
-                    {
-                        length++;
-                    }
-                    else
-                    {
-                        length += 0.5m;
-                    }
-                }
-            }
-
-            return length;
+            return CalcCjk.Count(s, skipSpace: true, includeJapaneseFullWidth: false);
         }
     }
 }

--- a/src/libse/Forms/RemoveInterjection.cs
+++ b/src/libse/Forms/RemoveInterjection.cs
@@ -67,11 +67,10 @@ namespace Nikse.SubtitleEdit.Core.Forms
                         {
                             var index = match.Index;
 
-                            var fromIndexPart = text.Substring(match.Index);
                             var doSkip = false;
                             foreach (var skipIfStartsWith in context.InterjectionsSkipIfStartsWith)
                             {
-                                if (fromIndexPart.StartsWith(skipIfStartsWith, StringComparison.OrdinalIgnoreCase))
+                                if (text.AsSpan(index).StartsWith(skipIfStartsWith.AsSpan(), StringComparison.OrdinalIgnoreCase))
                                 {
                                     doSkip = true;
                                     break;

--- a/src/libse/SubtitleFormats/AdobeEncore.cs
+++ b/src/libse/SubtitleFormats/AdobeEncore.cs
@@ -19,13 +19,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
         {
             var subtitle = new Subtitle();
 
-            var sb = new StringBuilder();
-            foreach (string line in lines)
-            {
-                sb.AppendLine(line);
-            }
+            var allText = JoinLines(lines);
 
-            if (sb.ToString().Contains("#INPOINT OUTPOINT PATH"))
+            if (allText.Contains("#INPOINT OUTPOINT PATH"))
             {
                 return false; // Pinnacle Impression
             }
@@ -38,9 +34,10 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 if (p.Text.Contains(Environment.NewLine))
                 {
                     containsNewLine = true;
+                    break;
                 }
             }
-            if (sb.ToString().Contains("//") && !containsNewLine)
+            if (!containsNewLine && allText.Contains("//"))
             {
                 return false; // "DVD Subtitle System" format
             }

--- a/src/libse/SubtitleFormats/AdobeEncoreLineTabNewLine.cs
+++ b/src/libse/SubtitleFormats/AdobeEncoreLineTabNewLine.cs
@@ -16,18 +16,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            foreach (string line in lines)
-            {
-                sb.AppendLine(line);
-            }
+            var allText = JoinLines(lines);
 
-            if (sb.ToString().Contains(Environment.NewLine + "SP_NUMBER\tSTART\tEND\tFILE_NAME"))
+            if (allText.Contains(Environment.NewLine + "SP_NUMBER\tSTART\tEND\tFILE_NAME"))
             {
                 return false; // SON
             }
 
-            if (sb.ToString().Contains(Environment.NewLine + "SP_NUMBER     START        END       FILE_NAME"))
+            if (allText.Contains(Environment.NewLine + "SP_NUMBER     START        END       FILE_NAME"))
             {
                 return false; // SON
             }

--- a/src/libse/SubtitleFormats/AdobeEncoreLineTabs.cs
+++ b/src/libse/SubtitleFormats/AdobeEncoreLineTabs.cs
@@ -16,18 +16,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            foreach (string line in lines)
-            {
-                sb.AppendLine(line);
-            }
+            var allText = JoinLines(lines);
 
-            if (sb.ToString().Contains(Environment.NewLine + "SP_NUMBER\tSTART\tEND\tFILE_NAME"))
+            if (allText.Contains(Environment.NewLine + "SP_NUMBER\tSTART\tEND\tFILE_NAME"))
             {
                 return false; // SON
             }
 
-            if (sb.ToString().Contains(Environment.NewLine + "SP_NUMBER     START        END       FILE_NAME"))
+            if (allText.Contains(Environment.NewLine + "SP_NUMBER     START        END       FILE_NAME"))
             {
                 return false; // SON
             }

--- a/src/libse/SubtitleFormats/AdobeEncoreWithLineNumbers.cs
+++ b/src/libse/SubtitleFormats/AdobeEncoreWithLineNumbers.cs
@@ -16,18 +16,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            foreach (var line in lines)
-            {
-                sb.AppendLine(line);
-            }
+            var allText = JoinLines(lines);
 
-            if (sb.ToString().Contains("#INPOINT OUTPOINT PATH"))
+            if (allText.Contains("#INPOINT OUTPOINT PATH"))
             {
                 return false; // Pinnacle Impression
             }
 
-            if (sb.ToString().StartsWith("{\\rtf1", StringComparison.Ordinal))
+            if (allText.StartsWith("{\\rtf1", StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/libse/SubtitleFormats/AdobeEncoreWithLineNumbersNtsc.cs
+++ b/src/libse/SubtitleFormats/AdobeEncoreWithLineNumbersNtsc.cs
@@ -16,13 +16,9 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
-            var sb = new StringBuilder();
-            foreach (string line in lines)
-            {
-                sb.AppendLine(line);
-            }
+            var allText = JoinLines(lines);
 
-            if (sb.ToString().Contains("#INPOINT OUTPOINT PATH"))
+            if (allText.Contains("#INPOINT OUTPOINT PATH"))
             {
                 return false; // Pinnacle Impression
             }

--- a/src/libse/SubtitleFormats/BelleNuitSubtitler.cs
+++ b/src/libse/SubtitleFormats/BelleNuitSubtitler.cs
@@ -212,7 +212,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         try
                         {
-                            if (paragraph != null && !string.IsNullOrWhiteSpace(sb.ToString()))
+                            if (paragraph != null && !sb.IsNullOrWhiteSpace())
                             {
                                 paragraph.Text = DecodeText(sb);
                             }
@@ -243,7 +243,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     _errorCount++;
                 }
             }
-            if (paragraph != null && !string.IsNullOrWhiteSpace(sb.ToString()))
+            if (paragraph != null && !sb.IsNullOrWhiteSpace())
             {
                 paragraph.Text = DecodeText(sb);
             }

--- a/src/libse/SubtitleFormats/CaptionsInc.cs
+++ b/src/libse/SubtitleFormats/CaptionsInc.cs
@@ -12,6 +12,8 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override string Name => "Caption Inc";
 
+        private static readonly Encoding Cp1252 = Encoding.GetEncoding(1252);
+
         public static void Save(string fileName, Subtitle subtitle)
         {
             using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write))
@@ -35,7 +37,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                 fs.Write(buffer, 0, buffer.Length);
 
                 // paragraphs
-                var cp1252 = Encoding.GetEncoding(1252);
+                var cp1252 = Cp1252;
                 var oneChar = new char[1];
                 var oneByte = new byte[4];
                 foreach (Paragraph p in subtitle.Paragraphs)
@@ -202,7 +204,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         }
                         else if (buffer[i] <= 0x17)
                         {
-                            if (!sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                            if (!sb.EndsWith(Environment.NewLine))
                             {
                                 sb.Append(Environment.NewLine);
                             }
@@ -211,7 +213,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         }
                         else
                         {
-                            sb.Append(Encoding.GetEncoding(1252).GetString(buffer, i, 1));
+                            sb.Append(Cp1252.GetString(buffer, i, 1));
                         }
 
                         i++;

--- a/src/libse/SubtitleFormats/CheetahCaption.cs
+++ b/src/libse/SubtitleFormats/CheetahCaption.cs
@@ -233,14 +233,14 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                             }
 
                             italics = false;
-                            if (!sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                            if (!sb.EndsWith(Environment.NewLine))
                             {
                                 sb.AppendLine();
                             }
                         }
-                        else if (DicCodeLatin.ContainsKey(buffer[index]))
+                        else if (DicCodeLatin.TryGetValue(buffer[index], out var latin))
                         {
-                            sb.Append(DicCodeLatin[buffer[index]]);
+                            sb.Append(latin);
                         }
                         else if (buffer[index] >= 0xC0 || buffer[index] <= 0x1F) // codes/styles (0x15-0x1F are not text in cp1252 either - e.g. the 0x1E right-align style byte)
                         {

--- a/src/libse/SubtitleFormats/Csv3.cs
+++ b/src/libse/SubtitleFormats/Csv3.cs
@@ -184,7 +184,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                     {
                         isBreak = false;
                     }
-                    else if (i == 0 || i == csv.Length - 1 || sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                    else if (i == 0 || i == csv.Length - 1 || sb.EndsWith(Environment.NewLine))
                     {
                         sb.Append('"');
                     }

--- a/src/libse/SubtitleFormats/JsonType8.cs
+++ b/src/libse/SubtitleFormats/JsonType8.cs
@@ -14,6 +14,17 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
 
         public override bool IsMine(List<string> lines, string fileName)
         {
+            // LoadSubtitle produces no paragraph (so IsMine is false) unless the text starts
+            // with '{'/'[' and every one of these tags is present - test that before the full parse.
+            var allText = JoinLinesTrimmed(lines);
+            if (!(allText.StartsWith('{') || allText.StartsWith('[')) ||
+                !allText.Contains("start_time", StringComparison.Ordinal) ||
+                !allText.Contains("end_time", StringComparison.Ordinal) ||
+                !allText.Contains("text", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
             var subtitle = new Subtitle();
             LoadSubtitle(subtitle, lines, fileName);
             if (_errorCount >= subtitle.Paragraphs.Count)

--- a/src/libse/SubtitleFormats/MicroDvd.cs
+++ b/src/libse/SubtitleFormats/MicroDvd.cs
@@ -339,6 +339,40 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return sb.ToString().Trim();
         }
 
+        /// <summary>
+        /// Same lines as string.Join(NewLine, lines).TrimEnd().SplitToLines(): trailing
+        /// whitespace-only lines are dropped and the last kept line is end-trimmed - without
+        /// materializing and re-splitting the whole file. Lines that themselves contain a line
+        /// break would split differently, so those fall back to the join/split.
+        /// </summary>
+        private static List<string> GetEndTrimmedLines(List<string> lines)
+        {
+            var last = lines.Count - 1;
+            while (last >= 0 && string.IsNullOrWhiteSpace(lines[last]))
+            {
+                last--;
+            }
+
+            var result = new List<string>(last + 2);
+            for (var i = 0; i <= last; i++)
+            {
+                var line = lines[i] ?? string.Empty;
+                if (line.AsSpan().IndexOfAny('\r', '\n', '\u2028') >= 0)
+                {
+                    return string.Join(Environment.NewLine, lines).TrimEnd().SplitToLines();
+                }
+
+                result.Add(i == last ? line.TrimEnd() : line);
+            }
+
+            if (result.Count == 0)
+            {
+                result.Add(string.Empty);
+            }
+
+            return result;
+        }
+
         public override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
         {
             _errorCount = 0;
@@ -348,7 +382,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             var lineSb = new StringBuilder();
             var pre = new StringBuilder();
             char[] splitChar = { '|' };
-            var endTrimmedLines = string.Join(Environment.NewLine, lines).TrimEnd().SplitToLines();
+            var endTrimmedLines = GetEndTrimmedLines(lines);
             foreach (string line in endTrimmedLines)
             {
                 _lineNumber++;

--- a/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -1556,7 +1556,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         var cp = GetColorAndPosition(part);
                         if (cp != null)
                         {
-                            if (!string.IsNullOrWhiteSpace(sb.ToString()) && cp.Y > 0 && y >= 0 && cp.Y > y && !sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                            if (!sb.IsNullOrWhiteSpace() && cp.Y > 0 && y >= 0 && cp.Y > y && !sb.EndsWith(Environment.NewLine))
                             {
                                 sb.AppendLine();
                             }
@@ -1669,7 +1669,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                     break;
                                 case "9440":
                                 case "94e0":
-                                    if (!sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                                    if (!sb.EndsWith(Environment.NewLine))
                                     {
                                         sb.AppendLine();
                                     }
@@ -1724,7 +1724,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                                         // Unrecognized Preamble Address Code: it repositions the
                                         // cursor onto a new row, so emit a line break instead of
                                         // decoding its bytes as stray letters (e.g. "n"/"N"). (#9803)
-                                        if (sb.Length > 0 && !sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal))
+                                        if (sb.Length > 0 && !sb.EndsWith(Environment.NewLine))
                                         {
                                             sb.AppendLine();
                                         }

--- a/src/libse/SubtitleFormats/Ultech130.cs
+++ b/src/libse/SubtitleFormats/Ultech130.cs
@@ -232,7 +232,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                         {
                             byte b2 = buffer[k + 1];
                             skipCount = 1;
-                            if (sb.Length > 0 && !sb.ToString().EndsWith(Environment.NewLine, StringComparison.Ordinal) && !sb.EndsWith('>'))
+                            if (sb.Length > 0 && !sb.EndsWith(Environment.NewLine) && !sb.EndsWith('>'))
                             {
                                 if (italics)
                                 {

--- a/src/libuilogic/Ocr/BinaryOcrBitmap.cs
+++ b/src/libuilogic/Ocr/BinaryOcrBitmap.cs
@@ -19,12 +19,52 @@ public class BinaryOcrBitmap
     //text len bytes=text (UTF-8)
     //w*h bytes / 8=pixels as bits(byte aligned)
 
-    public int Width { get; set; }
-    public int Height { get; set; }
+    private int _width;
+    public int Width
+    {
+        get => _width;
+        set
+        {
+            _width = value;
+            _key = null;
+        }
+    }
+
+    private int _height;
+    public int Height
+    {
+        get => _height;
+        set
+        {
+            _height = value;
+            _key = null;
+        }
+    }
+
     public int X { get; set; }
     public int Y { get; set; }
-    public int NumberOfColoredPixels { get; set; }
-    public uint Hash { get; set; }
+
+    private int _numberOfColoredPixels;
+    public int NumberOfColoredPixels
+    {
+        get => _numberOfColoredPixels;
+        set
+        {
+            _numberOfColoredPixels = value;
+            _key = null;
+        }
+    }
+
+    private uint _hash;
+    public uint Hash
+    {
+        get => _hash;
+        set
+        {
+            _hash = value;
+            _key = null;
+        }
+    }
 
     private byte[] _colors = [];
     public byte[] Colors
@@ -39,10 +79,23 @@ public class BinaryOcrBitmap
     public bool Italic { get; set; }
     public int ExpandCount { get; set; }
     public bool LoadedOk { get; }
-    public string? Text { get; set; }
+    private string? _text;
+    public string? Text
+    {
+        get => _text;
+        set
+        {
+            _text = value;
+            _key = null;
+        }
+    }
+
     public List<BinaryOcrBitmap> ExpandedList { get; set; } = new List<BinaryOcrBitmap>();
 
-    public string Key => Text + "|#|" + Hash + "_" + Width + "x" + Height + "_" + NumberOfColoredPixels;
+    // Cached: the key is built from five properties and read repeatedly during matching; every
+    // setter that feeds it resets the cache.
+    private string? _key;
+    public string Key => _key ??= Text + "|#|" + Hash + "_" + Width + "x" + Height + "_" + NumberOfColoredPixels;
 
     public override string ToString()
     {

--- a/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
+++ b/src/libuilogic/Ocr/NikseBitmapImageSplitter2.cs
@@ -925,16 +925,29 @@ public class NikseBitmapImageSplitter2
             }
             else if (width > 0 && newStartX > startX + 1)
             {
-                var bmp0 = new NikseBitmap2(bmp);
-                // Remove pixels after current
-                for (var index = 0; index < points.Count; index++)
-                {
-                    var p = points[index];
-                    bmp0.MakeVerticalLinePartTransparent(p.X, p.X + index, p.Y);
-                }
                 width = FindMaxX(points, x) - startX - 1;
                 startX++;
-                var b1 = bmp0.CopyRectangle(new NikseRectangle(startX, 0, width, bmpHeight));
+                // Copy only the glyph rectangle and blank the trailing pixels inside it - blanking
+                // outside the copied rectangle never affected the result, so a full clone of the
+                // line bitmap was wasted work per glyph.
+                var b1 = bmp.CopyRectangle(new NikseRectangle(startX, 0, width, bmpHeight));
+                var b1Width = b1.Width;
+                if (b1Width > 0)
+                {
+                    // Remove pixels after current
+                    for (var index = 0; index < points.Count; index++)
+                    {
+                        var p = points[index];
+                        var xStart = p.X - startX;
+                        var xEnd = p.X + index - startX;
+                        if (xEnd < 0 || xStart >= b1Width)
+                        {
+                            continue;
+                        }
+
+                        b1.MakeVerticalLinePartTransparent(xStart, xEnd, p.Y);
+                    }
+                }
 
                 b1 = CropTopAndBottom(b1, out var addY);
 
@@ -1005,7 +1018,7 @@ public class NikseBitmapImageSplitter2
         var leftCount = 0;
         var rightCount = 0;
         clean = true;
-        var points = new List<NiksePoint>();
+        List<NiksePoint>? points = null;
         var y = 0;
         var bmpHeight = bmp.Height;
         var bmpWidth = bmp.Width;
@@ -1063,7 +1076,7 @@ public class NikseBitmapImageSplitter2
                     y--;
                     left = true;
                     // Remove points with Y > current Y
-                    while (points.Count > 0 && points[^1].Y > y)
+                    while (points != null && points.Count > 0 && points[^1].Y > y)
                     {
                         points.RemoveAt(points.Count - 1);
                     }
@@ -1074,7 +1087,7 @@ public class NikseBitmapImageSplitter2
                     y -= 2;
                     left = true;
                     // Remove points with Y > current Y
-                    while (points.Count > 0 && points[^1].Y > y)
+                    while (points != null && points.Count > 0 && points[^1].Y > y)
                     {
                         points.RemoveAt(points.Count - 1);
                     }
@@ -1101,12 +1114,13 @@ public class NikseBitmapImageSplitter2
             }
             else
             {
+                points ??= new List<NiksePoint>();
                 points.Add(new NiksePoint(x, y));
                 y++;
             }
         }
 
-        return points;
+        return points ?? new List<NiksePoint>();
     }
 
     //internal static int IsBitmapsAlike(ManagedBitmap2 bmp1, NikseBitmap2 bmp2)

--- a/src/ui/Features/Assa/AssaDraw/AssaDrawCanvas.cs
+++ b/src/ui/Features/Assa/AssaDraw/AssaDrawCanvas.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 
 namespace Nikse.SubtitleEdit.Features.Assa.AssaDraw;
 
@@ -18,6 +19,37 @@ public class AssaDrawCanvas : Control
     private float _panY;
     private Point? _lastMousePosition;
     private bool _isPanning;
+
+    private static readonly ImmutableSolidColorBrush CheckerBrush1 = new(Color.FromRgb(60, 60, 60));
+    private static readonly ImmutableSolidColorBrush CheckerBrush2 = new(Color.FromRgb(80, 80, 80));
+
+    private readonly Dictionary<Color, IBrush> _brushCache = new();
+    private readonly Dictionary<(Color Color, double Thickness, PenLineCap LineCap, PenLineJoin LineJoin, bool Dashed), IPen> _penCache = new();
+
+    private static readonly ImmutableDashStyle DashedStyle = new ImmutableDashStyle(DashStyle.Dash.Dashes, DashStyle.Dash.Offset);
+
+    private IBrush GetBrush(Color color)
+    {
+        if (!_brushCache.TryGetValue(color, out var brush))
+        {
+            brush = new ImmutableSolidColorBrush(color);
+            _brushCache[color] = brush;
+        }
+
+        return brush;
+    }
+
+    private IPen GetPen(Color color, double thickness, PenLineCap lineCap = PenLineCap.Flat, PenLineJoin lineJoin = PenLineJoin.Miter, bool dashed = false)
+    {
+        var key = (color, thickness, lineCap, lineJoin, dashed);
+        if (!_penCache.TryGetValue(key, out var pen))
+        {
+            pen = new ImmutablePen((ImmutableSolidColorBrush)GetBrush(color), thickness, dashed ? DashedStyle : null, lineCap, lineJoin);
+            _penCache[key] = pen;
+        }
+
+        return pen;
+    }
 
     public static readonly StyledProperty<List<DrawShape>> ShapesProperty =
         AvaloniaProperty.Register<AssaDrawCanvas, List<DrawShape>>(nameof(Shapes), []);
@@ -172,25 +204,42 @@ public class AssaDrawCanvas : Control
         DrawResolutionBorder(context);
 
         // Draw all shapes
-        foreach (var shape in Shapes.Where(s => !s.Hidden))
+        var shapes = Shapes;
+        var selectedShapes = SelectedShapes;
+        var selectedSet = selectedShapes.Count > 4 ? new HashSet<DrawShape>(selectedShapes) : null;
+        var activeShape = ActiveShape;
+        var selectedShape = SelectedShape;
+        var activeShapeInList = false;
+        for (var idx = 0; idx < shapes.Count; idx++)
         {
-            var isSelected = SelectedShapes.Contains(shape);
-            var isActive = shape == ActiveShape || shape == SelectedShape || isSelected;
-            DrawShape(context, shape, isActive, isSelected);
+            var shape = shapes[idx];
+            if (shape == activeShape)
+            {
+                activeShapeInList = true;
+            }
+
+            if (shape.Hidden)
+            {
+                continue;
+            }
+
+            var isSelected = selectedSet != null ? selectedSet.Contains(shape) : selectedShapes.Contains(shape);
+            var isActive = shape == activeShape || shape == selectedShape || isSelected;
+            DrawShape(context, shape, isActive, isSelected, isInShapes: true);
             DrawShapePoints(context, shape);
         }
 
         // Draw active shape being created (not yet in Shapes list)
-        if (ActiveShape != null && !Shapes.Contains(ActiveShape))
+        if (ActiveShape != null && !activeShapeInList)
         {
-            DrawShape(context, ActiveShape, true, false);
+            DrawShape(context, ActiveShape, true, false, isInShapes: false);
             DrawShapePoints(context, ActiveShape);
 
             // Draw preview to current mouse position
             if (CurrentX > float.MinValue && CurrentY > float.MinValue && ActiveShape.Points.Count > 0)
             {
                 var lastPoint = ActiveShape.Points[^1];
-                var pen = new Pen(new SolidColorBrush(DrawSettings.ActiveShapeLineColor), 2, lineCap: PenLineCap.Round);
+                var pen = GetPen(DrawSettings.ActiveShapeLineColor, 2, lineCap: PenLineCap.Round);
 
                 if (CurrentTool == DrawingTool.Circle && ActiveShape.Points.Count == 1)
                 {
@@ -232,7 +281,7 @@ public class AssaDrawCanvas : Control
         if (ActivePoint != null)
         {
             var pointColor = new Color(255, ActivePoint.PointColor.R, ActivePoint.PointColor.G, ActivePoint.PointColor.B);
-            var pen = new Pen(new SolidColorBrush(pointColor), 3);
+            var pen = GetPen(pointColor, 3);
             var x = ToZoomFactorX(ActivePoint.X);
             var y = ToZoomFactorY(ActivePoint.Y);
             context.DrawLine(pen, new Point(x - 8, y), new Point(x + 8, y));
@@ -243,15 +292,13 @@ public class AssaDrawCanvas : Control
     private void DrawCheckerBackground(DrawingContext context, Rect bounds)
     {
         const int size = 10;
-        var color1 = Color.FromRgb(60, 60, 60);
-        var color2 = Color.FromRgb(80, 80, 80);
 
         for (var y = 0; y < bounds.Height; y += size)
         {
             for (var x = 0; x < bounds.Width; x += size)
             {
                 var isEven = ((x / size) + (y / size)) % 2 == 0;
-                var brush = new SolidColorBrush(isEven ? color1 : color2);
+                var brush = isEven ? CheckerBrush1 : CheckerBrush2;
                 context.FillRectangle(brush, new Rect(x, y, size, size));
             }
         }
@@ -259,14 +306,14 @@ public class AssaDrawCanvas : Control
 
     private void DrawCanvasArea(DrawingContext context)
     {
-        var brush = new SolidColorBrush(DrawSettings.BackgroundColor);
+        var brush = GetBrush(DrawSettings.BackgroundColor);
         var rect = new Rect(_panX, _panY, CanvasWidth * _zoomFactor, CanvasHeight * _zoomFactor);
         context.FillRectangle(brush, rect);
     }
 
     private void DrawGrid(DrawingContext context)
     {
-        var pen = new Pen(new SolidColorBrush(DrawSettings.GridColor), 0.5);
+        var pen = GetPen(DrawSettings.GridColor, 0.5);
         var gridSize = DrawSettings.GridSize * _zoomFactor;
 
         for (float x = _panX; x < _panX + CanvasWidth * _zoomFactor; x += gridSize)
@@ -282,12 +329,12 @@ public class AssaDrawCanvas : Control
 
     private void DrawResolutionBorder(DrawingContext context)
     {
-        var pen = new Pen(new SolidColorBrush(DrawSettings.ScreenSizeColor), 2);
+        var pen = GetPen(DrawSettings.ScreenSizeColor, 2);
         var rect = new Rect(_panX - 1, _panY - 1, CanvasWidth * _zoomFactor + 2, CanvasHeight * _zoomFactor + 2);
         context.DrawRectangle(null, pen, rect);
     }
 
-    private void DrawShape(DrawingContext context, DrawShape shape, bool isActive, bool isSelected)
+    private void DrawShape(DrawingContext context, DrawShape shape, bool isActive, bool isSelected, bool isInShapes)
     {
         if (shape.Points.Count == 0)
         {
@@ -303,11 +350,7 @@ public class AssaDrawCanvas : Control
         }
 
         // Use dashed lines for eraser shapes
-        var pen = new Pen(new SolidColorBrush(color), 2, lineCap: PenLineCap.Round);
-        if (shape.IsEraser)
-        {
-            pen.DashStyle = DashStyle.Dash;
-        }
+        var pen = GetPen(color, 2, lineCap: PenLineCap.Round, dashed: shape.IsEraser);
 
         var i = 0;
         while (i < shape.Points.Count)
@@ -349,10 +392,7 @@ public class AssaDrawCanvas : Control
                     // Draw control point lines (guides)
                     if (isActive)
                     {
-                        var guidePen = new Pen(new SolidColorBrush(Colors.Gray), 1, lineJoin: PenLineJoin.Round)
-                        {
-                            DashStyle = DashStyle.Dash
-                        };
+                        var guidePen = GetPen(Colors.Gray, 1, lineJoin: PenLineJoin.Round, dashed: true);
                         context.DrawLine(guidePen, ToZoomFactorPoint(startPoint), ToZoomFactorPoint(control1));
                         context.DrawLine(guidePen, ToZoomFactorPoint(endPoint), ToZoomFactorPoint(control2));
                     }
@@ -371,7 +411,7 @@ public class AssaDrawCanvas : Control
         }
 
         // Close the shape by drawing line from last to first point
-        if (shape.Points.Count > 2 && Shapes.Contains(shape))
+        if (shape.Points.Count > 2 && isInShapes)
         {
             var first = shape.Points[0];
             var last = shape.Points[^1];
@@ -383,7 +423,7 @@ public class AssaDrawCanvas : Control
     {
         foreach (var point in shape.Points)
         {
-            var pen = new Pen(new SolidColorBrush(point.PointColor), 2);
+            var pen = GetPen(point.PointColor, 2);
             var x = ToZoomFactorX(point.X);
             var y = ToZoomFactorY(point.Y);
 

--- a/src/ui/Features/Files/Compare/CompareViewModel.cs
+++ b/src/ui/Features/Files/Compare/CompareViewModel.cs
@@ -325,13 +325,36 @@ public partial class CompareViewModel : ObservableObject
         // remove items not in differences
         if (onlyShowTextDiff || onlyShowDiff)
         {
-            for (var idx = LeftSubtitles.Count - 1; idx >= 0; idx--)
+            var differenceSet = new HashSet<int>(differences);
+            var leftCount = LeftSubtitles.Count;
+            var leftSurvivors = new List<CompareItem>(differenceSet.Count);
+            var rightSurvivors = new List<CompareItem>(differenceSet.Count);
+            for (var idx = 0; idx < leftCount; idx++)
             {
-                if (!differences.Contains(idx))
+                if (differenceSet.Contains(idx))
                 {
-                    LeftSubtitles.RemoveAt(idx);
-                    RightSubtitles.RemoveAt(idx);
+                    leftSurvivors.Add(LeftSubtitles[idx]);
+                    rightSurvivors.Add(RightSubtitles[idx]);
                 }
+            }
+
+            // Rows beyond the left count were never removed by the old per-row loop.
+            for (var idx = leftCount; idx < RightSubtitles.Count; idx++)
+            {
+                rightSurvivors.Add(RightSubtitles[idx]);
+            }
+
+            // Rebuild both collections in one pass instead of one RemoveAt notification per row.
+            LeftSubtitles.Clear();
+            RightSubtitles.Clear();
+            foreach (var item in leftSurvivors)
+            {
+                LeftSubtitles.Add(item);
+            }
+
+            foreach (var item in rightSurvivors)
+            {
+                RightSubtitles.Add(item);
             }
         }
 

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -22,6 +22,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -139,6 +140,7 @@ public partial class BurnInViewModel : ObservableObject
     private VideoPlayerControl? _fullScreenVideoPlayerControl;
     private DispatcherTimer? _previewTimer;
     private string _oldPreviewAssa = string.Empty;
+    private bool _previewDirty = true; // true = preview ASSA must be regenerated on the next timer tick
     private readonly string _tempPreviewAssaFileName;
     private bool _isPreviewSubtitleLoaded;
 
@@ -236,6 +238,7 @@ public partial class BurnInViewModel : ObservableObject
         _selectedEffects = new List<BurnInEffectItem>();
         _log = new StringBuilder();
         _loading = false;
+        _previewDirty = true;
         _inputVideoFileName = string.Empty;
 
         _timerGenerate = new();
@@ -257,6 +260,7 @@ public partial class BurnInViewModel : ObservableObject
     {
         _subtitle = new Subtitle(subtitle, false);
         _subtitleFormat = subtitleFormat;
+        _previewDirty = true;
         SetVideo(videoFileName);
     }
 
@@ -270,6 +274,7 @@ public partial class BurnInViewModel : ObservableObject
         _imageSubtitleFileName = bluRaySupFileName;
         _subtitle = new Subtitle();
         _subtitleFormat = null;
+        _previewDirty = true;
         SetVideo(videoFileName);
     }
 
@@ -286,6 +291,7 @@ public partial class BurnInViewModel : ObservableObject
             _ = Task.Run(() =>
             {
                 _mediaInfo = FfmpegMediaInfo2.Parse(videoFileName);
+                _previewDirty = true;
                 Dispatcher.UIThread.Post(() =>
                 {
                     // Audio-only files have no video stream (0x0) - keep the configured
@@ -911,6 +917,8 @@ public partial class BurnInViewModel : ObservableObject
                 : _tempSubtitleFiles.Write(subtitle, new SubRip());
 
         _mediaInfo = FfmpegMediaInfo2.Parse(VideoFileName);
+
+        _previewDirty = true;
         if (_mediaInfo.Dimension.Width > 0 && _mediaInfo.Dimension.Height > 0 &&
             (UseSourceResolution || VideoWidth is null or <= 0 || VideoHeight is null or <= 0))
         {
@@ -1527,6 +1535,7 @@ public partial class BurnInViewModel : ObservableObject
 
         var effectsAsStringArray = settings.Effects?.Split(',') ?? [];
         _selectedEffects = BurnInEffectItem.List().Where(p => effectsAsStringArray.Contains(p.Name)).ToList();
+        _previewDirty = true;
         DisplayEffect = string.Join(", ", _selectedEffects.Select(p => p.Name));
     }
 
@@ -1627,6 +1636,8 @@ public partial class BurnInViewModel : ObservableObject
         }
 
         _selectedEffects = result.SelectedEffects.ToList();
+
+        _previewDirty = true;
         DisplayEffect = string.Join(", ", _selectedEffects.Select(p => p.Name));
     }
 
@@ -2554,6 +2565,13 @@ public partial class BurnInViewModel : ObservableObject
                 return;
             }
 
+            if (!_previewDirty)
+            {
+                return;
+            }
+
+            _previewDirty = false;
+
             string? assaText;
             try
             {
@@ -2561,6 +2579,7 @@ public partial class BurnInViewModel : ObservableObject
             }
             catch
             {
+                _previewDirty = true;
                 return; // ignore transient errors while the user is editing settings
             }
 
@@ -2594,7 +2613,36 @@ public partial class BurnInViewModel : ObservableObject
         _mpvPreviewPlayer = mpv;
         _isPreviewSubtitleLoaded = alreadyHasSubtitle;
         _oldPreviewAssa = string.Empty;
+        _previewDirty = true;
     }
+
+    /// <summary>
+    /// Any view-model property may feed the styled preview (font, colors, margins, effects,
+    /// video size, subtitle format ...), so every change marks it dirty except the pure
+    /// output/progress properties that the generate/analyze timers write themselves.
+    /// </summary>
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (!PreviewNeutralProperties.Contains(e.PropertyName ?? string.Empty))
+        {
+            _previewDirty = true;
+        }
+    }
+
+    private static readonly HashSet<string> PreviewNeutralProperties =
+    [
+        nameof(ProgressText),
+        nameof(ProgressValue),
+        nameof(IsGenerating),
+        nameof(ImagePreview),
+        nameof(SelectedJobItem),
+        nameof(JobItems),
+        nameof(VideoFileSize),
+        nameof(TargetVideoBitRateInfo),
+        nameof(VideoCrfHint),
+    ];
 
     [RelayCommand]
     private void PreviewFullScreen()

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -23,6 +23,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -110,6 +111,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
     private LibMpvDynamicPlayer? _mpvPreviewPlayer;
     private DispatcherTimer? _previewTimer;
     private string _oldPreviewAssa = string.Empty;
+    private bool _previewDirty = true; // true = preview ASSA must be regenerated on the next timer tick
     private readonly string _tempPreviewAssaFileName;
     private bool _isPreviewSubtitleLoaded;
 
@@ -180,6 +182,8 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         _timerAnalyze.Interval = 100;
 
         _loading = false;
+
+        _previewDirty = true;
         _inputVideoFileName = string.Empty;
         LoadSettings();
         BoxTypeChanged();
@@ -192,6 +196,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         _inputVideoFileName = videoFileName;
         _subtitle = new Subtitle(subtitle, false);
         _subtitleFormat = subtitleFormat;
+        _previewDirty = true;
 
         var fileExists = !string.IsNullOrWhiteSpace(videoFileName) && File.Exists(videoFileName);
         if (fileExists)
@@ -1032,6 +1037,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
 
         var effectsAsStringArray = settings.Effects?.Split(',') ?? [];
         _selectedEffects = BurnInEffectItem.List().Where(p => effectsAsStringArray.Contains(p.Name)).ToList();
+        _previewDirty = true;
         DisplayEffect = string.Join(", ", _selectedEffects.Select(p => p.Name));
 
         // The frame rate is a real encoding parameter and the extension picks the container, but
@@ -1117,6 +1123,8 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         }
 
         _selectedEffects = result.SelectedEffects.ToList();
+
+        _previewDirty = true;
         DisplayEffect = string.Join(", ", _selectedEffects.Select(p => p.Name));
     }
 
@@ -1443,6 +1451,13 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
                 return;
             }
 
+            if (!_previewDirty)
+            {
+                return;
+            }
+
+            _previewDirty = false;
+
             string? assaText;
             try
             {
@@ -1450,6 +1465,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
             }
             catch
             {
+                _previewDirty = true;
                 return; // ignore transient errors while the user is editing settings
             }
 
@@ -1483,7 +1499,34 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
         _mpvPreviewPlayer = mpv;
         _isPreviewSubtitleLoaded = alreadyHasSubtitle;
         _oldPreviewAssa = string.Empty;
+        _previewDirty = true;
     }
+
+    /// <summary>
+    /// Any view-model property may feed the styled preview (font, colors, margins, effects,
+    /// video size, subtitle format ...), so every change marks it dirty except the pure
+    /// output/progress properties that the generate/analyze timers write themselves.
+    /// </summary>
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (!PreviewNeutralProperties.Contains(e.PropertyName ?? string.Empty))
+        {
+            _previewDirty = true;
+        }
+    }
+
+    private static readonly HashSet<string> PreviewNeutralProperties =
+    [
+        nameof(ProgressText),
+        nameof(ProgressValue),
+        nameof(IsGenerating),
+        nameof(ImagePreview),
+        nameof(SelectedJobItem),
+        nameof(JobItems),
+        nameof(VideoFileSize),
+    ];
 
     [RelayCommand]
     private void PreviewFullScreen()


### PR DESCRIPTION
Ten independent performance fixes found by random sampling across libse, libuilogic and the UI. One commit per fix, all behavior-preserving; each commit message carries its own measurement.

| Fix | Before → after |
|---|---|
| Adobe Encore / JsonType8 / MicroDvd detection copies | AdobeEncore.IsMine 0.51 → 0.15 ms, JsonType8.IsMine 1.04 → 0.016 ms, both 0 alloc |
| Convert colors to dialog per-char probes | 36 → 29 ms, 37 MB → 4 MB per 2000 paragraphs |
| CJK character count set lookups | ~20 % faster |
| FixCasing / RemoveInterjection tail Substring → span | allocation only |
| StringBuilder EndsWith/IsNullOrWhiteSpace in binary caption decoders | allocation only, no measurable time change |
| OCR splitter: crop before blanking, lazy point list | 27 → 19 ms, pixel-identical on 1200 glyphs |
| Binary OCR bitmap Key cached | per-glyph string concat removed |
| Burn-in / Transparent preview dirty flag | no more 500 ms whole-file ASSA regeneration when idle |
| ASSA draw pen/brush cache | thousands of brush allocations per frame removed |
| Compare difference-only rebuild | O(n²) Contains + per-row RemoveAt → HashSet + one pass |

Tests: libse 1968, libuilogic 801, seconv 476, UI (Compare/BurnIn/Transparent/AssaDraw) 95 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)