### PR TITLE
align seconv PaddleOCR with GUI logic

### DIFF
--- a/src/seconv/Core/IOcrEngine.cs
+++ b/src/seconv/Core/IOcrEngine.cs
@@ -13,4 +13,19 @@ internal interface IOcrEngine : IDisposable
 
     /// <summary>Recognises a single subtitle bitmap.</summary>
     string Recognize(SKBitmap bitmap);
+
+    /// <summary>
+    /// Recognises multiple subtitle bitmaps. The default implementation calls
+    /// <see cref="Recognize(SKBitmap)"/> once per bitmap and reports completed images.
+    /// </summary>
+    IReadOnlyList<string> Recognize(IReadOnlyList<SKBitmap> bitmaps, Action<int>? progress = null)
+    {
+        var results = new List<string>(bitmaps.Count);
+        for (var i = 0; i < bitmaps.Count; i++)
+        {
+            results.Add(Recognize(bitmaps[i]));
+            progress?.Invoke(i + 1);
+        }
+        return results;
+    }
 }

--- a/src/seconv/Core/ImageOcrLoader.cs
+++ b/src/seconv/Core/ImageOcrLoader.cs
@@ -306,54 +306,75 @@ internal static class ImageOcrLoader
         // Time-codes-only mode is instant, so only a real OCR run reports progress (#14267).
         var showProgress = ocr is not null && !quiet;
         var done = 0;
-        foreach (var item in items)
+        if (ocr is null)
         {
-            // Reported before the image is recognised, so the count is images *finished*.
-            if (showProgress)
-            {
-                ProgressLine.Report("OCR", done, items.Count);
-            }
-
-            done++;
-
-            string text;
-            if (ocr is null)
-            {
-                text = string.Empty;
-            }
-            else if (isolateColors)
-            {
-                using var isolated = VobSubColorIsolation.Isolate(item.Bitmap);
-                text = ocr.Recognize(isolated);
-            }
-            else
-            {
-                text = ocr.Recognize(item.Bitmap);
-            }
-
-            if (ocr is null || !string.IsNullOrWhiteSpace(text))
+            foreach (var item in items)
             {
                 subtitle.Paragraphs.Add(new LibSeParagraph(
-                    text, item.StartTime.TotalMilliseconds, item.EndTime.TotalMilliseconds));
+                    string.Empty, item.StartTime.TotalMilliseconds, item.EndTime.TotalMilliseconds));
             }
-            else
+
+            subtitle.Renumber();
+            return subtitle;
+        }
+
+        var bitmaps = new List<SKBitmap>(items.Count);
+        var isolatedBitmaps = new List<SKBitmap>();
+        try
+        {
+            foreach (var item in items)
             {
-                blankCount++;
+                if (isolateColors)
+                {
+                    isolatedBitmaps.Add(VobSubColorIsolation.Isolate(item.Bitmap));
+                    bitmaps.Add(isolatedBitmaps[^1]);
+                }
+                else
+                {
+                    bitmaps.Add(item.Bitmap);
+                }
+            }
+
+            if (showProgress) { ProgressLine.Report("OCR", 0, items.Count); }
+
+            var texts = ocr.Recognize(bitmaps, done => {
+                if (showProgress) { ProgressLine.Report("OCR", done, items.Count); }
+            });
+
+            for (var i = 0; i < items.Count; i++)
+            {
+                var text = texts[i];
+
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    subtitle.Paragraphs.Add(new LibSeParagraph(
+                        text, items[i].StartTime.TotalMilliseconds, items[i].EndTime.TotalMilliseconds));
+                }
+                else
+                {
+                    blankCount++;
+                }
+            }
+
+            if (showProgress)
+            {
+                ProgressLine.Report("OCR", items.Count, items.Count);
+                ProgressLine.Finish();
+            }
+            if (blankCount > 0 && !quiet)
+            {
+                // Issue #12772: these used to vanish without a trace, making it look like the
+                // source had fewer subtitles than the GUI sees.
+                AnsiConsole.MarkupLine(
+                    $"[yellow]Note: {blankCount} image(s) produced no OCR text and were dropped.[/]");
             }
         }
