### PR TITLE
seconv: use the GUI's PaddleOCR install and add a run timeout

### DIFF
--- a/src/libse/Common/PaddleOcrModels.cs
+++ b/src/libse/Common/PaddleOcrModels.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Maps a PaddleOCR language code to the detection/recognition model names shipped in the
+    /// "PaddleOCR.PP-OCRv6.support.files" bundle (standalone PaddleOCR 3.7). Shared by the GUI
+    /// engine and seconv so both launch the same models for the same language.
+    ///
+    /// Only the models in that bundle are on disk - nothing is fetched per language. Returning
+    /// a name that is not in the bundle points at a folder that does not exist, and the run then
+    /// fails when PaddleX tries to read the model's inference.yml.
+    /// </summary>
+    public static class PaddleOcrModels
+    {
+        public const string TextlineOrientationModelName = "PP-LCNet_x1_0_textline_ori";
+
+        // The script groups below mirror LATIN_LANGS/ARABIC_LANGS/ESLAV_LANGS/CYRILLIC_LANGS/
+        // DEVANAGARI_LANGS in PaddleOCR 3.7 (paddleocr/_utils/langs.py) - the version the
+        // bundled standalone engine is built from. Keep them in sync with the GUI's language
+        // list; a code offered in the dropdown but missing from every group here silently falls
+        // through to the Latin recognition model and OCRs to garbage.
+        private static readonly HashSet<string> LatinLanguageCodes = new HashSet<string>
+        {
+            "af", "az", "bs", "ca", "cs", "cy", "da", "de", "es", "et", "eu",
+            "fi", "fr", "ga", "gl", "hr", "hu", "id", "is", "it", "ku", "la",
+            "lb", "lt", "lv", "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl",
+            "pt", "qu", "rm", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw",
+            "tl", "tr", "uz", "vi", "french", "german"
+        };
+
+        private static readonly HashSet<string> ArabicLanguageCodes = new HashSet<string>
+        {
+            "ar", "bal", "fa", "ps", "sd", "ug", "ur"
+        };
+
+        private static readonly HashSet<string> EslavLanguageCodes = new HashSet<string>
+        {
+            "ru", "be", "uk"
+        };
+
+        private static readonly HashSet<string> CyrillicLanguageCodes = new HashSet<string>
+        {
+            "rs_cyrillic", "bg", "mn", "abq", "ady", "kbd", "ava", "dar",
+            "inh", "che", "lbe", "lez", "tab", "ba", "bua", "cv", "kaa",
+            "kk", "kv", "ky", "mhr", "mk", "mo", "os", "sah", "tg", "tt",
+            "tyv", "udm", "xal"
+        };
+
+        private static readonly HashSet<string> DevanagariLanguageCodes = new HashSet<string>
+        {
+            "hi", "mr", "ne", "bh", "mai", "ang", "bho", "mah",
+            "sck", "new", "gom", "bgc", "sa"
+        };
+
+        // The languages with their own single-language PP-OCRv5 recognition model.
+        private static readonly HashSet<string> OwnModelLanguageCodes = new HashSet<string>
+        {
+            "el", "ta", "te", "th"
+        };
+
+        // Pali is the one Latin language PP-OCRv6 does not cover, so it stays on the PP-OCRv5
+        // Latin model (_PPOCRV6_UNSUPPORTED_LATIN_LANGS in paddleocr/_pipelines/ocr.py).
+        private const string PaliLanguageCode = "pi";
+
+        /// <summary>
+        /// True for the languages PP-OCRv6 (new in PaddleOCR 3.7) recognizes with its single
+        /// unified model: Chinese, English, Japanese and the Latin languages except Pali - the
+        /// _PPOCRV6_LANGS set in paddleocr/_pipelines/ocr.py. No non-Latin script has a v6 model
+        /// at all, so every other language keeps the PP-OCRv5 (Georgian: PP-OCRv3) models that
+        /// the support-files bundle still ships alongside the v6 pair.
+        /// </summary>
+        public static bool IsPpOcrV6Language(string language)
+        {
+            if (language == "ch" || language == "chinese_cht" || language == "en" || language == "japan")
+            {
+                return true;
+            }
+
+            return LatinLanguageCodes.Contains(language) && language != PaliLanguageCode;
+        }
+
+        /// <summary>Arabic-script languages, whose words read right-to-left.</summary>
+        public static bool IsArabicScript(string language) => ArabicLanguageCodes.Contains(language);
+
+        // PP-OCRv6 replaced the mobile/server pair with tiny/small/medium tiers, and the bundle
+        // ships small and medium - so the saved mode picks between those two.
+        private static string PpOcrV6Tier(string mode) => mode == "server" ? "medium" : "small";
+
+        /// <param name="language">PaddleOCR language code (e.g. "en", "korean", "rs_cyrillic").</param>
+        /// <param name="mode">"mobile" or "server" - the GUI's saved model-size setting.</param>
+        public static string GetRecName(string language, string mode)
+        {
+            if (IsPpOcrV6Language(language))
+            {
+                return $"PP-OCRv6_{PpOcrV6Tier(mode)}_rec";
+            }
+
+            if (ArabicLanguageCodes.Contains(language))
+            {
+                return "arabic_PP-OCRv5_mobile_rec";
+            }
+
+            if (EslavLanguageCodes.Contains(language))
+            {
+                return "eslav_PP-OCRv5_mobile_rec";
+            }
+
+            if (CyrillicLanguageCodes.Contains(language))
+            {
+                return "cyrillic_PP-OCRv5_mobile_rec";
+            }
+
+            if (DevanagariLanguageCodes.Contains(language))
+            {
+                return "devanagari_PP-OCRv5_mobile_rec";
+            }
+
+            if (language == "korean")
+            {
+                return "korean_PP-OCRv5_mobile_rec";
+            }
+
+            if (OwnModelLanguageCodes.Contains(language))
+            {
+                return $"{language}_PP-OCRv5_mobile_rec";
+            }
+
+            if (language == "ka")
+            {
+                // Georgian has no PP-OCRv5 recognition model yet.
+                return "ka_PP-OCRv3_mobile_rec";
+            }
+
+            // Pali, plus the safety net for a code no script group claims - the v6 bundle
+            // no longer has a general-purpose PP-OCRv5 model to fall back on.
+            return "latin_PP-OCRv5_mobile_rec";
+        }
+
+        /// <inheritdoc cref="GetRecName"/>
+        public static string GetDetectionName(string language, string mode)
+        {
+            // Georgian is the one remaining PP-OCRv3 language.
+            if (language == "ka")
+            {
+                return "PP-OCRv3_mobile_det";
+            }
+
+            // Detector and recognition model come from the same PaddleOCR generation, which is
+            // how upstream pairs them (PP-OCRv6 languages get the v6 detector of the same tier).
+            return IsPpOcrV6Language(language)
+                ? $"PP-OCRv6_{PpOcrV6Tier(mode)}_det"
+                : $"PP-OCRv5_{mode}_det";
+        }
+
+        public static IReadOnlyCollection<string> LatinLanguageCodesForTest => LatinLanguageCodes;
+
+        public static IEnumerable<string> AllScriptGroupCodesForTest =>
+            LatinLanguageCodes
+                .Concat(ArabicLanguageCodes)
+                .Concat(EslavLanguageCodes)
+                .Concat(CyrillicLanguageCodes)
+                .Concat(DevanagariLanguageCodes)
+                .Concat(OwnModelLanguageCodes)
+                .Distinct();
+    }
+}

