### PR TITLE
Fix Blu-ray sup save from the binary editor dropping the first line and duplicating the last

### DIFF
--- a/src/libuilogic/Export/ExportHandlerBluRaySup.cs
+++ b/src/libuilogic/Export/ExportHandlerBluRaySup.cs
@@ -24,12 +24,21 @@ public class ExportHandlerBluRaySup : IExportHandler
     private readonly ConcurrentDictionary<ImageParameter, BluRaySupPicture> _pictures = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
+    /// What <see cref="WriteParagraph"/> keeps of a subtitle until it is written. A copy, not
+    /// the caller's <see cref="ImageParameter"/>: the binary edit window reuses one parameter
+    /// object for every line, so by the time a deferred line was written its buffer and times
+    /// had been overwritten with the next line's - the first line vanished and the last was
+    /// written twice (issue #14666).
+    /// </summary>
+    private sealed record PendingCue(byte[] Buffer, BluRaySupPicture Picture, SKColor FontColor, bool IsForced, double FramesPerSecond);
+
+    /// <summary>
     /// Subtitles waiting to be written because they overlap in time. A Blu-ray shows one
     /// display set at a time, so overlapping subtitles have to go into the same display sets
     /// to be seen together (issue #14456) - the group is written when the next subtitle does
     /// not overlap it, or at the end.
     /// </summary>
-    private readonly List<ImageParameter> _pending = [];
+    private readonly List<PendingCue> _pending = [];
     private long _pendingStartMs;
     private long _pendingEndMs;
 
@@ -49,7 +58,9 @@ public class ExportHandlerBluRaySup : IExportHandler
 
     public void WriteParagraph(ImageParameter param)
     {
-        if (!_pictures.TryGetValue(param, out var picture))
+        // Remove rather than look up: the same parameter object may come back with the next
+        // line, and a later ready-made buffer on it must not be taken for this picture.
+        if (!_pictures.TryRemove(param, out var picture))
         {
             FlushPending();
             _fileStream!.Write(param.Buffer, 0, param.Buffer.Length);
@@ -73,7 +84,7 @@ public class ExportHandlerBluRaySup : IExportHandler
             _pendingEndMs = Math.Max(_pendingEndMs, picture.EndTime);
         }
 
-        _pending.Add(param);
+        _pending.Add(new PendingCue(param.Buffer, picture, param.FontColor, param.IsForced, param.FramesPerSecond));
     }
 
     public void WriteFooter()
@@ -170,9 +181,9 @@ public class ExportHandlerBluRaySup : IExportHandler
     /// same time. Only the last slice clears the screen; before that, the next epoch start
     /// replaces the previous one.
     /// </summary>
-    private void WriteOverlapping(List<ImageParameter> cues)
+    private void WriteOverlapping(List<PendingCue> cues)
     {
-        var pictures = cues.Select(c => _pictures[c]).ToList();
+        var pictures = cues.Select(c => c.Picture).ToList();
         var times = pictures.SelectMany(p => new[] { p.StartTime, p.EndTime }).Distinct().OrderBy(t => t).ToList();
         var compositionNumber = pictures[0].CompositionNumber;
         var fps = cues[0].FramesPerSecond;
@@ -243,7 +254,7 @@ public class ExportHandlerBluRaySup : IExportHandler
         }
     }
 