-
-        if (showProgress)
+        finally
         {
-            ProgressLine.Report("OCR", items.Count, items.Count);
-            ProgressLine.Finish();
-        }
-
-        if (blankCount > 0 && !quiet)
-        {
-            // Issue #12772: these used to vanish without a trace, making it look like the
-            // source had fewer subtitles than the GUI sees.
-            AnsiConsole.MarkupLine(
-                $"[yellow]Note: {blankCount} image(s) produced no OCR text and were dropped.[/]");
+            foreach (var bitmap in isolatedBitmaps)
+            {
+                bitmap.Dispose();
+            }
         }
 
         subtitle.Renumber();
@@ -373,55 +394,70 @@ internal static class ImageOcrLoader
         // Time-codes-only mode is instant, so only a real OCR run reports progress (#14267).
         var showProgress = ocr is not null && !quiet;
         var done = 0;
+        if (ocr is null)
+        {
+            foreach (var pcs in pcsList)
+            {
+                var bitmap = pcs.GetBitmap();
+                if (bitmap is null) { continue; }
+                bitmap.Dispose();
+                subtitle.Paragraphs.Add(new LibSeParagraph(
+                    string.Empty, pcs.StartTime / 90.0, pcs.EndTime / 90.0));
+            }
+            subtitle.Renumber();
+            return subtitle;
+        }
+
+        var entries = new List<(BluRaySupParser.PcsData Pcs, SKBitmap Bitmap)>();
+        var bitmaps = new List<SKBitmap>();
 
         foreach (var pcs in pcsList)
         {
-            // Reported before the image is recognised, so the count is images *finished*.
-            if (showProgress)
-            {
-                ProgressLine.Report("OCR", done, pcsList.Count);
-            }
-
-            done++;
-
             var bitmap = pcs.GetBitmap();
-            if (bitmap is null)
+            if (bitmap is null) { continue; }
+            if (isolateColors)
             {
-                continue;
-            }
-            try
-            {
-                string text;
-                if (ocr is null)
-                {
-                    text = string.Empty;
-                }
-                else if (isolateColors)
-                {
-                    // PGS glyphs are white fill + black outline on transparency; binarise so
-                    // the fill survives the opaque white OCR canvas (issue #12291).
-                    using var isolated = VobSubColorIsolation.BinarizeForOcr(bitmap);
-                    text = ocr.Recognize(isolated);
-                }
-                else
-                {
-                    text = ocr.Recognize(bitmap);
-                }
-                if (ocr is null || !string.IsNullOrWhiteSpace(text))
-                {
-                    subtitle.Paragraphs.Add(new LibSeParagraph(text, pcs.StartTime / 90.0, pcs.EndTime / 90.0));
-                }
-            }
-            finally
-            {
+                var isolated = VobSubColorIsolation.BinarizeForOcr(bitmap);
                 bitmap.Dispose();
+                entries.Add((pcs, isolated));
+                bitmaps.Add(isolated);
+            }
+            else
+            {
+                entries.Add((pcs, bitmap));
+                bitmaps.Add(bitmap);
             }
         }
 
-        if (showProgress)
+        try
         {
-            ProgressLine.Report("OCR", pcsList.Count, pcsList.Count);
-            ProgressLine.Finish();
+            if (showProgress) { ProgressLine.Report("OCR", 0, bitmaps.Count); }
+
+            var texts = ocr.Recognize(bitmaps, done => {
+                if (showProgress) { ProgressLine.Report("OCR", done, bitmaps.Count); }
+            });
+
+            for (var i = 0; i < entries.Count; i++)
+            {
+                var text = texts[i];
+
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    var pcs = entries[i].Pcs;
+                    subtitle.Paragraphs.Add(new LibSeParagraph(
+                        text, pcs.StartTime / 90.0, pcs.EndTime / 90.0));
+                }
+            }
+
+            if (showProgress)
+            {
+                ProgressLine.Report("OCR", bitmaps.Count, bitmaps.Count);
+                ProgressLine.Finish();
+            }
+        }
+        finally
+        {
+            foreach (var bitmap in bitmaps) { bitmap.Dispose(); }
         }
 
         subtitle.Renumber();

--- a/src/seconv/Core/PaddleOcrEngine.cs
+++ b/src/seconv/Core/PaddleOcrEngine.cs
@@ -1,14 +1,13 @@
 using System.Diagnostics;
 using System.Text;
