### PR TITLE
Replace DllImport with source-generated LibraryImport

### DIFF
--- a/src/ui/Features/Main/Layout/MacWindowsMenuInterop.cs
+++ b/src/ui/Features/Main/Layout/MacWindowsMenuInterop.cs
@@ -18,33 +18,33 @@ namespace Nikse.SubtitleEdit.Features.Main.Layout;
 /// window list from InitNativeMacMenu as the fallback, so the worst case is the
 /// pre-existing behavior.
 /// </summary>
-internal static class MacWindowsMenuInterop
+internal static partial class MacWindowsMenuInterop
 {
     private const string LibObjC = "/usr/lib/libobjc.A.dylib";
 
-    [DllImport(LibObjC)]
-    private static extern IntPtr objc_getClass(string name);
+    [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr objc_getClass(string name);
 
-    [DllImport(LibObjC)]
-    private static extern IntPtr sel_registerName(string name);
+    [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr sel_registerName(string name);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtr(IntPtr receiver, IntPtr sel);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtr(IntPtr receiver, IntPtr sel);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrPtr(IntPtr receiver, IntPtr sel, IntPtr arg);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrPtr(IntPtr receiver, IntPtr sel, IntPtr arg);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrLong(IntPtr receiver, IntPtr sel, long arg);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrLong(IntPtr receiver, IntPtr sel, long arg);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern long SendLong(IntPtr receiver, IntPtr sel);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial long SendLong(IntPtr receiver, IntPtr sel);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrUtf8(IntPtr receiver, IntPtr sel, string arg);
+    [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrUtf8(IntPtr receiver, IntPtr sel, string arg);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern void SendVoidPtrPtrBool(IntPtr receiver, IntPtr sel, IntPtr arg1, IntPtr arg2, sbyte arg3);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial void SendVoidPtrPtrBool(IntPtr receiver, IntPtr sel, IntPtr arg1, IntPtr arg2, sbyte arg3);
 
     private static readonly IntPtr SelSharedApplication = sel_registerName("sharedApplication");
     private static readonly IntPtr SelMainMenu = sel_registerName("mainMenu");

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Features.Main.Layout;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Main;
@@ -18,7 +19,7 @@ public static class Locator
     public static IServiceProvider Services { get; set; } = default!;
 }
 
-public class MainView : ViewBase
+public partial class MainView : ViewBase
 {
     private MainViewModel? _vm;
 
@@ -230,8 +231,8 @@ public class MainView : ViewBase
         return IntPtr.Zero;
     }
 
-    [System.Runtime.InteropServices.DllImport("user32.dll")]
-    private static extern short GetKeyState(int keyCode);
+    [LibraryImport("user32.dll")]
+    private static partial short GetKeyState(int keyCode);
 
     internal async Task OpenFile(string fileName)
     {

--- a/src/ui/Features/Ocr/Engines/AppleVisionOcr.cs
+++ b/src/ui/Features/Ocr/Engines/AppleVisionOcr.cs
@@ -23,7 +23,7 @@ namespace Nikse.SubtitleEdit.Features.Ocr.Engines;
 /// reports "unavailable" rather than throwing, so a macOS that ever lacks the framework simply
 /// does not offer the engine.
 /// </summary>
-public static class AppleVisionOcr
+public static partial class AppleVisionOcr
 {
     public const string StaticName = "Apple Vision";
 
@@ -35,47 +35,47 @@ public static class AppleVisionOcr
     private const long RecognitionLevelAccurate = 0;
     private const long RecognitionLevelFast = 1;
 
-    [DllImport(LibSystem)]
-    private static extern IntPtr dlopen(string path, int mode);
+    [LibraryImport(LibSystem, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr dlopen(string path, int mode);
 
-    [DllImport(LibObjC)]
-    private static extern IntPtr objc_getClass(string name);
+    [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr objc_getClass(string name);
 
-    [DllImport(LibObjC)]
-    private static extern IntPtr sel_registerName(string name);
+    [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial IntPtr sel_registerName(string name);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtr(IntPtr receiver, IntPtr sel);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtr(IntPtr receiver, IntPtr sel);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrPtr(IntPtr receiver, IntPtr sel, IntPtr a);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrPtr(IntPtr receiver, IntPtr sel, IntPtr a);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrPtrPtr(IntPtr receiver, IntPtr sel, IntPtr a, IntPtr b);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrPtrPtr(IntPtr receiver, IntPtr sel, IntPtr a, IntPtr b);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrBytesLong(IntPtr receiver, IntPtr sel, byte[] bytes, long length);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrBytesLong(IntPtr receiver, IntPtr sel, byte[] bytes, long length);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrUtf8(IntPtr receiver, IntPtr sel, string a);
+    [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrUtf8(IntPtr receiver, IntPtr sel, string a);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern IntPtr SendPtrLong(IntPtr receiver, IntPtr sel, long a);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial IntPtr SendPtrLong(IntPtr receiver, IntPtr sel, long a);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern long SendLong(IntPtr receiver, IntPtr sel);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial long SendLong(IntPtr receiver, IntPtr sel);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern void SendVoid(IntPtr receiver, IntPtr sel);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial void SendVoid(IntPtr receiver, IntPtr sel);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern void SendVoidLong(IntPtr receiver, IntPtr sel, long a);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial void SendVoidLong(IntPtr receiver, IntPtr sel, long a);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern void SendVoidBool(IntPtr receiver, IntPtr sel, byte a);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial void SendVoidBool(IntPtr receiver, IntPtr sel, byte a);
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern void SendVoidPtr(IntPtr receiver, IntPtr sel, IntPtr a);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial void SendVoidPtr(IntPtr receiver, IntPtr sel, IntPtr a);
 
     /// <summary>
     /// CGPoint. Read the corners rather than <c>boundingBox</c> on purpose: a CGRect is four
@@ -91,8 +91,8 @@ public static class AppleVisionOcr
         public double Y;
     }
 
-    [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-    private static extern CGPoint SendPoint(IntPtr receiver, IntPtr sel);
+    [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+    private static partial CGPoint SendPoint(IntPtr receiver, IntPtr sel);
 
     private static readonly object AvailabilityLock = new();
     private static bool _availabilityChecked;

--- a/src/ui/Logic/ClipboardHelper.cs
+++ b/src/ui/Logic/ClipboardHelper.cs
@@ -9,63 +9,68 @@ using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Logic;
 
-public static class ClipboardHelper
+public static partial class ClipboardHelper
 {
     // Win32 API declarations
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern bool OpenClipboard(IntPtr hWndNewOwner);
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool OpenClipboard(IntPtr hWndNewOwner);
 
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern bool CloseClipboard();
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseClipboard();
 
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern bool EmptyClipboard();
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool EmptyClipboard();
 
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
+    [LibraryImport("user32.dll", SetLastError = true)]
+    private static partial IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
 
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern uint RegisterClipboardFormatW([MarshalAs(UnmanagedType.LPWStr)] string lpszFormat);
+    [LibraryImport("user32.dll", SetLastError = true)]
+    private static partial uint RegisterClipboardFormatW([MarshalAs(UnmanagedType.LPWStr)] string lpszFormat);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern IntPtr GlobalAlloc(uint uFlags, UIntPtr dwBytes);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr GlobalAlloc(uint uFlags, UIntPtr dwBytes);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern IntPtr GlobalLock(IntPtr hMem);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr GlobalLock(IntPtr hMem);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern bool GlobalUnlock(IntPtr hMem);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GlobalUnlock(IntPtr hMem);
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern IntPtr GlobalFree(IntPtr hMem);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr GlobalFree(IntPtr hMem);
 
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+    [LibraryImport("gdi32.dll")]
+    private static partial IntPtr CreateCompatibleDC(IntPtr hdc);
 
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFO pbmi, uint usage, out IntPtr ppvBits, IntPtr hSection, uint offset);
+    [LibraryImport("gdi32.dll")]
+    private static partial IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFO pbmi, uint usage, out IntPtr ppvBits, IntPtr hSection, uint offset);
 
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr SelectObject(IntPtr hdc, IntPtr h);
+    [LibraryImport("gdi32.dll")]
+    private static partial IntPtr SelectObject(IntPtr hdc, IntPtr h);
 
-    [DllImport("gdi32.dll")]
-    private static extern bool DeleteObject(IntPtr ho);
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool DeleteObject(IntPtr ho);
 
-    [DllImport("gdi32.dll")]
-    private static extern bool DeleteDC(IntPtr hdc);
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool DeleteDC(IntPtr hdc);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetDC(IntPtr hwnd);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetDC(IntPtr hwnd);
 
-    [DllImport("user32.dll")]
-    private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+    [LibraryImport("user32.dll")]
+    private static partial int ReleaseDC(IntPtr hwnd, IntPtr hdc);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct BITMAPINFO
     {
         public BITMAPINFOHEADER bmiHeader;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
-        public RGBQUAD[] bmiColors;
+        public RGBQUAD bmiColors;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/ui/Logic/CursorPositionHelper.cs
+++ b/src/ui/Logic/CursorPositionHelper.cs
@@ -6,14 +6,15 @@ using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic;
 
-public static  class CursorPositionHelper
+public static partial class CursorPositionHelper
 {
     // Windows API for getting cursor position
-    [DllImport("user32.dll")]
-    private static extern bool GetCursorPos(out POINT lpPoint);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetCursorPos(out POINT lpPoint);
 
-    [DllImport("user32.dll")]
-    private static extern short GetAsyncKeyState(int vKey);
+    [LibraryImport("user32.dll")]
+    private static partial short GetAsyncKeyState(int vKey);
 
     private const int VkLButton = 0x01;
     private const int VkRButton = 0x02;
@@ -31,22 +32,23 @@ public static  class CursorPositionHelper
     private const string ApplicationServicesLib = "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices";
 
 
-    [DllImport(CoreGraphicsLib)]
-    private static extern CGPoint CGEventSourceGetCursorPosition(uint source);
+    [LibraryImport(CoreGraphicsLib)]
+    private static partial CGPoint CGEventSourceGetCursorPosition(uint source);
 
-    [DllImport(CoreGraphicsLib)]
-    private static extern bool CGEventSourceButtonState(int stateId, uint button);
+    [LibraryImport(CoreGraphicsLib)]
+    [return: MarshalAs(UnmanagedType.U1)]
+    private static partial bool CGEventSourceButtonState(int stateId, uint button);
 
     private const int CGEventSourceStateCombinedSessionState = 0;
 
-    [DllImport(CoreGraphicsLib)]
-    private static extern IntPtr CGEventCreate(IntPtr source);
+    [LibraryImport(CoreGraphicsLib)]
+    private static partial IntPtr CGEventCreate(IntPtr source);
 
-    [DllImport(ApplicationServicesLib)]
-    private static extern CGPoint CGEventGetLocation(IntPtr eventRef);
+    [LibraryImport(ApplicationServicesLib)]
+    private static partial CGPoint CGEventGetLocation(IntPtr eventRef);
 
-    [DllImport(CoreGraphicsLib)]
-    private static extern void CFRelease(IntPtr cf);
+    [LibraryImport(CoreGraphicsLib)]
+    private static partial void CFRelease(IntPtr cf);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct CGPoint
@@ -56,18 +58,19 @@ public static  class CursorPositionHelper
     }
 
     // Linux X11 API for getting cursor position
-    [DllImport("libX11.so.6")]
-    private static extern IntPtr XOpenDisplay(IntPtr display);
+    [LibraryImport("libX11.so.6")]
+    private static partial IntPtr XOpenDisplay(IntPtr display);
 
-    [DllImport("libX11.so.6")]
-    private static extern int XCloseDisplay(IntPtr display);
+    [LibraryImport("libX11.so.6")]
+    private static partial int XCloseDisplay(IntPtr display);
 
-    [DllImport("libX11.so.6")]
-    private static extern bool XQueryPointer(IntPtr display, IntPtr window, out IntPtr root, out IntPtr child,
+    [LibraryImport("libX11.so.6")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool XQueryPointer(IntPtr display, IntPtr window, out IntPtr root, out IntPtr child,
         out int rootX, out int rootY, out int winX, out int winY, out uint mask);
 
-    [DllImport("libX11.so.6")]
-    private static extern IntPtr XDefaultRootWindow(IntPtr display);
+    [LibraryImport("libX11.so.6")]
+    private static partial IntPtr XDefaultRootWindow(IntPtr display);
 
     public static (int X, int Y)? GetCursorPosition()
     {

--- a/src/ui/Logic/ForegroundWindowTracker.cs
+++ b/src/ui/Logic/ForegroundWindowTracker.cs
@@ -1,7 +1,6 @@
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Nikse.SubtitleEdit.Logic;
 
@@ -34,7 +33,7 @@ namespace Nikse.SubtitleEdit.Logic;
 /// the caller on its pointer-only rules. The hooks must be installed from a thread that pumps
 /// messages (the UI thread) and live for the process lifetime.
 /// </summary>
-public static class ForegroundWindowTracker
+public static partial class ForegroundWindowTracker
 {
     private const uint EventSystemForeground = 0x0003;
     private const uint EventSystemSwitchStart = 0x0014;
@@ -54,25 +53,28 @@ public static class ForegroundWindowTracker
     private delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd,
         int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax,
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr SetWinEventHook(uint eventMin, uint eventMax,
         IntPtr hmodWinEventProc, WinEventDelegate pfnWinEventProc, uint idProcess, uint idThread,
         uint dwFlags);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetForegroundWindow();
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetForegroundWindow();
 
-    [DllImport("user32.dll")]
-    private static extern bool IsWindow(IntPtr hWnd);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsWindow(IntPtr hWnd);
 
-    [DllImport("user32.dll")]
-    private static extern bool IsWindowVisible(IntPtr hWnd);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsWindowVisible(IntPtr hWnd);
 
-    [DllImport("user32.dll")]
-    private static extern bool IsIconic(IntPtr hWnd);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsIconic(IntPtr hWnd);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    private static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+    [LibraryImport("user32.dll", EntryPoint = "GetClassNameW", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial int GetClassName(IntPtr hWnd, [Out] char[] lpClassName, int nMaxCount);
 
     // Keeps the delegate alive for the lifetime of the hooks - the GC must not collect it while
     // user32 still holds the callback pointer.
@@ -169,13 +171,14 @@ public static class ForegroundWindowTracker
 
     private static bool IsTaskSwitcherWindow(IntPtr hwnd)
     {
-        var className = new StringBuilder(64);
-        if (GetClassName(hwnd, className, className.Capacity) == 0)
+        var className = new char[64];
+        var length = GetClassName(hwnd, className, className.Length);
+        if (length == 0)
         {
             return false;
         }
 
-        var name = className.ToString();
+        var name = new string(className, 0, length);
         foreach (var switcherClass in TaskSwitcherWindowClasses)
         {
             if (string.Equals(name, switcherClass, StringComparison.Ordinal))

--- a/src/ui/Logic/Platform/Windows/FileTypeAssociations.cs
+++ b/src/ui/Logic/Platform/Windows/FileTypeAssociations.cs
@@ -5,15 +5,15 @@ using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic.Platform.Windows;
 
-internal static class FileTypeAssociationsHelper
+internal static partial class FileTypeAssociationsHelper
 {
     // Shell notification constants
     private const int SHCNE_ASSOCCHANGED = 0x08000000;
     private const uint SHCNF_IDLIST = 0x0000;
     private const uint SHCNF_FLUSH = 0x1000;
 
-    [DllImport("Shell32.dll", SetLastError = true)]
-    private static extern void SHChangeNotify(int eventId, uint flags, nint item1, nint item2);
+    [LibraryImport("Shell32.dll", SetLastError = true)]
+    private static partial void SHChangeNotify(int eventId, uint flags, nint item1, nint item2);
 
     /// <summary>
     /// Checks if the app is currently the default handler for a specific extension.

--- a/src/ui/Logic/Platform/Windows/SystemMenu.cs
+++ b/src/ui/Logic/Platform/Windows/SystemMenu.cs
@@ -5,26 +5,29 @@ using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic.Platform.Windows;
 
-public static class SystemMenu
+public static partial class SystemMenu
 {
     private const uint WM_SYSCOMMAND = 0x0112;
     private const uint TPM_LEFTALIGN = 0x0000;
     private const uint TPM_RETURNCMD = 0x0100;
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetSystemMenu(IntPtr hWnd, bool bRevert);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetSystemMenu(IntPtr hWnd, [MarshalAs(UnmanagedType.Bool)] bool bRevert);
 
-    [DllImport("user32.dll")]
-    private static extern bool GetCursorPos(out POINT lpPoint);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetCursorPos(out POINT lpPoint);
 
-    [DllImport("user32.dll")]
-    private static extern uint TrackPopupMenu(IntPtr hMenu, uint uFlags, int x, int y, int nReserved, IntPtr hWnd, IntPtr prcRect);
+    [LibraryImport("user32.dll")]
+    private static partial uint TrackPopupMenu(IntPtr hMenu, uint uFlags, int x, int y, int nReserved, IntPtr hWnd, IntPtr prcRect);
 
-    [DllImport("user32.dll")]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetForegroundWindow(IntPtr hWnd);
 
-    [DllImport("user32.dll")]
-    private static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+    [LibraryImport("user32.dll", EntryPoint = "PostMessageW")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct POINT

--- a/src/ui/Logic/Platform/Windows/WindowsDarkMode.cs
+++ b/src/ui/Logic/Platform/Windows/WindowsDarkMode.cs
@@ -8,15 +8,15 @@ namespace Nikse.SubtitleEdit.Logic.Platform.Windows;
 /// Subtitle Edit's dark/light theme instead of staying light (reported by OmrSi, #10766).
 /// No-op on non-Windows platforms.
 /// </summary>
-public static class WindowsDarkMode
+public static partial class WindowsDarkMode
 {
     // Windows 10 1903+ and Windows 11 use attribute 20; Windows 10 1809 (build 17763) used 19.
     // Try the modern attribute first and fall back so older Windows 10 still themes the caption.
     private const int DwmwaUseImmersiveDarkMode = 20;
     private const int DwmwaUseImmersiveDarkModeBefore20H1 = 19;
 
-    [DllImport("dwmapi.dll", PreserveSig = true)]
-    private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int valueSize);
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int valueSize);
 
     public static void Apply(IntPtr hwnd, bool dark)
     {

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/LibMpvDynamicNativeControl.cs
@@ -10,7 +10,7 @@ using System.Timers;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 
-public class LibMpvDynamicNativeControl : NativeControlHost
+public partial class LibMpvDynamicNativeControl : NativeControlHost
 {
     private LibMpvDynamicPlayer? _mpvPlayer;
     private bool _isInitialized;
@@ -284,14 +284,15 @@ public class LibMpvDynamicNativeControl : NativeControlHost
         return handle.ToString();
     }
 
-    [DllImport("user32.dll")]
-    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr SetCursor(IntPtr hCursor);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr SetCursor(IntPtr hCursor);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr CreateWindowExW(
+    [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial IntPtr CreateWindowExW(
         uint dwExStyle,
         string lpClassName,
         string lpWindowName,
@@ -305,45 +306,47 @@ public class LibMpvDynamicNativeControl : NativeControlHost
         IntPtr hInstance,
         IntPtr lpParam);
 
-    [DllImport("user32.dll", SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool DestroyWindow(IntPtr hWnd);
+    private static partial bool DestroyWindow(IntPtr hWnd);
 
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+    [LibraryImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+    private static partial IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+    [LibraryImport("user32.dll", EntryPoint = "CallWindowProcW")]
+    private static partial IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
-    [DllImport("user32.dll")]
-    private static extern bool GetClientRect(IntPtr hWnd, ref RECT lpRect);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetClientRect(IntPtr hWnd, ref RECT lpRect);
 
-    [DllImport("user32.dll")]
-    private static extern int FillRect(IntPtr hDC, ref RECT lprc, IntPtr hbr);
+    [LibraryImport("user32.dll")]
+    private static partial int FillRect(IntPtr hDC, ref RECT lprc, IntPtr hbr);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr BeginPaint(IntPtr hWnd, ref PAINTSTRUCT lpPaint);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr BeginPaint(IntPtr hWnd, ref PAINTSTRUCT lpPaint);
 
-    [DllImport("user32.dll")]
-    private static extern bool EndPaint(IntPtr hWnd, ref PAINTSTRUCT lpPaint);
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool EndPaint(IntPtr hWnd, ref PAINTSTRUCT lpPaint);
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct PAINTSTRUCT
+    private unsafe struct PAINTSTRUCT
     {
         public IntPtr hdc;
-        public bool fErase;
+        public int fErase;
         public RECT rcPaint;
-        public bool fRestore;
-        public bool fIncUpdate;
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-        public byte[] rgbReserved;
+        public int fRestore;
+        public int fIncUpdate;
+        public fixed byte rgbReserved[32];
     }
 
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateSolidBrush(uint crColor);
+    [LibraryImport("gdi32.dll")]
+    private static partial IntPtr CreateSolidBrush(uint crColor);
 
-    [DllImport("gdi32.dll")]
-    private static extern bool DeleteObject(IntPtr hObject);
+    [LibraryImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool DeleteObject(IntPtr hObject);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct RECT

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/NativeMethods.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/NativeMethods.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
     private static IntPtr _libdlHandle;
     private static IntPtr _libcHandle;
@@ -109,32 +109,32 @@ internal static class NativeMethods
     }
 
     // Windows
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
-    internal static extern IntPtr LoadLibrary(string dllToLoad);
+    [LibraryImport("kernel32.dll", EntryPoint = "LoadLibraryA", SetLastError = true)]
+    internal static partial IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string dllToLoad);
 
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    internal static extern IntPtr LoadLibraryW(string dllToLoad);
+    [LibraryImport("kernel32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    internal static partial IntPtr LoadLibraryW(string dllToLoad);
 
     // Unicode (LoadLibraryExW) so paths with non-ASCII characters (e.g. Chinese user/install
     // folders) are passed through correctly - the ANSI variant mangles them and the load fails (#12001).
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    internal static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, uint dwFlags);
+    [LibraryImport("kernel32.dll", EntryPoint = "LoadLibraryExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    internal static partial IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, uint dwFlags);
 
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
-    internal static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    internal static partial IntPtr GetProcAddress(IntPtr hModule, [MarshalAs(UnmanagedType.LPStr)] string procedureName);
 
-    [DllImport("kernel32.dll")]
+    [LibraryImport("kernel32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    internal static extern bool FreeLibrary(IntPtr hModule);
+    internal static partial bool FreeLibrary(IntPtr hModule);
 
     // Unicode (SetDllDirectoryW) so a non-ASCII dependency directory (e.g. a Chinese path) is set
     // correctly; the ANSI variant mangles it so libvlccore.dll / plugins are not found (#12001).
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [LibraryImport("kernel32.dll", EntryPoint = "SetDllDirectoryW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    internal static extern bool SetDllDirectory(string lpPathName);
+    internal static partial bool SetDllDirectory(string lpPathName);
 
-    [DllImport("kernel32.dll")]
-    internal static extern uint GetLastError();
+    [LibraryImport("kernel32.dll")]
+    internal static partial uint GetLastError();
 
     // LoadLibraryEx flags
     internal const uint LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008;

--- a/src/ui/Logic/VideoPlayers/LibMpvDynamic/PlatformCursorManager.cs
+++ b/src/ui/Logic/VideoPlayers/LibMpvDynamic/PlatformCursorManager.cs
@@ -7,15 +7,15 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 /// Platform-specific cursor management for forcing cursor updates.
 /// Used to work around cursor display issues with native window embedding (libmpv with wid).
 /// </summary>
-public static class PlatformCursorManager
+public static partial class PlatformCursorManager
 {
     #region Windows API
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr SetCursor(IntPtr hCursor);
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr SetCursor(IntPtr hCursor);
 
-    [DllImport("user32.dll")]
-    private static extern IntPtr LoadCursor(IntPtr hInstance, int lpCursorName);
+    [LibraryImport("user32.dll", EntryPoint = "LoadCursorW")]
+    private static partial IntPtr LoadCursor(IntPtr hInstance, int lpCursorName);
 
     private const int IDC_ARROW = 32512;
 
@@ -23,17 +23,17 @@ public static class PlatformCursorManager
 
     #region Linux X11 API
 
-    [DllImport("libX11.so.6", EntryPoint = "XDefineCursor")]
-    private static extern int XDefineCursor(IntPtr display, IntPtr window, IntPtr cursor);
+    [LibraryImport("libX11.so.6", EntryPoint = "XDefineCursor")]
+    private static partial int XDefineCursor(IntPtr display, IntPtr window, IntPtr cursor);
 
-    [DllImport("libX11.so.6", EntryPoint = "XCreateFontCursor")]
-    private static extern IntPtr XCreateFontCursor(IntPtr display, uint shape);
+    [LibraryImport("libX11.so.6", EntryPoint = "XCreateFontCursor")]
+    private static partial IntPtr XCreateFontCursor(IntPtr display, uint shape);
 
-    [DllImport("libX11.so.6", EntryPoint = "XOpenDisplay")]
-    private static extern IntPtr XOpenDisplay(IntPtr display);
+    [LibraryImport("libX11.so.6", EntryPoint = "XOpenDisplay")]
+    private static partial IntPtr XOpenDisplay(IntPtr display);
 
-    [DllImport("libX11.so.6", EntryPoint = "XDefaultRootWindow")]
-    private static extern IntPtr XDefaultRootWindow(IntPtr display);
+    [LibraryImport("libX11.so.6", EntryPoint = "XDefaultRootWindow")]
+    private static partial IntPtr XDefaultRootWindow(IntPtr display);
 
     private const uint XC_LEFT_PTR = 68; // Standard arrow cursor in X11
 

--- a/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicNativeControl.cs
+++ b/src/ui/Logic/VideoPlayers/LibVlcDynamic/LibVlcDynamicNativeControl.cs
@@ -12,7 +12,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
 /// Native window control for LibVLC that embeds VLC's video output directly into a native window handle.
 /// This approach uses platform-specific window embedding (HWND on Windows, X11 window on Linux, NSView on macOS).
 /// </summary>
-public class LibVlcDynamicNativeControl : NativeControlHost
+public partial class LibVlcDynamicNativeControl : NativeControlHost
 {
     private LibVlcDynamicPlayer? _vlcPlayer;
     private bool _isInitialized;
@@ -226,8 +226,8 @@ public class LibVlcDynamicNativeControl : NativeControlHost
         }, DispatcherPriority.Background);
     }
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern IntPtr CreateWindowExW(
+    [LibraryImport("user32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial IntPtr CreateWindowExW(
         uint dwExStyle,
         string lpClassName,
         string lpWindowName,
@@ -241,24 +241,24 @@ public class LibVlcDynamicNativeControl : NativeControlHost
         IntPtr hInstance,
         IntPtr lpParam);
 
-    [DllImport("user32.dll", SetLastError = true)]
+    [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool DestroyWindow(IntPtr hWnd);
+    private static partial bool DestroyWindow(IntPtr hWnd);
 
-    [DllImport("libX11.so.6")]
-    private static extern IntPtr XOpenDisplay(IntPtr display);
+    [LibraryImport("libX11.so.6")]
+    private static partial IntPtr XOpenDisplay(IntPtr display);
 
-    [DllImport("libX11.so.6")]
-    private static extern int XCloseDisplay(IntPtr display);
+    [LibraryImport("libX11.so.6")]
+    private static partial int XCloseDisplay(IntPtr display);
 
-    [DllImport("libX11.so.6")]
-    private static extern int XDefaultScreen(IntPtr display);
+    [LibraryImport("libX11.so.6")]
+    private static partial int XDefaultScreen(IntPtr display);
 
-    [DllImport("libX11.so.6")]
-    private static extern UIntPtr XBlackPixel(IntPtr display, int screenNumber);
+    [LibraryImport("libX11.so.6")]
+    private static partial UIntPtr XBlackPixel(IntPtr display, int screenNumber);
 
-    [DllImport("libX11.so.6")]
-    private static extern IntPtr XCreateSimpleWindow(
+    [LibraryImport("libX11.so.6")]
+    private static partial IntPtr XCreateSimpleWindow(
         IntPtr display,
         IntPtr parent,
         int x,
@@ -269,14 +269,14 @@ public class LibVlcDynamicNativeControl : NativeControlHost
         UIntPtr border,
         UIntPtr background);
 
-    [DllImport("libX11.so.6")]
-    private static extern int XMapWindow(IntPtr display, IntPtr window);
+    [LibraryImport("libX11.so.6")]
+    private static partial int XMapWindow(IntPtr display, IntPtr window);
 
-    [DllImport("libX11.so.6")]
-    private static extern int XDestroyWindow(IntPtr display, IntPtr window);
+    [LibraryImport("libX11.so.6")]
+    private static partial int XDestroyWindow(IntPtr display, IntPtr window);
 
-    [DllImport("libX11.so.6")]
-    private static extern int XSync(IntPtr display, [MarshalAs(UnmanagedType.Bool)] bool discard);
+    [LibraryImport("libX11.so.6")]
+    private static partial int XSync(IntPtr display, [MarshalAs(UnmanagedType.Bool)] bool discard);
 
     public async void LoadFile(string path)
     {

--- a/src/ui/Logic/VideoPlayers/NativeMediaPath.cs
+++ b/src/ui/Logic/VideoPlayers/NativeMediaPath.cs
@@ -15,7 +15,7 @@ namespace Nikse.SubtitleEdit.Logic.VideoPlayers;
 /// is what made the symptom look like a broken container (#14407).
 /// </para>
 /// </summary>
-public static class NativeMediaPath
+public static partial class NativeMediaPath
 {
     /// <summary>Win32 MAX_PATH, counting the terminating NUL - so 259 chars is the longest plain path.</summary>
     public const int WindowsMaxPath = 260;
@@ -165,6 +165,6 @@ public static class NativeMediaPath
         }
     }
 
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-    private static extern uint GetShortPathNameW(string lpszLongPath, [Out] char[] lpszShortPath, uint cchBuffer);
+    [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial uint GetShortPathNameW(string lpszLongPath, [Out] char[] lpszShortPath, uint cchBuffer);
 }

--- a/src/ui/Logic/WindowsService.cs
+++ b/src/ui/Logic/WindowsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -99,7 +100,7 @@ namespace Nikse.SubtitleEdit.Logic
     /// <summary>
     /// Implementation of the window service that uses dependency injection to create windows.
     /// </summary>
-    public class WindowService : IWindowService
+    public partial class WindowService : IWindowService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -979,8 +980,9 @@ namespace Nikse.SubtitleEdit.Logic
             return handle == IntPtr.Zero ? window.IsVisible : IsWindowVisible(handle);
         }
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern bool IsWindowVisible(IntPtr hWnd);
+        [LibraryImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool IsWindowVisible(IntPtr hWnd);
 
         /// <summary>
         /// Hands the foreground and the keyboard back to <paramref name="dialog"/> after the
@@ -1312,20 +1314,21 @@ namespace Nikse.SubtitleEdit.Logic
         private const uint SwpNoMove = 0x0002;
         private const uint SwpNoActivate = 0x0010;
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern IntPtr GetForegroundWindow();
+        [LibraryImport("user32.dll")]
+        private static partial IntPtr GetForegroundWindow();
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+        [LibraryImport("user32.dll")]
+        private static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern int GetWindowLongW(IntPtr hWnd, int nIndex);
+        [LibraryImport("user32.dll")]
+        private static partial int GetWindowLongW(IntPtr hWnd, int nIndex);
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
+        [LibraryImport("user32.dll")]
+        private static partial IntPtr GetWindow(IntPtr hWnd, uint uCmd);
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
+        [LibraryImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
 
         /// <summary>
         /// Creates a window instance using the service provider.

--- a/src/ui/Program.cs
+++ b/src/ui/Program.cs
@@ -25,7 +25,7 @@ using Nikse.SubtitleEdit.UiLogic.SpellCheck;
 
 namespace Nikse.SubtitleEdit
 {
-    internal class Program
+    internal partial class Program
     {
         private const string AppName = "Subtitle Edit";
 
@@ -290,8 +290,8 @@ namespace Nikse.SubtitleEdit
             }
         }
 
-        [DllImport("libc", SetLastError = true)]
-        private static extern int setenv(string name, string value, int overwrite);
+        [LibraryImport("libc", StringMarshalling = StringMarshalling.Utf8, SetLastError = true)]
+        private static partial int setenv(string name, string value, int overwrite);
 
         /// <summary>
         /// Makes dead-key accents (á, ê, õ, ...) work on Linux. Avalonia's ibus D-Bus client


### PR DESCRIPTION
## Summary
- Converts all 107 `DllImport` declarations in `src/ui` (16 files) to source-generated `[LibraryImport]`, so P/Invoke marshalling stubs are emitted at compile time instead of as runtime IL stubs. No `DllImport` remains in the repo.
- Mechanical part: containing classes become `partial`, methods `static partial`, `CharSet` becomes `StringMarshalling`, every Win32 `BOOL` / X11 `Bool` gets an explicit `[MarshalAs(UnmanagedType.Bool)]`, `PreserveSig` is dropped.
- `GetClassName` (`ForegroundWindowTracker`): `StringBuilder` is not supported by the generator, replaced with `[Out] char[]`.
- `PAINTSTRUCT` (`LibMpvDynamicNativeControl`) and `BITMAPINFO` (`ClipboardHelper`) made blittable with identical native layout (BOOL fields as `int`, `fixed byte[32]`, inline `RGBQUAD`). No code reads those fields.
- Entry points are exact with `LibraryImport`, so the A/W suffix is explicit where the runtime used to probe: `GetClassNameW`, `PostMessageW`, `LoadCursorW`, `LoadLibraryExW`, `SetDllDirectoryW`, `LoadLibraryA`. The mpv child-window subclass uses `SetWindowLongPtrW`/`CallWindowProcW` to pair with its `CreateWindowExW` window; it only handles `WM_NCHITTEST`/`WM_SETCURSOR`/`WM_ERASEBKGND`/`WM_PAINT`/`WM_LBUTTONDOWN`, so there is no behaviour change.
- One deliberate semantic fix: `CGEventSourceButtonState` (macOS) returns a 1-byte C `bool`, now marshalled as `U1` instead of the 4-byte `BOOL` that `DllImport` assumed.
- Strings: UTF-16 on Windows, UTF-8 on libc/libobjc/libSystem (what ANSI already meant there), `LPStr` on the two ANSI kernel32 calls to keep system-codepage semantics.

## Test plan
- [x] `dotnet build SubtitleEdit.sln -c Release`: 0 errors, no SYSLIB105x diagnostics
- [x] `tests/UI`: the same 25 failures as unmodified `main` (pre-existing headless focus/menu tests), no interop exceptions in the output
- [x] Windows: Release `SubtitleEdit.exe` starts and stays up (dark-mode title bar, foreground hooks, window service)
- [x] Windows: open a video with the mpv player (child HWND, WndProc subclass, black background before the first frame) and with VLC
- [ ] Windows: Alt+Space system menu, copy an image to the clipboard from OCR, Alt+Tab to an undocked window
- [ ] Linux: video with mpv/VLC (X11 child window), cursor position over the video window, dead-key input fix (`setenv`)
- [ ] macOS: Apple Vision OCR, the Window menu / Dock window list, cursor position and button state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sDF9tsdNZszz8q6igt2it