--- a/src/seconv/Core/PaddleOcrEngine.cs
+++ b/src/seconv/Core/PaddleOcrEngine.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Nikse.SubtitleEdit.Core.Common;
 using SkiaSharp;
 
 namespace SeConv.Core;
@@ -186,8 +187,6 @@ internal sealed class PaddleOcrEngine : IOcrEngine
     /// <summary>Upper bound for one paddleocr run (model load + one image).</summary>
     internal static readonly TimeSpan ProcessTimeout = TimeSpan.FromMinutes(10);
 
-    private const string TextlineOrientationModelName = "PP-LCNet_x1_0_textline_ori";
-
     /// <summary>
     /// Command line for one image. The standalone install gets the GUI's full argument set
     /// with explicit model folders (it has no model download of its own); a PATH install
@@ -204,8 +203,9 @@ internal sealed class PaddleOcrEngine : IOcrEngine
             return args;
         }
 
-        var detName = GetDetectionName(Language);
-        var recName = GetRecName(Language);
+        // "server" = the PP-OCRv6 medium tier, the more accurate of the two bundled sizes.
+        var detName = PaddleOcrModels.GetDetectionName(Language, "server");
+        var recName = PaddleOcrModels.GetRecName(Language, "server");
         args.AddRange(new[]
         {
             "--use_textline_orientation", "true",
@@ -215,64 +215,10 @@ internal sealed class PaddleOcrEngine : IOcrEngine
             "--text_detection_model_name", detName,
             "--text_recognition_model_dir", Path.Combine(modelsFolder, "rec", recName),
             "--text_recognition_model_name", recName,
-            "--textline_orientation_model_dir", Path.Combine(modelsFolder, "cls", TextlineOrientationModelName),
-            "--textline_orientation_model_name", TextlineOrientationModelName,
+            "--textline_orientation_model_dir", Path.Combine(modelsFolder, "cls", PaddleOcrModels.TextlineOrientationModelName),
+            "--textline_orientation_model_name", PaddleOcrModels.TextlineOrientationModelName,
         });
         return args;