-using Nikse.SubtitleEdit.Core.Common;
+using System.Text.Json;
 using SkiaSharp;
 
 namespace SeConv.Core;
 
 /// <summary>
-/// OCR via the PaddleOCR command-line tool. Prefers the standalone install the GUI downloads
-/// (SE data folder, OCR/PaddleOCR3-7, with its bundled models), then a <c>paddleocr</c> from
-/// <c>pip install paddleocr</c> on the system PATH.
+/// OCR via the PaddleOCR command-line tool on the system PATH. Supports the standalone
+/// binary (<c>paddleocr</c> / <c>paddleocr.exe</c>) installed via <c>pip install paddleocr</c>.
 /// Limited subset compared to SE's UI implementation; assumes a single image per invocation.
 /// </summary>
 internal sealed class PaddleOcrEngine : IOcrEngine
@@ -27,47 +26,7 @@ internal sealed class PaddleOcrEngine : IOcrEngine
         _workDir = workDir;
     }
 
-    /// <summary>
-    /// Folder name of the GUI's standalone PaddleOCR install, under the SE "OCR" data folder.
-    /// Keep in sync with <c>Se.PaddleOcrFolder</c> in the UI project.
-    /// </summary>
-    private const string StandaloneFolderName = "PaddleOCR3-7";
-
-    /// <summary>
-    /// Locates PaddleOCR. The GUI's standalone install is preferred (portable SE first, then
-    /// the installed GUI's data folder), so seconv reuses the engine and models the user
-    /// already downloaded; then falls back to a <c>paddleocr</c> on the system PATH.
-    /// Returns null if missing.
-    /// </summary>
     public static string? Detect()
