### PR TITLE
Fix grid paste overlapping the selected line in time (#14667)

### DIFF
--- a/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
+++ b/src/ui/Logic/SubtitleGridCopyPasteHelper.cs
@@ -109,6 +109,7 @@ internal static class SubtitleGridCopyPasteHelper
             if (item.IsMine(lines, string.Empty))
             {
                 item.LoadSubtitle(subtitle, lines, string.Empty);
+                subtitle.OriginalFormat = item;
                 return subtitle;
             }
         }
@@ -145,6 +146,7 @@ internal static class SubtitleGridCopyPasteHelper
         var clipboardSubtitle = ParseClipboardSubtitle(text, subtitleFormat);
         if (clipboardSubtitle != null)
         {
+            ShiftToAvoidOverlap(subtitles, index, subtitleFormat, clipboardSubtitle);
             return LoadParagraphs(subtitles, index, subtitleFormat, clipboardSubtitle);
         }
 
@@ -169,6 +171,48 @@ internal static class SubtitleGridCopyPasteHelper
         }
 
         return insertedLines;
+    }
+
+    /// <summary>
+    /// Moves the pasted block in time so it does not overlap the line it is pasted below, the way
+    /// SE4's Ctrl+V did: copying a line and pasting it must produce a line that starts after the
+    /// selected one, not a duplicate on top of it (#14667). The whole block is shifted by one delta
+    /// computed from its first paragraph, so the spacing inside the block is kept - and only when
+    /// it would actually overlap; time codes that already fit are left alone, so pasting lines
+    /// that were copied from elsewhere in the same file keeps their timing.
+    /// ASSA into an ASSA file is the exception, also from SE4: events are pasted as-is.
+    /// </summary>
+    private static void ShiftToAvoidOverlap(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, Subtitle clipboardSubtitle)
+    {
+        if (clipboardSubtitle.Paragraphs.Count == 0 || index <= 0 || index > subtitles.Count)
+        {
+            return;
+        }
+
+        // The clipboard payload is bare Dialogue lines (no header, #10476), which parse as plain
+        // SSA rather than ASSA - so the whole SSA family counts here.
+        if (subtitleFormat is AdvancedSubStationAlpha or SubStationAlpha &&
+            clipboardSubtitle.OriginalFormat is AdvancedSubStationAlpha or SubStationAlpha)
+        {
+            return;
+        }
+
+        var previous = subtitles[index - 1];
+        var next = index < subtitles.Count ? subtitles[index] : null;
+        var pastedStart = clipboardSubtitle.Paragraphs[0].StartTime.TotalMilliseconds;
+        var overlapsPrevious = previous.EndTime.TotalMilliseconds > pastedStart;
+        var overlapsNext = next != null && next.StartTime.TotalMilliseconds < pastedStart;
+        if (!overlapsPrevious && !overlapsNext)
+        {
+            return;
+        }
+
+        var addMs = previous.EndTime.TotalMilliseconds - pastedStart + Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        foreach (var p in clipboardSubtitle.Paragraphs)
+        {
+            p.StartTime.TotalMilliseconds += addMs;
+            p.EndTime.TotalMilliseconds += addMs;
+        }
     }
 
     private static List<SubtitleLineViewModel> LoadParagraphs(ObservableCollection<SubtitleLineViewModel> subtitles, int index, SubtitleFormat subtitleFormat, Subtitle subtitle)

--- a/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
+++ b/tests/UI/Logic/SubtitleGridCopyPasteHelperTests.cs
@@ -2,6 +2,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -194,6 +195,109 @@ public class SubtitleGridCopyPasteHelperTests
         Assert.Empty(SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, string.Empty));
         Assert.Empty(SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, null));
         Assert.Single(subtitles);