-    }
-
-    // Script groups mirror PaddleOCR 3.7 (paddleocr/_utils/langs.py) and the GUI's
-    // PaddleOcr.GetRecName/GetDetectionName - only the models in the bundled
-    // "PaddleOCR.PP-OCRv6.support.files" archive exist on disk, so the mapping must stay in sync.
-    private static readonly HashSet<string> LatinLanguageCodes = new()
-    {
-        "af", "az", "bs", "ca", "cs", "cy", "da", "de", "es", "et", "eu",
-        "fi", "fr", "ga", "gl", "hr", "hu", "id", "is", "it", "ku", "la",
-        "lb", "lt", "lv", "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl",
-        "pt", "qu", "rm", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw",
-        "tl", "tr", "uz", "vi", "french", "german"
-    };
-
-    private static readonly HashSet<string> ArabicLanguageCodes = new() { "ar", "bal", "fa", "ps", "sd", "ug", "ur" };
-    private static readonly HashSet<string> EslavLanguageCodes = new() { "ru", "be", "uk" };
-
-    private static readonly HashSet<string> CyrillicLanguageCodes = new()
-    {
-        "rs_cyrillic", "bg", "mn", "abq", "ady", "kbd", "ava", "dar",
-        "inh", "che", "lbe", "lez", "tab", "ba", "bua", "cv", "kaa",
-        "kk", "kv", "ky", "mhr", "mk", "mo", "os", "sah", "tg", "tt",
-        "tyv", "udm", "xal"
-    };
-
-    private static readonly HashSet<string> DevanagariLanguageCodes = new()
-    {
-        "hi", "mr", "ne", "bh", "mai", "ang", "bho", "mah", "sck", "new", "gom", "bgc", "sa"
-    };
-
-    private static readonly HashSet<string> OwnModelLanguageCodes = new() { "el", "ta", "te", "th" };
-
-    // Pali is the one Latin language PP-OCRv6 does not cover.
-    private static bool IsPpOcrV6Language(string language) =>
-        language is "ch" or "chinese_cht" or "en" or "japan" ||
-        (LatinLanguageCodes.Contains(language) && language != "pi");
-
-    internal static string GetRecName(string language)
-    {
-        if (IsPpOcrV6Language(language)) return "PP-OCRv6_medium_rec";
-        if (ArabicLanguageCodes.Contains(language)) return "arabic_PP-OCRv5_mobile_rec";
-        if (EslavLanguageCodes.Contains(language)) return "eslav_PP-OCRv5_mobile_rec";
-        if (CyrillicLanguageCodes.Contains(language)) return "cyrillic_PP-OCRv5_mobile_rec";
-        if (DevanagariLanguageCodes.Contains(language)) return "devanagari_PP-OCRv5_mobile_rec";
-        if (language == "korean") return "korean_PP-OCRv5_mobile_rec";
-        if (OwnModelLanguageCodes.Contains(language)) return $"{language}_PP-OCRv5_mobile_rec";
-        if (language == "ka") return "ka_PP-OCRv3_mobile_rec"; // no PP-OCRv5 model for Georgian yet
-        return "latin_PP-OCRv5_mobile_rec"; // Pali + safety net for unknown codes
-    }
-
-    internal static string GetDetectionName(string language)
-    {
-        if (language == "ka") return "PP-OCRv3_mobile_det";
-        return IsPpOcrV6Language(language) ? "PP-OCRv6_medium_det" : "PP-OCRv5_server_det";
     }
 
     /// <summary>

