### PR TITLE
Bind display-only properties OneWay in the UI helpers

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedPreviewWindow.cs
@@ -20,7 +20,7 @@ public class ImageBasedPreviewWindow : Window
 
         var image = new Image
         {
-            [!Image.SourceProperty] = new Binding(nameof(vm.BitmapPreview)) { Mode = BindingMode.TwoWay },
+            [!Image.SourceProperty] = new Binding(nameof(vm.BitmapPreview)) { Mode = BindingMode.OneWay },
         };
         vm.ImagePreview = image;
 

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedProfileWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedProfileWindow.cs
@@ -69,7 +69,7 @@ public class ImageBasedProfileWindow : Window
                             CommandParameter = profile,
                             DataContext = vm,
                         };
-                        deleteButton.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.IsProfileDeleteEnabled)) { Mode = BindingMode.TwoWay });
+                        deleteButton.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.IsProfileDeleteEnabled)) { Mode = BindingMode.OneWay });
                         Attached.SetIcon(deleteButton, "fa-solid fa-trash");
                         Grid.SetColumn(deleteButton, 1);
                         grid.Children.Add(deleteButton);

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -767,7 +767,7 @@ public static partial class InitListViewAndEditBox
             Header = Se.Language.General.Styles,
             DataContext = vm,
         };
-        assaStylesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreAssaContentMenuItemsVisible)) { Mode = BindingMode.TwoWay });
+        assaStylesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreAssaContentMenuItemsVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(assaStylesMenuItem);
         vm.MenuItemStyles = assaStylesMenuItem;
 
@@ -776,7 +776,7 @@ public static partial class InitListViewAndEditBox
             Header = Se.Language.General.Actors,
             DataContext = vm,
         };
-        assaActorsMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreAssaContentMenuItemsVisible)) { Mode = BindingMode.TwoWay });
+        assaActorsMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreAssaContentMenuItemsVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(assaActorsMenuItem);
         vm.MenuItemActors = assaActorsMenuItem;
 
@@ -791,7 +791,7 @@ public static partial class InitListViewAndEditBox
             DataContext = vm,
             Command = vm.SetWebVttStylesForSelectedLinesCommand,
         };
-        webVttStylesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)) { Mode = BindingMode.TwoWay });
+        webVttStylesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(webVttStylesMenuItem);
 
         var webVttVoicesMenuItem = new MenuItem
@@ -799,7 +799,7 @@ public static partial class InitListViewAndEditBox
             Header = Se.Language.File.WebVtt.Voices,
             DataContext = vm,
         };
-        webVttVoicesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)) { Mode = BindingMode.TwoWay });
+        webVttVoicesMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.AreWebVttContentMenuItemsVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(webVttVoicesMenuItem);
         vm.MenuItemWebVttVoices = webVttVoicesMenuItem;
 
@@ -809,7 +809,7 @@ public static partial class InitListViewAndEditBox
             DataContext = vm,
             Command = vm.ShowWebVttBrowserPreviewCommand,
         };
-        webVttBrowserPreviewMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsWebVttBrowserPreviewVisible)) { Mode = BindingMode.TwoWay });
+        webVttBrowserPreviewMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsWebVttBrowserPreviewVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(webVttBrowserPreviewMenuItem);
 
         var sepWebVtt = new Separator { DataContext = vm };
@@ -828,7 +828,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnStartTime)),
             }
         };
-        showStartTimeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showStartTimeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showStartTimeMenuItem);
         
         var showEndTimeMenuItem = new MenuItem
@@ -843,7 +843,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnEndTime)),
             }
         };
-        showEndTimeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showEndTimeMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showEndTimeMenuItem);
 
         var showDurationMenuItem = new MenuItem
@@ -858,7 +858,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnDuration)),
             }
         };
-        showDurationMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showDurationMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showDurationMenuItem);
 
         var showGapMenuItem = new MenuItem
@@ -873,7 +873,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnGap)),
             }
         };
-        showGapMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showGapMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showGapMenuItem);
 
         var showStyleMenuItem = new MenuItem
@@ -914,7 +914,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnActor)),
             }
         };
-        showActorMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showActorMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showActorMenuItem);
 
         var showCpsMenuItem = new MenuItem
@@ -929,7 +929,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnCps)),
             }
         };
