### PR TITLE
Fix missing brace in Bulgarian translation

### DIFF
--- a/src/ui/Assets/Languages/Bulgarian.json
+++ b/src/ui/Assets/Languages/Bulgarian.json
@@ -3660,7 +3660,7 @@
     "resolutionResamplerFromVideo": "От видеото...",
     "resolutionResamplerSourceAndTargetEqual": "Изходната и целевата резолюция са еднакви - няма какво да се прави.",
     "resolutionResamplerNothingSelected": "Моля, изберете поне една опция за промяна.",
-    "resolutionResamplerVideoDiffers": "Разделителната способност на субтитрите (0}x{1}) се различава от разделителната способност на видеото ({2}x{3}).\nДа се променят ли субтитрите, за да съответстват на видеото?",
+    "resolutionResamplerVideoDiffers": "Разделителната способност на субтитрите ({0}x{1}) се различава от разделителната способност на видеото ({2}x{3}).\nДа се променят ли субтитрите, за да съответстват на видеото?",
     "resolutionResamplerAskOnVideoOpen": "Попитай, когато се отвори видеоклип с различна резолюция",
     "backgroundBoxGenerator": "Генериране на фоново поле",
     "backgroundBoxFillWidth": "Ширина на запълване",


### PR DESCRIPTION
The CI test `LanguageFileFormatStringTests.EveryTranslation_FormatsWithoutThrowing` failed on `Bulgarian.json` after #14661: the `assa.resolutionResamplerVideoDiffers` string had `(0}x{1})` instead of `({0}x{1})`, so `string.Format` threw.

Restored the opening brace. Test passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)