--- a/src/seconv/Core/PaddleOcrEngine.cs
+++ b/src/seconv/Core/PaddleOcrEngine.cs
@@ -5,8 +5,9 @@ using SkiaSharp;
 namespace SeConv.Core;
 
 /// <summary>
-/// OCR via the PaddleOCR command-line tool on the system PATH. Supports the standalone
-/// binary (<c>paddleocr</c> / <c>paddleocr.exe</c>) installed via <c>pip install paddleocr</c>.
+/// OCR via the PaddleOCR command-line tool. Prefers the standalone install the GUI downloads
+/// (SE data folder, OCR/PaddleOCR3-7, with its bundled models), then a <c>paddleocr</c> from
+/// <c>pip install paddleocr</c> on the system PATH.
 /// Limited subset compared to SE's UI implementation; assumes a single image per invocation.
 /// </summary>
 internal sealed class PaddleOcrEngine : IOcrEngine
@@ -25,7 +26,47 @@ internal sealed class PaddleOcrEngine : IOcrEngine
         _workDir = workDir;
     }
 
+    /// <summary>
+    /// Folder name of the GUI's standalone PaddleOCR install, under the SE "OCR" data folder.
+    /// Keep in sync with <c>Se.PaddleOcrFolder</c> in the UI project.
+    /// </summary>
+    private const string StandaloneFolderName = "PaddleOCR3-7";
+
+    /// <summary>
+    /// Locates PaddleOCR. The GUI's standalone install is preferred (portable SE first, then
+    /// the installed GUI's data folder), so seconv reuses the engine and models the user
+    /// already downloaded; then falls back to a <c>paddleocr</c> on the system PATH.
+    /// Returns null if missing.
+    /// </summary>
     public static string? Detect()