-        showCpsMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showCpsMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showCpsMenuItem);
 
         var showWpmMenuItem = new MenuItem
@@ -944,7 +944,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnWpm)),
             }
         };
-        showWpmMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showWpmMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showWpmMenuItem);
         
         var showPixelWidthMenuItem = new MenuItem
@@ -959,7 +959,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnPixelWidth)),
             }
         };
-        showPixelWidthMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showPixelWidthMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showPixelWidthMenuItem);
 
         var showForcedMenuItem = new MenuItem
@@ -974,7 +974,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnForced)),
             }
         };
-        showForcedMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.TwoWay });
+        showForcedMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridFlyoutHeaderVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(showForcedMenuItem);
 
         var showLayerMenuItem = new MenuItem
@@ -989,7 +989,7 @@ public static partial class InitListViewAndEditBox
                 [!Visual.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnLayer)),
             }
         };
-        showLayerMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnLayerFlyoutMenuItem)) { Source = vm, Mode = BindingMode.TwoWay });
+        showLayerMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnLayerFlyoutMenuItem)) { Source = vm, Mode = BindingMode.OneWay });
         flyout.Items.Add(showLayerMenuItem);
 
         var columnsSeparator = new Separator { DataContext = vm };

--- a/src/ui/Features/Main/Layout/InitToolbar.cs
+++ b/src/ui/Features/Main/Layout/InitToolbar.cs
@@ -365,7 +365,7 @@ public static class InitToolbar
                 var assaSeparator = MakeSeparator();
                 stackPanelLeft.Children.Add(assaSeparator);
                 assaSeparator.DataContext = vm;
-                assaSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatAssa)) { Mode = BindingMode.TwoWay });
+                assaSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatAssa)) { Mode = BindingMode.OneWay });
             }
 
             if (showSsaIcons)
@@ -373,7 +373,7 @@ public static class InitToolbar
                 var ssaSeparator = MakeSeparator();
                 stackPanelLeft.Children.Add(ssaSeparator);
                 ssaSeparator.DataContext = vm;
-                ssaSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatSsa)) { Mode = BindingMode.TwoWay });
+                ssaSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatSsa)) { Mode = BindingMode.OneWay });
             }
 
             if (showWebVttIcons)
@@ -381,7 +381,7 @@ public static class InitToolbar
                 var webVttSeparator = MakeSeparator();
                 stackPanelLeft.Children.Add(webVttSeparator);
                 webVttSeparator.DataContext = vm;
-                webVttSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatWebVtt)) { Mode = BindingMode.TwoWay });
+                webVttSeparator.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatWebVtt)) { Mode = BindingMode.OneWay });
             }
 
             isLastSeparator = true;

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -632,7 +632,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.StartOcrSelectedLinesCommand,
         };
-        menuItemOcrSelectedLines.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemOcrSelectedLines.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemOcrSelectedLines);
 
         var menuItemInspectMatchesForLine = new MenuItem
@@ -641,7 +641,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.InspectLineCommand,
         };
-        menuItemInspectMatchesForLine.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsInspectLineVisible)) { Mode = BindingMode.TwoWay });
+        menuItemInspectMatchesForLine.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsInspectLineVisible)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemInspectMatchesForLine);
 
         var menuItemShowImage = new MenuItem
@@ -650,7 +650,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.ViewSelectedImageCommand,
         };
-        menuItemShowImage.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemShowImage.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemShowImage);
 
         var menuItemSaveImage = new MenuItem
@@ -659,7 +659,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.SaveImageAsCommand,
         };
-        menuItemSaveImage.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemSaveImage.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemSaveImage);
 
         var menuItemCopyImageToClipboard = new MenuItem
@@ -668,7 +668,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.CopyImageToClipboardCommand,
         };
-        menuItemCopyImageToClipboard.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemCopyImageToClipboard.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemCopyImageToClipboard);
 
         flyout.Items.Add(new Separator());
@@ -679,7 +679,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.DeleteSelectedLinesCommand,
         };
-        menuItemDelete.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemDelete.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemDelete);
 
         var menuItemFillSelectedLinesWithClipboard = new MenuItem
@@ -688,7 +688,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.FillSelectedLinesWithClipboardCommand,
         };
