### PR TITLE
Fix memory leaks in hot paths: dialog mpv cores, row handlers, spectrogram, auto-backup

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -2368,6 +2368,7 @@
       "cloneVoicePerLinePreparing": "Taking the voice of each line from the video...",
       "cloneVoicePerLineNeedsVideo": "Cloning the voice of each line needs the video the subtitle belongs to. Open the video and try again.",
       "cloneVoicePerLineNoClips": "No audio could be taken from the video, so there is nothing to clone from. Check that the video has an audio track.",
+      "cloneVoicePerLineNeedsOriginalSubtitleX": "{0} can only clone a line when it knows what is said in the video at that line, which comes from the original-language subtitle. No original subtitle is loaded, so every line would be spoken by the first imported voice instead of the voice in the video.\n\nOpen the original subtitle (File > Open original...) next to the translation, then generate again.",
       "voiceCloneConsentTitle": "Voice cloning - before you start",
       "voiceCloneConsentHeader": "You are about to clone a voice",
       "voiceCloneConsentIntro": "Cloning copies a real person's voice. That comes with rules in most places, and in the EU with legal duties that fall on you, not on Subtitle Edit. Please read this once.",

--- a/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyAdvancedEffect/AssaApplyAdvancedEffectViewModel.cs
@@ -314,7 +314,7 @@ public partial class AssaApplyAdvancedEffectViewModel : ObservableObject
     internal void OnClosing()
     {
         _positionTimer.Stop();
-        VideoPlayerControl.VideoPlayer.CloseFile();
+        VideoPlayerControl.CloseAndDisposePlayer();
         try
         {
             if (File.Exists(_tempSubtitleFileName))

--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaApplyCustomOverrideTagsViewModel.cs
@@ -316,7 +316,7 @@ public partial class AssaApplyCustomOverrideTagsViewModel : ObservableObject
     internal void OnClosing()
     {
         _positionTimer.Stop();
-        VideoPlayerControl.VideoPlayer.CloseFile();
+        VideoPlayerControl.CloseAndDisposePlayer();
         try
         {
             if (File.Exists(_tempSubtitleFileName))

--- a/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarViewModel.cs
+++ b/src/ui/Features/Assa/AssaProgressBar/AssaProgressBarViewModel.cs
@@ -586,7 +586,7 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
         try
         {
-            VideoPlayerControl?.Close();
+            VideoPlayerControl?.CloseAndDisposePlayer();
         }
         catch
         {

--- a/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundViewModel.cs
+++ b/src/ui/Features/Assa/AssaSetBackground/AssSetBackgroundViewModel.cs
@@ -797,7 +797,7 @@ public partial class AssSetBackgroundViewModel : ObservableObject
     {
         _positionTimer.Stop();
         _cancellationTokenSource.Cancel();
-        VideoPlayerControl.VideoPlayer.CloseFile();
+        VideoPlayerControl.CloseAndDisposePlayer();
         try
         {
             File.Delete(_tempSubtitleFileName);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -26541,6 +26541,9 @@ public partial class MainViewModel :
         if (AudioVisualizer != null)
         {
             AudioVisualizer.WavePeaks = null;
+            // Disposes the previous video's SKBitmap tiles - otherwise they stay resident (and get
+            // drawn against the next timeline) until a video that has its own spectrogram loads.
+            AudioVisualizer.SetSpectrogram(null);
             AudioVisualizer.ShotChanges = new List<double>();
             AudioVisualizer.Chapters = new List<WaveformChapter>();
             AudioVisualizer.StartPositionSeconds = 0;
@@ -29748,13 +29751,28 @@ public partial class MainViewModel :
             _referenceMappingDirty = true;
         }
 
-        if (e.NewItems != null)
-            foreach (SubtitleLineViewModel item in e.NewItems)
-                item.PropertyChanged += OnSubtitleItemChangedForMpv;
+        // Subtitles.Clear() raises Reset with no OldItems, and the bulk paths (sort, delete, merge,
+        // undo/redo, ReplaceSubtitles) then re-add the same row instances - so unhook via the
+        // tracked set on Reset and never subscribe a row twice, or every pass stacks one more
+        // delegate on each surviving row and the handler runs N times per time-code change.
+        if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+        {
+            foreach (var item in _mpvSubscribedRows)
+                item.PropertyChanged -= OnSubtitleItemChangedForMpv;
+            _mpvSubscribedRows.Clear();
+        }
+
         if (e.OldItems != null)
             foreach (SubtitleLineViewModel item in e.OldItems)
-                item.PropertyChanged -= OnSubtitleItemChangedForMpv;
+                if (_mpvSubscribedRows.Remove(item))
+                    item.PropertyChanged -= OnSubtitleItemChangedForMpv;
+        if (e.NewItems != null)
+            foreach (SubtitleLineViewModel item in e.NewItems)
+                if (_mpvSubscribedRows.Add(item))
+                    item.PropertyChanged += OnSubtitleItemChangedForMpv;
     }
+
+    private readonly HashSet<SubtitleLineViewModel> _mpvSubscribedRows = new(ReferenceEqualityComparer.Instance);
 
     private void OnSubtitleItemChangedForMpv(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
@@ -30225,7 +30243,8 @@ public partial class MainViewModel :
     {
         Subtitles.CollectionChanged += OnSubtitlesCollectionChangedForMpv;
         foreach (var item in Subtitles)
-            item.PropertyChanged += OnSubtitleItemChangedForMpv;
+            if (_mpvSubscribedRows.Add(item))
+                item.PropertyChanged += OnSubtitleItemChangedForMpv;
         _positionTimer = new UiTickPump(TimeSpan.FromMilliseconds(50));
         _positionTimer.Tick += (s, e) =>
         {
@@ -30622,6 +30641,18 @@ public partial class MainViewModel :
         _cursorTimer?.Stop();
         _slowTimer.Stop();
         _undoRedoManager.StopChangeDetection();
+
+        // The auto-backup DispatcherTimer closes over this view model; left running it roots a
+        // closed "New window" editor (grid, rows, waveform, player wrapper) for the rest of the
+        // process and keeps calling HasChanges() on it.
+        _autoBackupService.StopAutobackup();
+
+        // Static slot assigned in the constructor - only the most recent window is registered,
+        // so clear it when that window goes so the dead view model is not pinned.
+        if (UiTheme.SystemThemeChangedCallback == OnSystemThemeChanged)
+        {
+            UiTheme.SystemThemeChangedCallback = null;
+        }
     }
 
     // Preview settle window after the last keystroke. Deliberately shorter than

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2891,11 +2891,9 @@ public partial class BinaryEditViewModel : ObservableObject
         // so closing without ever opening a video forgot the window placement.
         UiUtil.SaveWindowPosition(Window);
 
-        if (VideoPlayerControl == null)
-            return;
-        if (string.IsNullOrWhiteSpace(VideoPlayerControl.VideoPlayer.FileName))
-            return;
-        VideoPlayerControl.VideoPlayer.CloseFile();
+        // Dispose the player core even when no video was ever opened - MakeVideoPlayer already
+        // created the mpv core and the position pump, and only CloseAndDisposePlayer frees them.
+        VideoPlayerControl?.CloseAndDisposePlayer();
     }
 
     public void Loaded()

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -507,7 +507,7 @@ public partial class SetSyncPointViewModel : ObservableObject
     {
         UiUtil.SaveWindowPosition(Window);
         _positionTimer.Stop();
-        VideoPlayerControl.VideoPlayer.CloseFile();
+        VideoPlayerControl.CloseAndDisposePlayer();
 
         // Deletes the temp subtitle file handed to the player.
         _previewSubtitle.Reset();

--- a/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
+++ b/src/ui/Features/Sync/VisualSync/VisualSyncViewModel.cs
@@ -566,8 +566,8 @@ public partial class VisualSyncViewModel : ObservableObject
     {
         UiUtil.SaveWindowPosition(Window);
         _positionTimer.Stop();
-        VideoPlayerControlLeft.VideoPlayer.CloseFile();
-        VideoPlayerControlRight.VideoPlayer.CloseFile();
+        VideoPlayerControlLeft.CloseAndDisposePlayer();
+        VideoPlayerControlRight.CloseAndDisposePlayer();
 
         // Deletes the temp subtitle files handed to the two players.
         _previewSubtitleLeft.Reset();

--- a/src/ui/Features/Video/BurnIn/BurnInEffectWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInEffectWindow.cs
@@ -104,7 +104,7 @@ public class BurnInEffectWindow : Window
     protected override void OnClosing(WindowClosingEventArgs e)
     {
         base.OnClosing(e);
-        _vm.VideoPlayerControl?.Close();
+        _vm.VideoPlayerControl?.CloseAndDisposePlayer();
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInLogoWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInLogoWindow.cs
@@ -246,7 +246,7 @@ public class BurnInLogoWindow : Window
     protected override void OnClosing(WindowClosingEventArgs e)
     {
         base.OnClosing(e);
-        _vm.VideoPlayerControl?.Close();
+        _vm.VideoPlayerControl?.CloseAndDisposePlayer();
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -2713,7 +2713,7 @@ public partial class BurnInViewModel : ObservableObject
 
         try
         {
-            VideoPlayerControl?.Close();
+            VideoPlayerControl?.CloseAndDisposePlayer();
         }
         catch
         {

--- a/src/ui/Features/Video/BurnIn/SelectVideoPositionWindow.cs
+++ b/src/ui/Features/Video/BurnIn/SelectVideoPositionWindow.cs
@@ -70,7 +70,7 @@ public class SelectVideoPositionWindow : Window
     protected override void OnClosing(WindowClosingEventArgs e)
     {
         base.OnClosing(e);
-        _vm.VideoPlayerControl?.Close();
+        _vm.VideoPlayerControl?.CloseAndDisposePlayer();
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoViewModel.cs
@@ -985,7 +985,7 @@ public partial class CutVideoViewModel : ObservableObject
 
         _positionTimer.Stop();
         _timerGenerate.StopAndDispose(TimerGenerateElapsed);
-        VideoPlayer.VideoPlayer.CloseFile();
+        VideoPlayer.CloseAndDisposePlayer();
 
         if (_ffmpegListKeyFramesProcess != null && !_ffmpegListKeyFramesProcess.HasExited)
         {

--- a/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
+++ b/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
@@ -181,7 +181,7 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
     internal void OnClosing()
     {
         _positionTimer.Stop();
-        VideoPlayerControl.VideoPlayer.CloseFile();
+        VideoPlayerControl.CloseAndDisposePlayer();
         try
         {
             if (File.Exists(_tempSubtitleFileName))

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesViewModel.cs
@@ -1593,7 +1593,7 @@ public partial class TransparentSubtitlesViewModel : ObservableObject
 
         try
         {
-            VideoPlayerControl?.Close();
+            VideoPlayerControl?.CloseAndDisposePlayer();
         }
         catch
         {


### PR DESCRIPTION
## Summary
Four leaks found in a hot-path audit of MainViewModel, the waveform and the video player.

1. **Every video-preview dialog leaked a live mpv core.** 13 dialogs (VisualSync x2, SetSyncPoint, CutVideo, OpenSecondarySubtitle, AssaApplyCustomOverrideTags, AssaApplyAdvancedEffect, AssaSetBackground, AssaProgressBar, BurnIn, BurnInLogo, BurnInEffect, SelectVideoPosition, TransparentSubtitles, BinaryEdit) built a `VideoPlayerControl` via `MakeVideoPlayer` but only called `VideoPlayer.CloseFile()` or `Close()` on close. Only `CloseAndDisposePlayer()` frees the core, render context and event thread, and for the `CloseFile()`-only dialogs the 50 ms position pump thread kept posting to the UI thread forever. Opening Visual Sync ten times left 20 mpv cores and 20 pump threads behind. All closing paths now call `CloseAndDisposePlayer()`.
2. **mpv-preview `PropertyChanged` handler stacked on rows.** `Subtitles.Clear()` raises Reset with no `OldItems`, and sort/delete/merge/undo/redo/`ReplaceSubtitles` then re-add the same row instances, adding one more delegate to every surviving row per pass. Subscribed rows are now tracked in a set; Reset unhooks them and a row is never subscribed twice.
3. **Stale spectrogram after closing a video.** `VideoCloseFile` nulled peaks/shot changes/chapters but never `SetSpectrogram(null)`, so the previous video's SKBitmap tiles stayed resident and were drawn against the next timeline.
4. **Closed secondary windows stayed rooted.** `StopBackgroundWork` did not stop the transient auto-backup `DispatcherTimer` (whose tick closes over the view model), and the static `UiTheme.SystemThemeChangedCallback` was assigned in every constructor and never cleared. Both are now released on cleanup.

## Test plan
- [x] `dotnet build src/ui/UI.csproj`
- [x] `dotnet test tests/UI/UITests.csproj` — 5004 passed, 1 skipped
- [ ] Manual: open/close Visual Sync several times, check thread count and mpv process memory stays flat
- [ ] Manual: open video with spectrogram, close video, confirm waveform area is blank and memory drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)