+    {
+        return DetectStandalone() ?? DetectOnPath();
+    }
+
+    internal static string? DetectStandalone()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "OCR", StandaloneFolderName),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit", "OCR", StandaloneFolderName),
+        };
+
+        foreach (var folder in candidates)
+        {
+            foreach (var name in new[] { "paddleocr.exe", "paddleocr.bin" })
+            {
+                var candidate = Path.Combine(folder, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string? DetectOnPath()
     {
         var name = OperatingSystem.IsWindows() ? "paddleocr.exe" : "paddleocr";
         var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
@@ -41,12 +82,28 @@ internal sealed class PaddleOcrEngine : IOcrEngine
         return null;
     }
 
+    /// <summary>
+    /// The standalone install ships its models in a "models" folder next to the binary
+    /// (cls/det/rec sub-folders). When present, they are passed explicitly like the GUI does.
+    /// </summary>
+    internal static string? GetModelsFolder(string executablePath)
+    {
+        var folder = Path.GetDirectoryName(executablePath);
+        if (folder == null)
+        {
+            return null;
+        }
+
+        var models = Path.Combine(folder, "models");
+        return Directory.Exists(Path.Combine(models, "rec")) ? models : null;
+    }
+
     public static PaddleOcrEngine Create(string language = "en")
     {
         var path = Detect()
             ?? throw new InvalidOperationException(
-                "PaddleOCR not found on PATH. Install it (e.g. `pip install paddleocr`) " +
-                "and ensure the `paddleocr` binary is on PATH.");
+                "PaddleOCR not found. Download it via Subtitle Edit (OCR > PaddleOCR), or install it " +
+                "(e.g. `pip install paddleocr`) and ensure the `paddleocr` binary is on PATH.");
 
         var workDir = Path.Combine(Path.GetTempPath(), "seconv_paddle_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(workDir);
@@ -72,14 +129,19 @@ internal sealed class PaddleOcrEngine : IOcrEngine
 
             var psi = new ProcessStartInfo(ExecutablePath)
             {
-                ArgumentList = { "ocr", "-i", pngPath, "--lang", Language, "--use_angle_cls", "false" },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 StandardOutputEncoding = System.Text.Encoding.UTF8,
                 StandardErrorEncoding = System.Text.Encoding.UTF8,
                 UseShellExecute = false,
                 CreateNoWindow = true,
+                // The tool may write relative to its current directory; make sure that is writable.
+                WorkingDirectory = _workDir,
             };
+            foreach (var arg in BuildArguments(pngPath))
+            {
+                psi.ArgumentList.Add(arg);
+            }
 
             // StandardOutputEncoding only fixes the decoding side. paddleocr is a Python CLI, and
             // on Windows Python encodes a *redirected* stdout with the ANSI codepage (until UTF-8
@@ -88,14 +150,26 @@ internal sealed class PaddleOcrEngine : IOcrEngine
             // Paddle engine sets.
             psi.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
             psi.EnvironmentVariables["PYTHONUTF8"] = "1";
+            // Skip PaddleX's online model-source connectivity check - it can hang the run at
+            // "Initializing..." when offline, and with explicit local model dirs it is pointless.
+            psi.EnvironmentVariables["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True";
 
             using var proc = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start paddleocr process.");
             // Drain stderr concurrently — paddleocr is chatty on stderr, and reading stdout
             // to completion while stderr fills the pipe buffer would deadlock.
             var stderrTask = proc.StandardError.ReadToEndAsync();
-            var stdout = proc.StandardOutput.ReadToEnd();
-            proc.WaitForExit();
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            // Never wait forever: a wedged run (missing model, stuck initialisation, a worker
+            // process that never returns) used to hang seconv with no output at all.
+            if (!proc.WaitForExit(ProcessTimeout))
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                throw new InvalidOperationException(
+                    $"paddleocr did not finish within {ProcessTimeout.TotalMinutes:0} minutes and was killed.");
+            }
+            proc.WaitForExit(); // flush the redirected streams
+            var stdout = stdoutTask.GetAwaiter().GetResult();
             if (proc.ExitCode != 0)
             {
                 var err = stderrTask.GetAwaiter().GetResult();
@@ -107,6 +181,98 @@ internal sealed class PaddleOcrEngine : IOcrEngine
         {
             try { File.Delete(pngPath); } catch { /* best-effort */ }
         }
+    }
+
+    /// <summary>Upper bound for one paddleocr run (model load + one image).</summary>
+    internal static readonly TimeSpan ProcessTimeout = TimeSpan.FromMinutes(10);
+
+    private const string TextlineOrientationModelName = "PP-LCNet_x1_0_textline_ori";
+
+    /// <summary>
+    /// Command line for one image. The standalone install gets the GUI's full argument set
+    /// with explicit model folders (it has no model download of its own); a PATH install
+    /// keeps the plain invocation and lets paddleocr resolve models itself.
+    /// </summary>
+    internal List<string> BuildArguments(string imagePath)
+    {
+        var args = new List<string> { "ocr", "-i", imagePath, "--lang", Language };
+
+        var modelsFolder = GetModelsFolder(ExecutablePath);
+        if (modelsFolder == null)
+        {
+            args.AddRange(new[] { "--use_angle_cls", "false" });
+            return args;
+        }
+
+        var detName = GetDetectionName(Language);
+        var recName = GetRecName(Language);
+        args.AddRange(new[]
+        {
+            "--use_textline_orientation", "true",
+            "--use_doc_orientation_classify", "false",
+            "--use_doc_unwarping", "false",
+            "--text_detection_model_dir", Path.Combine(modelsFolder, "det", detName),
+            "--text_detection_model_name", detName,
+            "--text_recognition_model_dir", Path.Combine(modelsFolder, "rec", recName),
+            "--text_recognition_model_name", recName,
+            "--textline_orientation_model_dir", Path.Combine(modelsFolder, "cls", TextlineOrientationModelName),
+            "--textline_orientation_model_name", TextlineOrientationModelName,
+        });
+        return args;
+    }
+
+    // Script groups mirror PaddleOCR 3.7 (paddleocr/_utils/langs.py) and the GUI's
+    // PaddleOcr.GetRecName/GetDetectionName - only the models in the bundled
+    // "PaddleOCR.PP-OCRv6.support.files" archive exist on disk, so the mapping must stay in sync.
+    private static readonly HashSet<string> LatinLanguageCodes = new()
+    {
+        "af", "az", "bs", "ca", "cs", "cy", "da", "de", "es", "et", "eu",
+        "fi", "fr", "ga", "gl", "hr", "hu", "id", "is", "it", "ku", "la",
+        "lb", "lt", "lv", "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl",
+        "pt", "qu", "rm", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw",
+        "tl", "tr", "uz", "vi", "french", "german"
+    };
+
+    private static readonly HashSet<string> ArabicLanguageCodes = new() { "ar", "bal", "fa", "ps", "sd", "ug", "ur" };
+    private static readonly HashSet<string> EslavLanguageCodes = new() { "ru", "be", "uk" };
+
+    private static readonly HashSet<string> CyrillicLanguageCodes = new()
+    {
+        "rs_cyrillic", "bg", "mn", "abq", "ady", "kbd", "ava", "dar",
+        "inh", "che", "lbe", "lez", "tab", "ba", "bua", "cv", "kaa",
+        "kk", "kv", "ky", "mhr", "mk", "mo", "os", "sah", "tg", "tt",
+        "tyv", "udm", "xal"
+    };
+
+    private static readonly HashSet<string> DevanagariLanguageCodes = new()
+    {
+        "hi", "mr", "ne", "bh", "mai", "ang", "bho", "mah", "sck", "new", "gom", "bgc", "sa"
+    };
+
+    private static readonly HashSet<string> OwnModelLanguageCodes = new() { "el", "ta", "te", "th" };
+
+    // Pali is the one Latin language PP-OCRv6 does not cover.
+    private static bool IsPpOcrV6Language(string language) =>
+        language is "ch" or "chinese_cht" or "en" or "japan" ||
+        (LatinLanguageCodes.Contains(language) && language != "pi");
+
+    internal static string GetRecName(string language)
+    {
+        if (IsPpOcrV6Language(language)) return "PP-OCRv6_medium_rec";
+        if (ArabicLanguageCodes.Contains(language)) return "arabic_PP-OCRv5_mobile_rec";
+        if (EslavLanguageCodes.Contains(language)) return "eslav_PP-OCRv5_mobile_rec";
+        if (CyrillicLanguageCodes.Contains(language)) return "cyrillic_PP-OCRv5_mobile_rec";
+        if (DevanagariLanguageCodes.Contains(language)) return "devanagari_PP-OCRv5_mobile_rec";
+        if (language == "korean") return "korean_PP-OCRv5_mobile_rec";
+        if (OwnModelLanguageCodes.Contains(language)) return $"{language}_PP-OCRv5_mobile_rec";
+        if (language == "ka") return "ka_PP-OCRv3_mobile_rec"; // no PP-OCRv5 model for Georgian yet
+        return "latin_PP-OCRv5_mobile_rec"; // Pali + safety net for unknown codes
+    }
+
+    internal static string GetDetectionName(string language)
+    {
+        if (language == "ka") return "PP-OCRv3_mobile_det";
+        return IsPpOcrV6Language(language) ? "PP-OCRv6_medium_det" : "PP-OCRv5_server_det";
     }
 
     /// <summary>

--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -1,5 +1,6 @@
 ﻿using Nikse.SubtitleEdit.Features.Ocr.Download;
 using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
 using System;
@@ -90,87 +91,12 @@ public partial class PaddleOcr
         return new PaddleOcrArchive(urls, rootFolderInArchive ?? fileName[..fileName.IndexOf(".7z", StringComparison.Ordinal)]);
     }
 
-    private const string TextlineOrientationModelName = "PP-LCNet_x1_0_textline_ori";
+    // Model-name mapping lives in libse (PaddleOcrModels) so seconv launches the same models.
+    private const string TextlineOrientationModelName = PaddleOcrModels.TextlineOrientationModelName;
 
-    // The script groups below mirror LATIN_LANGS/ARABIC_LANGS/ESLAV_LANGS/CYRILLIC_LANGS/
-    // DEVANAGARI_LANGS in PaddleOCR 3.7 (paddleocr/_utils/langs.py) - the version the
-    // bundled standalone engine is built from. Keep them in sync with GetLanguages(); a
-    // code offered in the dropdown but missing from every group here silently falls
-    // through to the Latin recognition model and OCRs to garbage.
-    private static readonly HashSet<string> LatinLanguageCodes = new HashSet<string>
-    {
-        "af", "az", "bs", "ca", "cs", "cy", "da", "de", "es", "et", "eu",
-        "fi", "fr", "ga", "gl", "hr", "hu", "id", "is", "it", "ku", "la",
-        "lb", "lt", "lv", "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl",
-        "pt", "qu", "rm", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw",
-        "tl", "tr", "uz", "vi", "french", "german"
-    };
+    internal static IReadOnlyCollection<string> GetLatinLanguageCodesForTest() => PaddleOcrModels.LatinLanguageCodesForTest;
 
-    private static readonly HashSet<string> ArabicLanguageCodes = new HashSet<string>
-    {
-        "ar", "bal", "fa", "ps", "sd", "ug", "ur"
-    };
-
-    private static readonly HashSet<string> EslavLanguageCodes = new HashSet<string>
-    {
-        "ru", "be", "uk"
-    };
-
-    private static readonly HashSet<string> CyrillicLanguageCodes = new HashSet<string>
-    {
-        "rs_cyrillic", "bg", "mn", "abq", "ady", "kbd", "ava", "dar",
-        "inh", "che", "lbe", "lez", "tab", "ba", "bua", "cv", "kaa",
-        "kk", "kv", "ky", "mhr", "mk", "mo", "os", "sah", "tg", "tt",
-        "tyv", "udm", "xal"
-    };
-
-    private static readonly HashSet<string> DevanagariLanguageCodes = new HashSet<string>
-    {
-        "hi", "mr", "ne", "bh", "mai", "ang", "bho", "mah",
-        "sck", "new", "gom", "bgc", "sa"
-    };
-
-    // The languages with their own single-language PP-OCRv5 recognition model.
-    private static readonly HashSet<string> OwnModelLanguageCodes = new HashSet<string>
-    {
-        "el", "ta", "te", "th"
-    };
-
-    // Pali is the one Latin language PP-OCRv6 does not cover, so it stays on the PP-OCRv5
-    // Latin model (_PPOCRV6_UNSUPPORTED_LATIN_LANGS in paddleocr/_pipelines/ocr.py).
-    private const string PaliLanguageCode = "pi";
-
-    /// <summary>
-    /// True for the languages PP-OCRv6 (new in PaddleOCR 3.7) recognizes with its single
-    /// unified model: Chinese, English, Japanese and the Latin languages except Pali - the
-    /// _PPOCRV6_LANGS set in paddleocr/_pipelines/ocr.py. No non-Latin script has a v6 model
-    /// at all, so every other language keeps the PP-OCRv5 (Georgian: PP-OCRv3) models that
-    /// the support-files bundle still ships alongside the v6 pair.
-    /// </summary>
-    private static bool IsPpOcrV6Language(string language)
-    {
-        if (language is "ch" or "chinese_cht" or "en" or "japan")
-        {
-            return true;
-        }
-
-        return LatinLanguageCodes.Contains(language) && language != PaliLanguageCode;
-    }
-
-    // PP-OCRv6 replaced the mobile/server pair with tiny/small/medium tiers, and the bundle
-    // ships small and medium - so the saved mode picks between those two.
-    private static string PpOcrV6Tier(string mode) => mode == "server" ? "medium" : "small";
-
-    internal static IReadOnlyCollection<string> GetLatinLanguageCodesForTest() => LatinLanguageCodes;
-
-    internal static IEnumerable<string> GetAllScriptGroupCodesForTest() =>
-        LatinLanguageCodes
-            .Concat(ArabicLanguageCodes)
-            .Concat(EslavLanguageCodes)
-            .Concat(CyrillicLanguageCodes)
-            .Concat(DevanagariLanguageCodes)
-            .Concat(OwnModelLanguageCodes)
-            .Distinct();
+    internal static IEnumerable<string> GetAllScriptGroupCodesForTest() => PaddleOcrModels.AllScriptGroupCodesForTest;
 
     public PaddleOcr()
     {
@@ -183,70 +109,9 @@ public partial class PaddleOcr
         _cancellationToken = new CancellationToken();
     }
 
-    // Only the recognition models shipped in "PaddleOCR.PP-OCRv6.support.files" are on
-    // disk - nothing is fetched per language. Returning a name that is not in that bundle
-    // points at a folder that does not exist, and the run then fails when PaddleX tries to
-    // read the model's inference.yml.
-    internal static string GetRecName(string language, string mode)
-    {
-        string recName;
-        if (IsPpOcrV6Language(language))
-        {
-            recName = $"PP-OCRv6_{PpOcrV6Tier(mode)}_rec";
-        }
-        else if (ArabicLanguageCodes.Contains(language))
-        {
-            recName = "arabic_PP-OCRv5_mobile_rec";
-        }
-        else if (EslavLanguageCodes.Contains(language))
-        {
-            recName = "eslav_PP-OCRv5_mobile_rec";
-        }
-        else if (CyrillicLanguageCodes.Contains(language))
-        {
-            recName = "cyrillic_PP-OCRv5_mobile_rec";
-        }
-        else if (DevanagariLanguageCodes.Contains(language))
-        {
-            recName = "devanagari_PP-OCRv5_mobile_rec";
-        }
-        else if (language == "korean")
-        {
-            recName = "korean_PP-OCRv5_mobile_rec";
-        }
-        else if (OwnModelLanguageCodes.Contains(language))
-        {
-            recName = $"{language}_PP-OCRv5_mobile_rec";
-        }
-        else if (language == "ka")
-        {
-            // Georgian has no PP-OCRv5 recognition model yet.
-            recName = "ka_PP-OCRv3_mobile_rec";
-        }
-        else
-        {
-            // Pali, plus the safety net for a code no script group claims - the v6 bundle
-            // no longer has a general-purpose PP-OCRv5 model to fall back on.
-            recName = "latin_PP-OCRv5_mobile_rec";
-        }
+    internal static string GetRecName(string language, string mode) => PaddleOcrModels.GetRecName(language, mode);
 
-        return recName;
-    }
-
-    internal static string GetDetectionName(string language, string mode)
-    {
-        // Georgian is the one remaining PP-OCRv3 language.
-        if (language == "ka")
-        {
-            return "PP-OCRv3_mobile_det";
-        }
-
-        // Detector and recognition model come from the same PaddleOCR generation, which is
-        // how upstream pairs them (PP-OCRv6 languages get the v6 detector of the same tier).
-        return IsPpOcrV6Language(language)
-            ? $"PP-OCRv6_{PpOcrV6Tier(mode)}_det"
-            : $"PP-OCRv5_{mode}_det";
-    }
+    internal static string GetDetectionName(string language, string mode) => PaddleOcrModels.GetDetectionName(language, mode);
 
     internal static SKBitmap MakeTransparentBlack(SKBitmap bitmap)
     {
@@ -319,7 +184,7 @@ public partial class PaddleOcr
     {
         var detName = GetDetectionName(language, mode);
         var recName = GetRecName(language, mode);
-        _batchRightToLeft = ArabicLanguageCodes.Contains(language);
+        _batchRightToLeft = PaddleOcrModels.IsArabicScript(language);
         _batchProgress = progress;
         var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(folder);


### PR DESCRIPTION
Follow-up to the review of #14658, kept to two fixes on a fresh branch from main.

- **Find the GUI's PaddleOCR install.** seconv only looked for `paddleocr` on PATH. It now checks the standalone install the GUI downloads first (portable `OCR/PaddleOCR3-7` next to the exe, then `%APPDATA%/Subtitle Edit/OCR/PaddleOCR3-7`), and passes its bundled det/rec/cls models explicitly with the same per-script model mapping the GUI uses (PP-OCRv6 medium for Chinese/English/Japanese/Latin, PP-OCRv5 per-script models for Arabic, Cyrillic, Korean, Devanagari, etc., v3 for Georgian). A PATH install keeps the plain invocation.
- **Never hang.** Each run is bounded to 10 minutes and the process tree is killed on timeout with a clear error. `PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK` is set, like in the GUI, to avoid the offline hang at "Initializing...".

Not included: batch-per-process OCR and JSON result reading from #14658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)