-        menuItemFillSelectedLinesWithClipboard.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.HasMultipleLinesSelected)) { Mode = BindingMode.TwoWay });
+        menuItemFillSelectedLinesWithClipboard.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.HasMultipleLinesSelected)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemFillSelectedLinesWithClipboard);
 
         flyout.Items.Add(new Separator());
@@ -699,7 +699,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.ToggleItalicCommand,
         };
-        menuItemItalic.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemItalic.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemItalic);
 
         var menuItemBold = new MenuItem
@@ -708,7 +708,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.ToggleBoldCommand,
         };
-        menuItemBold.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemBold.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemBold);
 
         flyout.Items.Add(new Separator());
@@ -719,7 +719,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.ExportCurrentOcrItemsCommand,
         };
-        menuItemExport.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemExport.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemExport);
 
         var menuItemImportTextFromSubtitle = new MenuItem
@@ -728,7 +728,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.ImportTextFromSubtitleCommand,
         };
-        menuItemImportTextFromSubtitle.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemImportTextFromSubtitle.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemImportTextFromSubtitle);
 
         var menuItemExportTextAsSubtitle = new MenuItem
@@ -737,7 +737,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.ExportTextAsSubtitleCommand,
         };
-        menuItemExportTextAsSubtitle.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemExportTextAsSubtitle.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemExportTextAsSubtitle);
 
         var menuItemSaveAllImagesWithHtmlIndex = new MenuItem
@@ -746,7 +746,7 @@ public class OcrWindow : Window
             DataContext = vm,
             Command = vm.SaveAllImagesWithHtmlIndexCommand,
         };
-        menuItemSaveAllImagesWithHtmlIndex.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.TwoWay });
+        menuItemSaveAllImagesWithHtmlIndex.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowContextMenu)) { Mode = BindingMode.OneWay });
         flyout.Items.Add(menuItemSaveAllImagesWithHtmlIndex);
 
         flyout.Items.Add(new Separator());

--- a/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryAdjustDuration/BinaryAdjustDurationWindow.cs
@@ -152,7 +152,7 @@ public class BinaryAdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(BinaryAdjustDurationDisplay.IsSecondsVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return panel;
@@ -196,7 +196,7 @@ public class BinaryAdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(BinaryAdjustDurationDisplay.IsPercentVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return panel;
@@ -241,7 +241,7 @@ public class BinaryAdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(BinaryAdjustDurationDisplay.IsFixedVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
         return panel;
     }

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationWindow.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationWindow.cs
@@ -137,7 +137,7 @@ public class AdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsSecondsVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return panel;
@@ -181,7 +181,7 @@ public class AdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsPercentVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return panel;
@@ -226,7 +226,7 @@ public class AdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsFixedVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
         return panel;
     }
@@ -327,7 +327,7 @@ public class AdjustDurationWindow : Window
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsRecalculateVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return grid;

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustDuration.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewAdjustDuration.cs
@@ -116,7 +116,7 @@ public static class ViewAdjustDuration
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsSecondsVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return panel;
@@ -159,7 +159,7 @@ public static class ViewAdjustDuration
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsPercentVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return panel;
@@ -205,7 +205,7 @@ public static class ViewAdjustDuration
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsFixedVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
         return panel;
     }
@@ -288,7 +288,7 @@ public static class ViewAdjustDuration
         {
             Path = $"{nameof(vm.SelectedAdjustType)}.{nameof(AdjustDurationDisplay.IsRecalculateVisible)}",
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return grid;

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileWindow.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileWindow.cs
@@ -74,7 +74,7 @@ public class FixCommonErrorsProfileWindow : Window
                             CommandParameter = profile,
                             DataContext = vm,
                         };
-                        deleteButton.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.IsProfileDeleteEnabled)) { Mode = BindingMode.TwoWay });
+                        deleteButton.Bind(Button.IsEnabledProperty, new Binding(nameof(vm.IsProfileDeleteEnabled)) { Mode = BindingMode.OneWay });
                         Attached.SetIcon(deleteButton, "fa-solid fa-trash");
                         Grid.SetColumn(deleteButton, 1);
                         grid.Children.Add(deleteButton);