-    {
-        return DetectStandalone() ?? DetectOnPath();
-    }
-
-    internal static string? DetectStandalone()
-    {
-        var candidates = new[]
-        {
-            Path.Combine(AppContext.BaseDirectory, "OCR", StandaloneFolderName),
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit", "OCR", StandaloneFolderName),
-        };
-
-        foreach (var folder in candidates)
-        {
-            foreach (var name in new[] { "paddleocr.exe", "paddleocr.bin" })
-            {
-                var candidate = Path.Combine(folder, name);
-                if (File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private static string? DetectOnPath()
     {
         var name = OperatingSystem.IsWindows() ? "paddleocr.exe" : "paddleocr";
         var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
@@ -83,28 +42,12 @@ internal sealed class PaddleOcrEngine : IOcrEngine
         return null;
     }
 
-    /// <summary>
-    /// The standalone install ships its models in a "models" folder next to the binary
-    /// (cls/det/rec sub-folders). When present, they are passed explicitly like the GUI does.
-    /// </summary>
-    internal static string? GetModelsFolder(string executablePath)
-    {
-        var folder = Path.GetDirectoryName(executablePath);
-        if (folder == null)
-        {
-            return null;
-        }
-
-        var models = Path.Combine(folder, "models");
-        return Directory.Exists(Path.Combine(models, "rec")) ? models : null;
-    }
-
     public static PaddleOcrEngine Create(string language = "en")
     {
         var path = Detect()
             ?? throw new InvalidOperationException(
-                "PaddleOCR not found. Download it via Subtitle Edit (OCR > PaddleOCR), or install it " +
-                "(e.g. `pip install paddleocr`) and ensure the `paddleocr` binary is on PATH.");
+                "PaddleOCR not found on PATH. Install it (e.g. `pip install paddleocr`) " +
+                "and ensure the `paddleocr` binary is on PATH.");
 
         var workDir = Path.Combine(Path.GetTempPath(), "seconv_paddle_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(workDir);
@@ -119,106 +62,267 @@ internal sealed class PaddleOcrEngine : IOcrEngine
         }
 
         var pngPath = Path.Combine(_workDir, "in_" + Guid.NewGuid().ToString("N") + ".png");
+        var resultDir = Path.Combine(_workDir, "result_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(resultDir);
         try
         {
-            using (var image = SKImage.FromBitmap(bitmap))
+            using var borderedBitmap = CreateDoubleBorder(bitmap, 10, SKColors.Black, new SKColor(0, 0, 0, 0));
+            using (var image = SKImage.FromBitmap(borderedBitmap))
             using (var data = image.Encode(SKEncodedImageFormat.Png, 90))
             using (var fs = File.Create(pngPath))
             {
                 data.SaveTo(fs);
             }
 
-            var psi = new ProcessStartInfo(ExecutablePath)
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                StandardOutputEncoding = System.Text.Encoding.UTF8,
-                StandardErrorEncoding = System.Text.Encoding.UTF8,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                // The tool may write relative to its current directory; make sure that is writable.
-                WorkingDirectory = _workDir,
-            };
-            foreach (var arg in BuildArguments(pngPath))
-            {
-                psi.ArgumentList.Add(arg);
-            }
-
-            // StandardOutputEncoding only fixes the decoding side. paddleocr is a Python CLI, and
-            // on Windows Python encodes a *redirected* stdout with the ANSI codepage (until UTF-8
-            // becomes the default in Python 3.15, PEP 686) - so the producer side must be forced
-            // to UTF-8 too, or non-ASCII text still arrives as mojibake. Same env vars the UI's
-            // Paddle engine sets.
-            psi.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
-            psi.EnvironmentVariables["PYTHONUTF8"] = "1";
-            // Skip PaddleX's online model-source connectivity check - it can hang the run at
-            // "Initializing..." when offline, and with explicit local model dirs it is pointless.
-            psi.EnvironmentVariables["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True";
+            var psi = CreateProcessStartInfo(pngPath, resultDir);
 
             using var proc = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start paddleocr process.");
             // Drain stderr concurrently — paddleocr is chatty on stderr, and reading stdout
             // to completion while stderr fills the pipe buffer would deadlock.
             var stderrTask = proc.StandardError.ReadToEndAsync();
-            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
-            // Never wait forever: a wedged run (missing model, stuck initialisation, a worker
-            // process that never returns) used to hang seconv with no output at all.
-            if (!proc.WaitForExit(ProcessTimeout))
-            {
-                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
-                throw new InvalidOperationException(
-                    $"paddleocr did not finish within {ProcessTimeout.TotalMinutes:0} minutes and was killed.");
-            }
-            proc.WaitForExit(); // flush the redirected streams
-            var stdout = stdoutTask.GetAwaiter().GetResult();
+            var stdout = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
             if (proc.ExitCode != 0)
             {
                 var err = stderrTask.GetAwaiter().GetResult();
                 throw new InvalidOperationException($"paddleocr exited with code {proc.ExitCode}: {err}");
             }
-            return ParseStdout(stdout);
+            var resultPath = Path.Combine(resultDir, Path.GetFileNameWithoutExtension(pngPath) + "_res.json");
+            if (!File.Exists(resultPath)) { return string.Empty; }
+            return ParseJsonResult(File.ReadAllText(resultPath));
         }
         finally
         {
             try { File.Delete(pngPath); } catch { /* best-effort */ }
+            try { if (Directory.Exists(resultDir)) { Directory.Delete(resultDir, recursive: true); } }
+            catch { /* best-effort */ }
         }
     }
 
-    /// <summary>Upper bound for one paddleocr run (model load + one image).</summary>
-    internal static readonly TimeSpan ProcessTimeout = TimeSpan.FromMinutes(10);
-
-    /// <summary>
-    /// Command line for one image. The standalone install gets the GUI's full argument set
-    /// with explicit model folders (it has no model download of its own); a PATH install
-    /// keeps the plain invocation and lets paddleocr resolve models itself.
-    /// </summary>
-    internal List<string> BuildArguments(string imagePath)
+    public IReadOnlyList<string> Recognize(IReadOnlyList<SKBitmap> bitmaps, Action<int>? progress = null)
     {
-        var args = new List<string> { "ocr", "-i", imagePath, "--lang", Language };
+        if (bitmaps.Count == 0) { return Array.Empty<string>(); }
 
-        var modelsFolder = GetModelsFolder(ExecutablePath);
-        if (modelsFolder == null)
+        var inputDir = Path.Combine(_workDir, "batch_" + Guid.NewGuid().ToString("N"));
+        var resultDir = Path.Combine(_workDir, "results_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(inputDir);
+        Directory.CreateDirectory(resultDir);
+
+        try
         {
-            args.AddRange(new[] { "--use_angle_cls", "false" });
-            return args;
+            for (var i = 0; i < bitmaps.Count; i++)
+            {
+                var pngPath = Path.Combine(inputDir, $"{i:D4}.png");
+                using var borderedBitmap = CreateDoubleBorder(bitmaps[i], 10, SKColors.Black, new SKColor(0, 0, 0, 0));
+                using var image = SKImage.FromBitmap(borderedBitmap);
+                using var data = image.Encode(SKEncodedImageFormat.Png, 90);
+                using var fs = File.Create(pngPath);
+                data.SaveTo(fs);
+            }
+
+            var psi = CreateProcessStartInfo(inputDir, resultDir);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start paddleocr process.");
+
+            var stderrTask = proc.StandardError.ReadToEndAsync();
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            var results = new string[bitmaps.Count];
+            var reported = new bool[bitmaps.Count];
+            var done = 0;
+
+            while (!proc.HasExited || done < bitmaps.Count)
+            {
+                for (var i = 0; i < bitmaps.Count; i++)
+                {
+                    if (reported[i]) { continue; }
+                    var jsonPath = Path.Combine(resultDir, $"{i:D4}_res.json");
+                    if (!TryReadJson(jsonPath, out _)) { continue; }
+                    reported[i] = true;
+                    done++;
+                    progress?.Invoke(done);
+                }
+
+                if (proc.HasExited)
+                {
+                    if (done >= bitmaps.Count) { break; }
+                    Thread.Sleep(100);
+                }
+                else
+                {
+                    Thread.Sleep(400);
+                }
+            }
+
+            proc.WaitForExit();
+            _ = stdoutTask.GetAwaiter().GetResult();
+
+            var stderr = stderrTask.GetAwaiter().GetResult();
+            if (proc.ExitCode != 0 && done == 0)
+            {
+                throw new InvalidOperationException($"paddleocr exited with code {proc.ExitCode}: {stderr}");
+            }
+
+            for (var i = 0; i < bitmaps.Count; i++)
+            {
+                var jsonPath = Path.Combine(resultDir, $"{i:D4}_res.json");
+                if (TryReadJson(jsonPath, out var json))
+                {
+                    results[i] = ParseJsonResult(json);
+                }
+                else
+                {
+                    results[i] = string.Empty;
+                }
+            }
+
+            return results;
         }
-
-        // "server" = the PP-OCRv6 medium tier, the more accurate of the two bundled sizes.
-        var detName = PaddleOcrModels.GetDetectionName(Language, "server");
-        var recName = PaddleOcrModels.GetRecName(Language, "server");
-        args.AddRange(new[]
+        finally
         {
-            "--use_textline_orientation", "true",
-            "--use_doc_orientation_classify", "false",
-            "--use_doc_unwarping", "false",
-            "--text_detection_model_dir", Path.Combine(modelsFolder, "det", detName),
-            "--text_detection_model_name", detName,
-            "--text_recognition_model_dir", Path.Combine(modelsFolder, "rec", recName),
-            "--text_recognition_model_name", recName,
-            "--textline_orientation_model_dir", Path.Combine(modelsFolder, "cls", PaddleOcrModels.TextlineOrientationModelName),
-            "--textline_orientation_model_name", PaddleOcrModels.TextlineOrientationModelName,
-        });
-        return args;
+            try
+            {
+                if (Directory.Exists(inputDir)) { Directory.Delete(inputDir, recursive: true); }
+            }
+            catch { /* best-effort */ }
+            try
+            {
+                if (Directory.Exists(resultDir)) { Directory.Delete(resultDir, recursive: true); }
+            }
+            catch { /* best-effort */ }
+        }
+    }
+
+    private ProcessStartInfo CreateProcessStartInfo(string inputPath, string resultDir)
+    {
+        var paddleOcrDir = Path.GetDirectoryName(ExecutablePath)
+            ?? throw new InvalidOperationException("Unable to determine PaddleOCR directory.");
+
+        var modelsDir = Path.Combine(paddleOcrDir, "models");
+        var clsDir = Path.Combine(modelsDir, "cls");
+        var detDir = Path.Combine(modelsDir, "det");
+        var recDir = Path.Combine(modelsDir, "rec");
+
+        const string detectionModel = "PP-OCRv6_medium_det";
+        const string recognitionModel = "PP-OCRv6_medium_rec";
+        const string textlineOrientationModel = "PP-LCNet_x1_0_textline_ori";
+
+        var psi = new ProcessStartInfo(ExecutablePath)
+        {
+            ArgumentList = {
+                "ocr",
+                "-i",
+                inputPath,
+                "--use_textline_orientation",
+                "true",
+                "--use_doc_orientation_classify",
+                "false",
+                "--use_doc_unwarping",
+                "false",
+                "--lang",
+                Language,
+                "--text_detection_model_dir",
+                Path.Combine(detDir, detectionModel),
+                "--text_detection_model_name",
+                detectionModel,
+                "--text_recognition_model_dir",
+                Path.Combine(recDir, recognitionModel),
+                "--text_recognition_model_name",
+                recognitionModel,
+                "--textline_orientation_model_dir",
+                Path.Combine(clsDir, textlineOrientationModel),
+                "--textline_orientation_model_name",
+                textlineOrientationModel,
+                "--save_path",
+                resultDir
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        psi.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
+        psi.EnvironmentVariables["PYTHONUTF8"] = "1";
+        psi.EnvironmentVariables["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True";
+
+        return psi;
+    }
+
+    private static bool TryReadJson(string path, out string json)
+    {
+        json = string.Empty;
+
+        if (!File.Exists(path)) { return false; }
+
+        try
+        {
+            json = File.ReadAllText(path);
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.ValueKind == JsonValueKind.Object;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string ParseJsonResult(string json)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+
+            if (!root.TryGetProperty("rec_texts", out var texts) ||
+                texts.ValueKind != JsonValueKind.Array)
+            {
+                return string.Empty;
+            }
+
+            root.TryGetProperty("rec_polys", out var polys);
+
+            var results = new List<(string Text, double Y, double X)>();
+
+            for (var i = 0; i < texts.GetArrayLength(); i++)
+            {
+                var text = texts[i].GetString() ?? string.Empty;
+                var x = 0.0;
+                var y = 0.0;
+
+                if (polys.ValueKind == JsonValueKind.Array &&
+                    i < polys.GetArrayLength() &&
+                    polys[i].ValueKind == JsonValueKind.Array &&
+                    polys[i].GetArrayLength() >= 4)
+                {
+                    var poly = polys[i];
+                    x = poly[0][0].GetDouble();
+                    y = poly[0][1].GetDouble();
+
+                    for (var p = 1; p < poly.GetArrayLength(); p++)
+                    {
+                        x = Math.Min(x, poly[p][0].GetDouble());
+                        y = Math.Min(y, poly[p][1].GetDouble());
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(text)) { results.Add((text, y, x)); }
+            }
+
+            results.Sort((a, b) => {
+                if (Math.Abs(a.Y - b.Y) < 10) { return a.X.CompareTo(b.X); }
+                return a.Y.CompareTo(b.Y);
+            });
+
+            return string.Join(Environment.NewLine, results.Select(r => r.Text)).Trim();
+        }
+        catch
+        {
+            return string.Empty;
+        }
     }
 
     /// <summary>
@@ -251,6 +355,34 @@ internal sealed class PaddleOcrEngine : IOcrEngine
             sb.Append(text);
         }
         return sb.ToString().Trim();
+    }
+
+    private static SKBitmap CreateDoubleBorder(
+        SKBitmap source,
+        int borderSize,
+        SKColor innerColor,
+        SKColor outerColor)
+    {
+        var totalBorder = borderSize * 2;
+        var finalWidth = source.Width + totalBorder * 2;
+        var finalHeight = source.Height + totalBorder * 2;
+
+        var result = new SKBitmap(finalWidth, finalHeight);
+        using var canvas = new SKCanvas(result);
+
+        canvas.Clear(outerColor);
+
+        using var paint = new SKPaint { Color = innerColor };
+        canvas.DrawRect(
+            borderSize,
+            borderSize,
+            finalWidth - borderSize * 2,
+            finalHeight - borderSize * 2,
+            paint);
+
+        canvas.DrawBitmap(source, totalBorder, totalBorder);
+
+        return result;
     }
 
     public void Dispose()


### PR DESCRIPTION
Use the same models and OCR options as the GUI
Apply the GUI's double-border preprocessing
Read recognition results from the generated JSON instead of stdout
Report OCR progress during batch processing
Handle UTF-8 output correctly on Windows