-    private static PlacedCaption Place(ImageParameter cue, BluRaySupPicture picture)
+    private static PlacedCaption Place(PendingCue cue, BluRaySupPicture picture)
     {
         // Not the cue's bitmap: callers may dispose that right after WriteParagraph (seconv
         // and the container track exports do), and the full frame image was let go as soon as

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1267,7 +1267,10 @@ public partial class BinaryEditViewModel : ObservableObject
 
     private void WriteExport(IExportHandler exportHandler, string fileOrFolderName)
     {
-        var imageParameter = new ImageParameter()
+        // One parameter object per line, like every other export caller: the Blu-ray sup
+        // handler holds a line back while the next may still overlap it, so a shared object
+        // mutated per line lost the first line and wrote the last twice (issue #14666).
+        ImageParameter MakeImageParameter() => new()
         {
             ScreenWidth = ScreenWidth,
             ScreenHeight = ScreenHeight,
@@ -1283,12 +1286,13 @@ public partial class BinaryEditViewModel : ObservableObject
             FramesPerSecond = Configuration.Settings.General.CurrentFrameRate,
         };
 
-        exportHandler.WriteHeader(fileOrFolderName, imageParameter);
+        exportHandler.WriteHeader(fileOrFolderName, MakeImageParameter());
         for (var i = 0; i < Subtitles.Count; i++)
         {
             // ToSkBitmap allocates a new SKBitmap each call; dispose it per iteration so the
             // export of a large file doesn't accumulate one undisposed native bitmap per line.
             using var skBitmap = Subtitles[i].Bitmap!.ToSkBitmap();
+            var imageParameter = MakeImageParameter();
             imageParameter.Bitmap = skBitmap;
             imageParameter.Text = Subtitles[i].Text;
             imageParameter.StartTime = Subtitles[i].StartTime;

--- a/tests/libuilogic/Export/ExportHandlerBluRaySupOverlapTests.cs
+++ b/tests/libuilogic/Export/ExportHandlerBluRaySupOverlapTests.cs
@@ -324,6 +324,45 @@ public class ExportHandlerBluRaySupOverlapTests : IDisposable
     }
 
     [Fact]
+    public void OneParameterObjectReusedForEveryLine_WritesEveryLineOnce()
+    {
+        // The binary edit window mutates a single ImageParameter per line. With the pending
+        // group holding that object, every deferred write read the *next* line's buffer: the
+        // first line vanished and the last was written twice (issue #14666).
+        var fileName = Path.Combine(_dir, "reused.sup");
+        var handler = new ExportHandlerBluRaySup();
+        var parameter = Cue(0, 1, 2, ExportAlignment.BottomCenter, SKColors.White);
+        handler.WriteHeader(fileName, parameter);
+        for (var i = 0; i < 3; i++)
+        {
+            using var bitmap = new SKBitmap(CueWidth, CueHeight + i * 10);
+            using (var canvas = new SKCanvas(bitmap))
+            {
+                canvas.Clear(SKColors.White);
+            }
+
+            parameter.Bitmap = bitmap;
+            parameter.Index = i;
+            parameter.StartTime = TimeSpan.FromSeconds(1 + i * 2);
+            parameter.EndTime = TimeSpan.FromSeconds(2 + i * 2);
+            handler.CreateParagraph(parameter);
+            handler.WriteParagraph(parameter);
+        }
+
+        handler.WriteFooter();
+
+        var subtitles = BluRaySupParser.ParseBluRaySup(fileName, new StringBuilder());
+        Assert.Equal(3, subtitles.Count);
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal((1 + i * 2) * 1000, subtitles[i].StartTimeCode.TotalMilliseconds, 1);
+            Assert.Equal((2 + i * 2) * 1000, subtitles[i].EndTimeCode.TotalMilliseconds, 1);
+            using var bitmap = subtitles[i].GetBitmap();
+            Assert.Equal(CueHeight + i * 10, bitmap.Height);
+        }
+    }
+
+    [Fact]
     public void ReadyMadeBuffers_AreWrittenAsTheyAre()
     {
         // A cue that never went through CreateParagraph (a track copied out of a container)


### PR DESCRIPTION
Fixes #14666

## Problem

Saving a Blu-ray `.sup` from the binary edit window produced a file with the first line missing and the last line written twice with identical, overlapping timings. Importing time codes was incidental; any save from that window was affected.

## Cause

`BinaryEditViewModel.WriteExport` mutates a single `ImageParameter` for every line. Since the overlap grouping for #14456 (`76b40ac6ad`, shipped in v5.2.0-rc1+), `ExportHandlerBluRaySup.WriteParagraph` defers each line until the next one proves not to overlap it, and it kept a reference to the caller's parameter object. By the time a deferred line was flushed, `CreateParagraph` had already overwritten `Buffer` and the times with the next line's, so every flush emitted the following line and the footer flush emitted the last line a second time.

Other callers (export images dialog, batch convert, seconv, MKV/MP4 track pickers) create a fresh parameter per line and were not affected.

## Fix

- `ExportHandlerBluRaySup` now snapshots what it needs (buffer, picture, font colour, forced flag, frame rate) into its own record at `WriteParagraph`, and removes the picture entry so a reused object cannot be mistaken for a ready-made buffer later.
- `BinaryEditViewModel.WriteExport` builds a fresh `ImageParameter` per line, matching every other export caller.
- New regression test `OneParameterObjectReusedForEveryLine_WritesEveryLineOnce` (fails on the old handler, passes now). All 19 Blu-ray sup handler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