--- a/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
@@ -146,7 +146,7 @@ public class ShotChangesWindow : Window
         {
             Converter = new InverseBooleanConverter(),
             Source = vm,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
         var labelSensitivityValue = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(ShotChangesViewModel.Sensitivity), new DoubleToTwoDecimalConverter());
         var buttonGenerate = UiUtil.MakeButton(Se.Language.Video.ShotChanges.GenerateShotChangesWithFfmpeg, vm.GenerateShotChangesFfmpegCommand).WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());

--- a/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsWindow.cs
@@ -41,7 +41,7 @@ public class EncodingSettingsWindow : Window
             IsChecked = vm.IsStereo,
             VerticalAlignment = VerticalAlignment.Center,
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.IsStereo)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
-            [!CheckBox.IsEnabledProperty] = new Binding(nameof(vm.SelectedEncoding) + "." + nameof(EncodingDisplayItem.IsStereoEnabled)) { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
+            [!CheckBox.IsEnabledProperty] = new Binding(nameof(vm.SelectedEncoding) + "." + nameof(EncodingDisplayItem.IsStereoEnabled)) { Mode = BindingMode.OneWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged },
         };
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -826,7 +826,7 @@ public static class UiUtil
             comboBox.Bind(ComboBox.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -1001,7 +1001,7 @@ public static class UiUtil
             textBox.Bind(TextBox.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -1070,7 +1070,7 @@ public static class UiUtil
             textBlock.Bind(TextBlock.TextProperty, new Binding
             {
                 Path = textPropertyPath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -1079,7 +1079,7 @@ public static class UiUtil
             textBlock.Bind(TextBlock.IsVisibleProperty, new Binding
             {
                 Path = visibilityPropertyPath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -1194,7 +1194,7 @@ public static class UiUtil
         link.Bind(TextBlock.TextProperty, new Binding
         {
             Path = propertyTextPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return link;
@@ -1457,7 +1457,7 @@ public static class UiUtil
         control.Bind(Button.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1468,7 +1468,7 @@ public static class UiUtil
         control.Bind(SplitButton.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1479,7 +1479,7 @@ public static class UiUtil
         control.Bind(SplitButton.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1490,7 +1490,7 @@ public static class UiUtil
         control.Bind(ComboBox.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1501,7 +1501,7 @@ public static class UiUtil
         control.Bind(ComboBox.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1518,7 +1518,7 @@ public static class UiUtil
         control.Bind(NumericUpDown.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1529,7 +1529,7 @@ public static class UiUtil
         control.Bind(Button.ContentProperty, new Binding
         {
             Path = contentPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1540,7 +1540,7 @@ public static class UiUtil
         control.Bind(CheckBox.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1551,7 +1551,7 @@ public static class UiUtil
         control.Bind(TextBox.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1563,7 +1563,7 @@ public static class UiUtil
         {
             Converter = converter,
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1575,7 +1575,7 @@ public static class UiUtil
         {
             Converter = converter,
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1586,7 +1586,7 @@ public static class UiUtil
         control.Bind(TextBox.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1599,7 +1599,7 @@ public static class UiUtil
         {
             Converter = converter,
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1610,7 +1610,7 @@ public static class UiUtil
         control.Bind(Button.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1622,7 +1622,7 @@ public static class UiUtil
         control.Bind(Button.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1633,7 +1633,7 @@ public static class UiUtil
         control.Bind(Button.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
             Converter = converter,
         });
 
@@ -1645,7 +1645,7 @@ public static class UiUtil
         control.Bind(Border.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
             Converter = converter,
         });
 
@@ -1657,7 +1657,7 @@ public static class UiUtil
         control.Bind(Border.IsVisibleProperty, new Binding
         {
             Path = isVisiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1701,7 +1701,7 @@ public static class UiUtil
         control.Bind(Button.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -1712,7 +1712,7 @@ public static class UiUtil
         control.Bind(Button.IsEnabledProperty, new Binding
         {
             Path = isEnabledPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
             Converter = converter,
         });
 
@@ -2168,7 +2168,7 @@ public static class UiUtil
         control.Bind(Visual.IsVisibleProperty, new Binding
         {
             Path = visibilityPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2421,7 +2421,7 @@ public static class UiUtil
             Label.IsVisibleProperty,
             CompiledBinding.Create(
                 isVisibleExpression,
-                mode: BindingMode.TwoWay
+                mode: BindingMode.OneWay
             )
         );
 
@@ -2562,7 +2562,7 @@ public static class UiUtil
             control.Bind(NumericUpDown.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -2606,7 +2606,7 @@ public static class UiUtil
             control.Bind(NumericUpDown.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -2647,7 +2647,7 @@ public static class UiUtil
             control.Bind(NumericUpDown.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -2686,7 +2686,7 @@ public static class UiUtil
             control.Bind(NumericUpDown.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -2726,7 +2726,7 @@ public static class UiUtil
             control.Bind(NumericUpDown.IsVisibleProperty, new Binding
             {
                 Path = propertyIsVisiblePath,
-                Mode = BindingMode.TwoWay,
+                Mode = BindingMode.OneWay,
             });
         }
 
@@ -2780,7 +2780,7 @@ public static class UiUtil
         control.Bind(Label.ContentProperty, new Binding
         {
             Path = contentPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2810,7 +2810,7 @@ public static class UiUtil
         control.Bind(Label.ContentProperty, new Binding
         {
             Path = contentPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
             Converter = valueConverter,
         });
 
@@ -2832,7 +2832,7 @@ public static class UiUtil
         control.Bind(TextBlock.TextProperty, new Binding
         {
             Path = contentPropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2844,7 +2844,7 @@ public static class UiUtil
         control.Bind(Label.IsVisibleProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2881,7 +2881,7 @@ public static class UiUtil
         control.Bind(Grid.IsVisibleProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2893,7 +2893,7 @@ public static class UiUtil
         control.Bind(TextBlock.IsVisibleProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2905,7 +2905,7 @@ public static class UiUtil
         control.Bind(TextBlock.IsEnabledProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2918,7 +2918,7 @@ public static class UiUtil
         control.Bind(Label.IsVisibleProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
             Converter = converter,
         });
 
@@ -2931,7 +2931,7 @@ public static class UiUtil
         control.Bind(StackPanel.IsVisibleProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
         });
 
         return control;
@@ -2944,7 +2944,7 @@ public static class UiUtil
         control.Bind(StackPanel.IsVisibleProperty, new Binding
         {
             Path = visiblePropertyPath,
-            Mode = BindingMode.TwoWay,
+            Mode = BindingMode.OneWay,
             Converter = converter,
         });
 


### PR DESCRIPTION
## Summary

The UI is built in C# on top of the `UiUtil` factory and `WithBind*` helpers. Most of those helpers bound display-only properties `TwoWay`: `IsVisible`, `IsEnabled`, `TextBlock.Text`, `Label`/`Button.Content` and `Image.Source`. Those properties never change from the control side, so TwoWay only subscribes to target changes for nothing and would let a stray control write leak into the view model. The generic `WithBindIsVisible<T>` and `WithBindIsEnabled<T>` overloads were already `OneWay`; this makes the rest consistent.

- 42 bindings in `Logic/UiUtil.cs` flip to `OneWay`. Editable targets stay `TwoWay`: `TextBox.Text`, editable `ComboBox.Text`, `SelectedItem`, `SelectedIndex`, `IsChecked`, `Value`.
- 47 direct bindings in views flip the same way (`InitListViewAndEditBox`, `OcrWindow`, `AdjustDuration`, `BinaryAdjustDuration`, `ImageBasedPreviewWindow`, and a few others).
- Every changed line is a literal `BindingMode.TwoWay` to `BindingMode.OneWay` swap; nothing else moves.

Audited before flipping: all 68 places where a view model writes a control property directly, and every view-side local write, were checked against the bindings created for those controls. None writes a property that is also bound, so no write-back path is lost.

Note: `refactor/inverse-converter-instance` touches some of the same view lines. Merge one, then rebase the other.

## Test plan

- [x] `dotnet build src/ui/UI.csproj -c Release` and `tests/UI/UITests.csproj` build with 0 warnings
- [x] Full `tests/UI` run: 4978 passed, 25 failed, and the 25 are exactly the known-flaky baseline set (menu keyboard activation, grid focus/scroll, Shift+Delete)
- [ ] Open a file, toggle the layout panels and toolbar items from the View menu, and confirm they show/hide as before
- [ ] Run OCR and Adjust Duration and confirm the mode-dependent panels switch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYrDKC6UJJFmDhxQXh7ywg