+    }
+
+    [Fact]
+    public void PasteText_ShiftsCopiedLineBelowSelectedLine_InsteadOfOverlapping()
+    {
+        // #14667: Ctrl+C / Ctrl+V on a line must not paste a duplicate on top of it in time.
+        var format = new SubRip();
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("One", 1000, 2000), format),
+            new(new Paragraph("Two", 3000, 4000), format),
+        };
+
+        var clipboard = format.ToText(BuildSubtitle(("One", 1000, 2000)), string.Empty);
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, clipboard);
+
+        Assert.Single(inserted);
+        Assert.Same(subtitles[1], inserted[0]);
+        Assert.Equal(2000 + gap, inserted[0].StartTime.TotalMilliseconds);
+        Assert.Equal(3000 + gap, inserted[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteText_ShiftsWholeBlockByOneDelta_KeepingSpacingInsideBlock()
+    {
+        // An SRT block pasted from a text editor lands after the selected line as one unit (#14667).
+        var format = new SubRip();
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("Last", 100000, 105000), format),
+        };
+
+        var clipboard = format.ToText(BuildSubtitle(("Credit one", 1000, 6000), ("Credit two", 6300, 11300)), string.Empty);
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, clipboard);
+
+        Assert.Equal(2, inserted.Count);
+        var delta = 105000 - 1000 + gap;
+        Assert.Equal(1000 + delta, inserted[0].StartTime.TotalMilliseconds);
+        Assert.Equal(6000 + delta, inserted[0].EndTime.TotalMilliseconds);
+        Assert.Equal(6300 + delta, inserted[1].StartTime.TotalMilliseconds);
+        Assert.Equal(11300 + delta, inserted[1].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteText_KeepsTimeCodes_WhenPastedLinesDoNotOverlap()
+    {
+        var format = new SubRip();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("One", 1000, 2000), format),
+            new(new Paragraph("Two", 9000, 10000), format),
+        };
+
+        var clipboard = format.ToText(BuildSubtitle(("Fits", 4000, 5000)), string.Empty);
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, clipboard);
+
+        Assert.Single(inserted);
+        Assert.Equal(4000, inserted[0].StartTime.TotalMilliseconds);
+        Assert.Equal(5000, inserted[0].EndTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteText_ShiftsPastedLine_WhenItStartsAfterNextLine()
+    {
+        var format = new SubRip();
+        var gap = Se.Settings.General.MinimumBetweenLines.GetMilliseconds();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("One", 1000, 2000), format),
+            new(new Paragraph("Two", 3000, 4000), format),
+        };
+
+        // Starts after "One" ends, but also after "Two" starts, so it would land out of time
+        // order between them - SE4 moved this right after "One" too.
+        var clipboard = format.ToText(BuildSubtitle(("Late", 3500, 4500)), string.Empty);
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, clipboard);
+
+        Assert.Single(inserted);
+        Assert.Equal(2000 + gap, inserted[0].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void PasteText_KeepsTimeCodes_ForAssaIntoAssa()
+    {
+        var format = new AdvancedSubStationAlpha();
+        var subtitles = new ObservableCollection<SubtitleLineViewModel>
+        {
+            new(new Paragraph("One", 1000, 2000), format),
+        };
+
+        var clipboard = SubtitleGridCopyPasteHelper.GetClipboardText(format, BuildSubtitle(("One", 1000, 2000)));
+
+        var inserted = SubtitleGridCopyPasteHelper.PasteText(subtitles, 0, format, clipboard);
+
+        Assert.Single(inserted);
+        Assert.Equal(1000, inserted[0].StartTime.TotalMilliseconds);
+        Assert.Equal(2000, inserted[0].EndTime.TotalMilliseconds);
     }
 
     private static Subtitle BuildSubtitle(params (string Text, int Start, int End)[] paragraphs)


### PR DESCRIPTION
Fixes #14667

## Problem
Copying a line and pressing Ctrl+V / Cmd+V pasted it with identical start and end times, so the new line sat on top of the original. Same for an SRT block pasted from a text editor: it kept its absolute time codes instead of landing after the selected line.

`SubtitleGridCopyPasteHelper.PasteText` already computed the time offset, but only the plain-text fallback used it. Subtitle-format clipboards went through `LoadParagraphs` untouched.

## Fix
Port SE4's Ctrl+V rule to `PasteText`:
- If the pasted block's first line would overlap the selected line, or would start after the next line starts, shift the whole block by one delta so it begins at the selected line's end plus the minimum gap. Spacing inside the block is preserved.
- Time codes that already fit are left alone, so lines copied from elsewhere in the same file keep their timing.
- ASSA/SSA into an ASSA/SSA file is pasted as-is, as in SE4. SE5's clipboard payload is bare `Dialogue:` lines, which parse as plain SSA, so the whole SSA family is treated as one here.

Also sets `OriginalFormat` in the fallback branch of `ParseClipboardSubtitle` so the format check above has something to look at.

## Tests
Five new cases in `SubtitleGridCopyPasteHelperTests`: copied line lands after the original, block keeps its internal spacing, non-overlapping time codes are kept, out-of-order paste is shifted, ASSA into ASSA is unchanged. All 17 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
