### PR TITLE
Fix subtitle numbering after batch OCR

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -356,6 +356,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                             {
                                 item.Subtitle = new Subtitle();
                                 item.Subtitle.Paragraphs.AddRange(track.Mdia.Minf.Stbl.GetParagraphs());
+                                item.Subtitle.Renumber(); // the sample table never numbers its paragraphs
                                 var fileName = Path.GetFileName(item.FileName);
                                 item.OutputFileName = fileName.Substring(0, fileName.LastIndexOf('.')).TrimEnd('.') + ".mp4";
                                 break;
@@ -417,7 +418,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 await RunOcrTesseract(imageSubtitle, item, cancellationToken);
             }
 
-            if (item.Subtitle != null) { item.Subtitle.Renumber(1); }
+            // The OCR runners build paragraphs with "new Paragraph(text, start, end)", which leaves
+            // Number at 0 - the SubRip writer emits that verbatim, so every cue would be numbered 0.
+            item.Subtitle?.Renumber();
 
             // OCR is only one step of the run - the item still goes through the convert functions
             // and the save before it can say "Converted". Leaving the last progress value up would

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -417,6 +417,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 await RunOcrTesseract(imageSubtitle, item, cancellationToken);
             }
 
+            if (item.Subtitle != null) { item.Subtitle.Renumber(1); }
+
             // OCR is only one step of the run - the item still goes through the convert functions
             // and the save before it can say "Converted". Leaving the last progress value up would
             // show a finished-looking "OCR: 100%" for that whole stretch, so put the row back to


### PR DESCRIPTION
When using GUI Batch Convert to OCR image-based subtitles to a text format such as SRT, the generated Paragraphs have the default number 0, resulting in every subtitle being numbered 0. This adds Subtitle.Renumber() after the OCR step for image-based → text-based conversions. This matches the behavior of the existing seconv OCR path, which renumbers the generated paragraphs after OCR. Text-based conversions are unaffected.