### PR TITLE
Share one InverseBooleanConverter instance across bindings

### DIFF
--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedWindow.cs
@@ -57,7 +57,7 @@ public class ExportImageBasedWindow : Window
             .WithBindIsVisible(vm, nameof(vm.IsExportButtonVisible));
         buttonExport.IsDefault = true; // the dialog's accept button - Enter runs it (#14586)
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating));
-        var buttonDone = UiUtil.MakeButtonDone(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating), new InverseBooleanConverter());
+        var buttonDone = UiUtil.MakeButtonDone(vm.CancelCommand).WithBindIsVisible(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var panelButtons = UiUtil.MakeButtonBar(buttonExport, buttonDone, buttonCancel);
         
         var comboProfile = UiUtil.MakeComboBox(vm.Profiles, vm, nameof(vm.SelectedProfile));

--- a/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
+++ b/src/ui/Features/Files/ImportPlainText/ImportPlainTextWindow.cs
@@ -50,7 +50,7 @@ public class ImportPlainTextWindow : Window
         var buttonImportFiles = UiUtil.MakeButton(Se.Language.File.Import.ImportFilesDotDotDot, vm.FilesImportCommand).WithMinWidth(110);
         buttonImportFiles.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm });
         var buttonImportFile = UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.FileImportCommand).WithMinWidth(110);
-        buttonImportFile.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm, Converter = new InverseBooleanConverter() });
+        buttonImportFile.Bind(Button.IsVisibleProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm, Converter = InverseBooleanConverter.Instance });
         var checkBoxImportFiles = UiUtil.MakeCheckBox(Se.Language.File.Import.MultipleFiles, vm, nameof(vm.IsImportFilesVisible));
         checkBoxImportFiles.IsCheckedChanged += (s, e) => vm.CheckBoxImportFilesChanged();
         var panelImport = new StackPanel
@@ -74,7 +74,7 @@ public class ImportPlainTextWindow : Window
         labelNumberOfSubtitles.Bind(IsVisibleProperty, new Binding(nameof(vm.IsAligning))
         {
             Source = vm,
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
         });
 
         // Progress sits next to the line count; forced alignment of a long video runs for
@@ -155,7 +155,7 @@ public class ImportPlainTextWindow : Window
             DataContext = vm,
         };
         textBox.Bind(TextBox.TextProperty, new Binding(nameof(vm.PlainText)) { Mode = BindingMode.TwoWay });
-        textBox.Bind(TextBox.IsVisibleProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm, Converter = new InverseBooleanConverter() });
+        textBox.Bind(TextBox.IsVisibleProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm, Converter = InverseBooleanConverter.Instance });
         textBox.TextChanged += (s, e) => vm.PlainTextChanged();
         var sizeConverter = new FileSizeConverter();
 
@@ -254,7 +254,7 @@ public class ImportPlainTextWindow : Window
         };
         comboBoxSplit.Bind(ComboBox.ItemsSourceProperty, new Binding(nameof(vm.SplitAtOptions)) { Source = vm });
         comboBoxSplit.Bind(ComboBox.SelectedItemProperty, new Binding(nameof(vm.SelectedSplitAtOption)) { Source = vm, Mode = BindingMode.TwoWay });
-        comboBoxSplit.Bind(ComboBox.IsEnabledProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm, Converter = new InverseBooleanConverter() });
+        comboBoxSplit.Bind(ComboBox.IsEnabledProperty, new Binding(nameof(vm.IsImportFilesVisible)) { Source = vm, Converter = InverseBooleanConverter.Instance });
         comboBoxSplit.SelectionChanged += (s, e) => vm.SplitAtOptionChanged();
 
         var panelSplit = UiUtil.MakeHorizontalPanel(labelSplit, comboBoxSplit);

--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -155,7 +155,7 @@ public static partial class InitListViewAndEditBox
         // the grid is rebuilt when settings are applied, so a changed mode takes effect then.
         var gridTextDisplayMode = SubtitleGridTextDisplayModeDisplay.FromSettings();
         var gapConverter = new DoubleToDisplayShortConverter();
-        var inverseBooleanConverter = new InverseBooleanConverter();
+        var inverseBooleanConverter = InverseBooleanConverter.Instance;
         var textOneLineShortConverter = new TextOneLineShortConverter();
         var booleanToGridLengthConverter = new BooleanToGridLengthConverter();
         var booleanAndConverter = BooleanAndConverter.Instance;

--- a/src/ui/Features/Main/Layout/InitMenu.cs
+++ b/src/ui/Features/Main/Layout/InitMenu.cs
@@ -104,7 +104,7 @@ public static class InitMenu
                 {
                     Header = l.OpenOriginal,
                     Command = vm.FileOpenOriginalCommand,
-                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnOriginalText)) { Converter = new InverseBooleanConverter() }
+                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.ShowColumnOriginalText)) { Converter = InverseBooleanConverter.Instance }
                 },
                 new MenuItem
                 {
@@ -412,7 +412,7 @@ public static class InitMenu
                 {
                     Header = l.RightToLeftMode,
                     Command = vm.RightToLeftToggleCommand,
-                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsRightToLeftEnabled)) { Converter = new InverseBooleanConverter() },
+                    [!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsRightToLeftEnabled)) { Converter = InverseBooleanConverter.Instance },
                 },
                 new MenuItem
                 {
@@ -814,7 +814,7 @@ public static class InitMenu
                 {
                     Header = l.UndockVideoControls,
                     Command = vm.VideoUndockControlsCommand,
-                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.AreVideoControlsUndocked)) {  Converter = new InverseBooleanConverter() },
+                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.AreVideoControlsUndocked)) {  Converter = InverseBooleanConverter.Instance },
                 },
                 new MenuItem
                 {
@@ -826,7 +826,7 @@ public static class InitMenu
                 {
                     Header = l.ToggleSelectSubtitleWhilePlayingCurrentlyOff,
                     Command = vm.ToggleCurrentSubtitleWhilePlayingCommand,
-                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.SelectCurrentSubtitleWhilePlaying)) {  Converter = new InverseBooleanConverter() },
+                    [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.SelectCurrentSubtitleWhilePlaying)) {  Converter = InverseBooleanConverter.Instance },
                 },
                 new MenuItem
                 {

--- a/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
+++ b/src/ui/Features/Ocr/Download/DownloadTesseractModelWindow.cs
@@ -55,7 +55,7 @@ public class DownloadTesseractModelWindow : Window
                 UiUtil.MakeButton(Se.Language.General.Download, vm.DownloadCommand),
             }
         };
-        panelPickDictionary.Bind(Panel.IsVisibleProperty, new Binding(nameof(vm.IsProgressVisible)) { Converter = new InverseBooleanConverter() });
+        panelPickDictionary.Bind(Panel.IsVisibleProperty, new Binding(nameof(vm.IsProgressVisible)) { Converter = InverseBooleanConverter.Instance });
 
         var progressBar = UiUtil.MakeProgressBar();
         progressBar.MinWidth = 400;

--- a/src/ui/Features/Ocr/OcrWindow.cs
+++ b/src/ui/Features/Ocr/OcrWindow.cs
@@ -135,7 +135,7 @@ public class OcrWindow : Window
             ResizeDirection = GridResizeDirection.Rows,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
-        splitter.Bind(GridSplitter.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = new InverseBooleanConverter() });
+        splitter.Bind(GridSplitter.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = InverseBooleanConverter.Instance });
 
         grid.Add(topControlsView, 0, 0);
         grid.Add(subtitleView, 1, 0);
@@ -206,7 +206,7 @@ public class OcrWindow : Window
         ToolTip.SetTip(toggleButtonShowOnlyForced, Se.Language.Ocr.ShowOnlyForcedSubtitles);
         toggleButtonShowOnlyForced.Bind(ToggleButton.IsCheckedProperty, new Binding(nameof(vm.ShowOnlyForced)));
         toggleButtonShowOnlyForced.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.HasForcedSubtitles)));
-        toggleButtonShowOnlyForced.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsOcrRunning)) { Converter = new InverseBooleanConverter() });
+        toggleButtonShowOnlyForced.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsOcrRunning)) { Converter = InverseBooleanConverter.Instance });
 
         var panelRight = new StackPanel
         {
@@ -224,7 +224,7 @@ public class OcrWindow : Window
 
         var comboBoxEngines = UiUtil.MakeComboBox(vm.OcrEngines, vm, nameof(vm.SelectedOcrEngine))
             .WithMarginRight(10)
-            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter());
+            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance);
         comboBoxEngines.SelectionChanged += vm.EngineSelectionChanged;
         comboBoxEngines.ItemTemplate = MakeOcrEngineItemTemplate();
         vm.RefreshEngineCombo = () => comboBoxEngines.ItemTemplate = MakeOcrEngineItemTemplate();
@@ -233,7 +233,7 @@ public class OcrWindow : Window
                 nameof(vm.IsCrispEmbedVisible))
             .WithMinWidth(220)
             .WithMarginRight(5)
-            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter());
+            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance);
         comboBoxCrispEmbedModels.ItemTemplate = MakeCrispEmbedModelItemTemplate();
         vm.RefreshCrispEmbedModelCombo = () => comboBoxCrispEmbedModels.ItemTemplate = MakeCrispEmbedModelItemTemplate();
 
@@ -241,7 +241,7 @@ public class OcrWindow : Window
                 nameof(vm.IsLlamaCppVisible))
             .WithWidth(220)
             .WithMarginRight(5)
-            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter());
+            .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance);
         comboBoxLlamaCppModels.ItemTemplate = LlamaCppDownloadHelper.ModelItemTemplate();
         vm.RefreshLlamaCppOcrModelCombo = () => comboBoxLlamaCppModels.ItemTemplate = LlamaCppDownloadHelper.ModelItemTemplate();
 
@@ -261,57 +261,57 @@ public class OcrWindow : Window
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.Database, vm => vm.IsNOcrVisible),
                 UiUtil.MakeComboBox(vm.NOcrDatabases, vm, nameof(vm.SelectedNOcrDatabase), nameof(vm.IsNOcrVisible))
                     .WithMarginRight(0)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeButton(vm.ShowNOcrSettingsCommand, IconNames.Settings, Se.Language.General.Settings)
                     .WithMarginRight(20)
                     .WithMarginBottom(2)
                     .WithBottomAlignment()
                     .WithBindIsVisible(nameof(vm.IsNOcrVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.MaxWrongPixels, vm => vm.IsNOcrVisible),
                 UiUtil.MakeComboBox(vm.NOcrMaxWrongPixelsList, vm, nameof(vm.SelectedNOcrMaxWrongPixels),
                         nameof(vm.IsNOcrVisible))
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.NumberOfPixelsIsSpace, vm => vm.IsNOcrVisible),
                 UiUtil.MakeComboBox(vm.NOcrPixelsAreSpaceList, vm, nameof(vm.SelectedNOcrPixelsAreSpace),
                         nameof(vm.IsNOcrVisible))
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Image Compare settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.Database, vm => vm.IsBinaryImageCompareVisible),
                 UiUtil.MakeComboBox(vm.ImageCompareDatabases, vm, nameof(vm.SelectedImageCompareDatabase), nameof(vm.IsBinaryImageCompareVisible))
                     .WithMarginRight(0)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeButton(vm.ShowBinaryOcrSettingsCommand, IconNames.Settings, Se.Language.General.Settings)
                     .WithMarginRight(20)
                     .WithMarginBottom(2)
                     .WithBottomAlignment()
                     .WithBindIsVisible(nameof(vm.IsBinaryImageCompareVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.NumberOfPixelsIsSpace, vm => vm.IsBinaryImageCompareVisible),
                 UiUtil.MakeComboBox(vm.BinaryOcrPixelsAreSpaceList, vm, nameof(vm.SelectedBinaryOcrPixelsAreSpace),
                         nameof(vm.IsBinaryImageCompareVisible))
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.MaxErrorPct, vm => vm.IsBinaryImageCompareVisible),
                 UiUtil.MakeNumericUpDownOneDecimal(0, 50, 120, vm, nameof(vm.BinaryOcrMaxErrorPercent), nameof(vm.IsBinaryImageCompareVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Tesseract settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsTesseractVisible),
                 UiUtil.MakeComboBox(vm.TesseractDictionaryItems, vm, nameof(vm.SelectedTesseractDictionaryItem),
                         nameof(vm.IsTesseractVisible))
                     .WithWidth(100)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeBrowseButton(vm.PickTesseractModelCommand).BindIsVisible(vm, nameof(vm.IsTesseractVisible))
-                    .BindIsEnabled(vm, nameof(vm.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(vm.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.Ocr.TesseractEngineMode, vm => vm.IsTesseractVisible)
                     .WithMarginLeft(10),
                 UiUtil.MakeComboBox(vm.TesseractEngineModes, vm, nameof(vm.SelectedTesseractEngineMode),
                         nameof(vm.IsTesseractVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Ollama settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsOllamaVisible),
@@ -319,18 +319,18 @@ public class OcrWindow : Window
                         nameof(vm.IsOllamaVisible))
                     .WithWidth(100)
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsOllamaVisible),
                 UiUtil.MakeTextBox(160, vm, nameof(vm.OllamaModel))
                     .BindIsVisible(vm, nameof(vm.IsOllamaVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeBrowseButton(vm.PickOllamaModelCommand)
                     .BindIsVisible(vm, nameof(vm.IsOllamaVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Url, vm => vm.IsOllamaVisible),
                 UiUtil.MakeTextBox(220, vm, nameof(vm.OllamaUrl))
                     .BindIsVisible(vm, nameof(vm.IsOllamaVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // llama.cpp settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsLlamaCppVisible),
@@ -338,34 +338,34 @@ public class OcrWindow : Window
                         nameof(vm.IsLlamaCppVisible))
                     .WithWidth(100)
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsLlamaCppVisible),
                 comboBoxLlamaCppModels,
                 UiUtil.MakeButton(vm.DownloadLlamaCppOcrCommand, IconNames.Download, Se.Language.General.Download)
                     .WithMarginRight(5)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 MakeLlamaCppOcrToggleServerButton(vm)
                     .WithMarginRight(5)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeButton(vm.ShowLlamaCppOcrSettingsCommand, IconNames.Settings, Se.Language.General.Settings)
                     .WithMarginRight(10)
                     .BindIsVisible(vm, nameof(vm.IsLlamaCppVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // CrispEmbed settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Backend, vm => vm.IsCrispEmbedVisible),
                 UiUtil.MakeComboBox(vm.CrispEmbedBackends, vm, nameof(vm.SelectedCrispEmbedBackend),
                         nameof(vm.IsCrispEmbedVisible))
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Model, vm => vm.IsCrispEmbedVisible),
                 comboBoxCrispEmbedModels,
                 UiUtil.MakeButton(vm.DownloadCrispEmbedCommand, IconNames.Download, Se.Language.General.Download)
                     .WithMarginRight(5)
                     .BindIsVisible(vm, nameof(vm.IsCrispEmbedVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 // Separate from the download button above, which fetches the selected *model*:
                 // this one re-fetches the engine binaries and re-asks CPU/Vulkan/CUDA, the only
                 // way to change hardware build after the first install (issue #13400).
@@ -373,7 +373,7 @@ public class OcrWindow : Window
                         string.Format(Se.Language.General.ReDownloadX, CrispEmbedEngine.StaticName))
                     .WithMarginRight(10)
                     .BindIsVisible(vm, nameof(vm.IsCrispEmbedVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Apple Vision settings - language only: the engine ships with macOS, so there is
                 // nothing to download, no key to enter and no model to pick.
@@ -382,7 +382,7 @@ public class OcrWindow : Window
                         nameof(vm.IsAppleVisionVisible))
                     .WithWidth(180)
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Google vision settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsGoogleVisionVisible),
@@ -390,11 +390,11 @@ public class OcrWindow : Window
                         nameof(vm.IsGoogleVisionVisible))
                     .WithWidth(100)
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.ApiKey, vm => vm.IsGoogleVisionVisible),
                 UiUtil.MakeTextBox(200, vm, nameof(vm.GoogleVisionApiKey))
                     .BindIsVisible(vm, nameof(vm.IsGoogleVisionVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Google Lens settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsGoogleLensVisible),
@@ -402,7 +402,7 @@ public class OcrWindow : Window
                         nameof(vm.IsGoogleLensVisible))
                     .WithWidth(100)
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Paddle OCR settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.Language, vm => vm.IsPaddleOcrVisible),
@@ -410,13 +410,13 @@ public class OcrWindow : Window
                         nameof(vm.IsPaddleOcrVisible))
                     .WithWidth(100)
                     .WithMarginRight(10)
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
 
                 // Mistral OCR settings
                 UiUtil.MakeLabel<OcrViewModel>(Se.Language.General.ApiKey, vm => vm.IsMistralOcrVisible),
                 UiUtil.MakeTextBox(200, vm, nameof(vm.MistralApiKey))
                     .BindIsVisible(vm, nameof(vm.IsMistralOcrVisible))
-                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()),
+                    .BindIsEnabled(vm, nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance),
             }
         };
 
@@ -912,7 +912,7 @@ public class OcrWindow : Window
 
         var border = UiUtil.MakeBorderForControl(grid).WithMarginBottom(5);
         border.ClipToBounds = true; // Prevent content from pushing the parent row larger
-        border.Bind(Border.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = new InverseBooleanConverter() });
+        border.Bind(Border.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = InverseBooleanConverter.Instance });
 
         return border;
     }
@@ -1121,19 +1121,19 @@ public class OcrWindow : Window
         statusText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm });
 
         var buttonStart = UiUtil.MakeButton(Se.Language.Ocr.StartOcr, vm.StartOcrCommand)
-            .WithBindIsVisible(nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()).WithBottomAlignment();
+            .WithBindIsVisible(nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance).WithBottomAlignment();
         var buttonPause = UiUtil.MakeButton(Se.Language.Ocr.PauseOcr, vm.PauseOcrCommand)
             .WithBindIsVisible(nameof(OcrViewModel.IsOcrRunning)).WithBottomAlignment();
         var buttonInspect = UiUtil.MakeButton(Se.Language.Ocr.InspectLine, vm.InspectLineCommand)
             .WithBindIsVisible(nameof(OcrViewModel.IsInspectLineVisible))
-            .WithBindIsEnabled(nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter())
+            .WithBindIsEnabled(nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance)
             .WithBottomAlignment();
         var buttonInspectAdditions = UiUtil.MakeButton(Se.Language.General.InspectAdditions, vm.InspectAdditionsCommand)
             .WithBindIsVisible(nameof(vm.IsInspectAdditionsVisible))
-            .WithBindIsEnabled(nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter())
+            .WithBindIsEnabled(nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance)
             .WithBottomAlignment();
         var buttonExport = UiUtil.MakeButton(Se.Language.Ocr.EditExportDotDotDot, vm.EditExportCommand)
-            .WithBindIsEnabled(nameof(OcrViewModel.IsOcrRunning), new InverseBooleanConverter()).WithBottomAlignment();
+            .WithBindIsEnabled(nameof(OcrViewModel.IsOcrRunning), InverseBooleanConverter.Instance).WithBottomAlignment();
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBottomAlignment();
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBottomAlignment();
 
@@ -1165,7 +1165,7 @@ public class OcrWindow : Window
             Margin = new Thickness(5, 0, 0, 0),
         };
         subtitleCountText.Bind(TextBlock.TextProperty, new Binding(nameof(vm.SelectionStatus)) { Source = vm });
-        subtitleCountText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = new InverseBooleanConverter() });
+        subtitleCountText.Bind(TextBlock.IsVisibleProperty, new Binding(nameof(vm.IsOcrRunning)) { Source = vm, Converter = InverseBooleanConverter.Instance });
 
         grid.Add(progressBar, 0, 0);
         grid.Add(statusText, 0, 0);

--- a/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordWindow.cs
@@ -121,7 +121,7 @@ public class PromptUnknownWordWindow : Window
         };
         scrollViewerWholeText.Bind(Border.IsVisibleProperty, new Binding(nameof(vm.DoEditWholeText))
         {
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
         });
 
         var buttonEditWholeText = new ToggleButton
@@ -170,7 +170,7 @@ public class PromptUnknownWordWindow : Window
 
         vm.TextBoxWord
             .WithHorizontalAlignmentStretch()
-            .WithBindEnabled(nameof(vm.DoEditWholeText), new InverseBooleanConverter())
+            .WithBindEnabled(nameof(vm.DoEditWholeText), InverseBooleanConverter.Instance)
             .Bind(TextBox.TextProperty, new Binding(nameof(vm.Word)) { Mode = BindingMode.TwoWay });
         if (!string.IsNullOrEmpty(Se.Settings.Appearance.SubtitleTextBoxAndGridFontName))
         {
@@ -178,23 +178,23 @@ public class PromptUnknownWordWindow : Window
         }
         var buttonChangeAll = UiUtil.MakeButton(Se.Language.General.ChangeAll, vm.ChangeAllCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), InverseBooleanConverter.Instance);
         var buttonChangeOnce = UiUtil.MakeButton(Se.Language.General.ChangeOnce, vm.ChangeOnceCommand)
             .WithHorizontalAlignmentStretch();
         var buttonSkipOne = UiUtil.MakeButton(Se.Language.General.SkipOnce, vm.SkipOnceCommand)
             .WithHorizontalAlignmentStretch();
         var buttonGoogleIt = UiUtil.MakeButton(Se.Language.General.GoogleIt, vm.GoogleItCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), InverseBooleanConverter.Instance);
         var buttonSkipAll = UiUtil.MakeButton(Se.Language.General.SkipAll, vm.SkipAllCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), InverseBooleanConverter.Instance);
         var buttonAddToNameList = UiUtil.MakeButton(Se.Language.General.AddToNamesListCaseSensitive, vm.AddToNamesListCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), InverseBooleanConverter.Instance);
         var buttonAddToUserDictionary = UiUtil.MakeButton(Se.Language.General.AddToUserDictionary, vm.AddToUserDictionaryCommand)
             .WithHorizontalAlignmentStretch()
-            .WithBindIsVisible(nameof(vm.DoEditWholeText), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.DoEditWholeText), InverseBooleanConverter.Instance);
 
         grid.Add(vm.TextBoxWord, 0, 0, 1, 2);
         grid.Add(buttonChangeAll, 1, 0, 1, 2);

--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportPage.cs
@@ -52,7 +52,7 @@ public class SettingsImportExportPage : UserControl
             Content = Se.Language.General.SyntaxColoring,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ExportImportSyntaxColoring)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ExportImportAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ExportImportAll), InverseBooleanConverter.Instance);
 
         var checkBoxExportImportShortcuts = new CheckBox
         {

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -1330,7 +1330,7 @@ public class SettingsPage : UserControl
         textBox[!Control.IsEnabledProperty] = new Binding(nameof(_vm.ProxyUseDefaultCredentials))
         {
             Source = _vm,
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
         };
 
         return textBox;

--- a/src/ui/Features/Options/Settings/SettingsResetWindow.cs
+++ b/src/ui/Features/Options/Settings/SettingsResetWindow.cs
@@ -31,56 +31,56 @@ public class SettingsResetWindow : Window
             Content = Se.Language.Options.Settings.ResetRules,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetRules)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetShortcuts = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetShortcuts,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetShortcuts)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetRecentFiles = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetRecentFiles,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetRecentFiles)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetAutoTranslate = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetAutoTranslate,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetAutoTranslate)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetAppearance = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetAppearance,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetAppearance)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetWaveform = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetWaveform,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetWaveform)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetSyntaxColoring = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetSyntaxColoring,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetSyntaxColoring)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
         var checkBoxResetWindowPositionAndSize = new CheckBox
         {
             Content = Se.Language.Options.Settings.ResetWindowPositionAndSize,
             Margin = new Thickness(20, 0, 55, 0),
             [!CheckBox.IsCheckedProperty] = new Binding(nameof(vm.ResetWindowPositionAndSize)) { Mode = BindingMode.TwoWay },
-        }.WithBindEnabled(nameof(vm.ResetAll), new InverseBooleanConverter());
+        }.WithBindEnabled(nameof(vm.ResetAll), InverseBooleanConverter.Instance);
 
 
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -422,7 +422,7 @@ public class BinaryEditWindow : Window
                     Command = vm.ToggleCurrentSubtitleWhilePlayingCommand,
                     [!MenuItem.IsVisibleProperty] = new Binding(nameof(vm.SelectCurrentSubtitleWhilePlaying))
                     {
-                        Converter = new InverseBooleanConverter(),
+                        Converter = InverseBooleanConverter.Instance,
                     },
                 },
             },

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -50,7 +50,7 @@ public class BatchConvertWindow : Window
                 labelBatchItemsInfo,
             }
         };
-        panelInfo.WithBindVisible(vm, nameof(vm.IsConverting), new InverseBooleanConverter());
+        panelInfo.WithBindVisible(vm, nameof(vm.IsConverting), InverseBooleanConverter.Instance);
 
         var buttonConvert = new SplitButton
         {
@@ -73,9 +73,9 @@ public class BatchConvertWindow : Window
                 }
             }
         };
-        buttonConvert.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsConverting)) { Converter = new InverseBooleanConverter() });
+        buttonConvert.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsConverting)) { Converter = InverseBooleanConverter.Instance });
 
-        var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand).WithBindIsVisible(nameof(vm.IsConverting), new InverseBooleanConverter());
+        var buttonDone = UiUtil.MakeButtonDone(vm.DoneCommand).WithBindIsVisible(nameof(vm.IsConverting), InverseBooleanConverter.Instance);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand).WithBindIsVisible(vm, nameof(vm.IsConverting));
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonConvert,
@@ -296,7 +296,7 @@ public class BatchConvertWindow : Window
         menuItemRemove.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsRemoveVisible)) { Source = vm });
         menuItemRemove.Bind(MenuItem.IsEnabledProperty, new Binding(nameof(vm.IsConverting))
         {
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
             Source = vm,
         });
         flyout.Items.Add(menuItemRemove);
@@ -310,7 +310,7 @@ public class BatchConvertWindow : Window
         menuItemOpenContainingFolder.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.IsOpenContainingFolderVisible)) { Source = vm });
         menuItemOpenContainingFolder.Bind(MenuItem.IsEnabledProperty, new Binding(nameof(vm.IsConverting))
         {
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
             Source = vm,
         });
         flyout.Items.Add(menuItemOpenContainingFolder);

--- a/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
+++ b/src/ui/Features/Tools/MergeTwoSubtitles/MergeTwoSubtitlesWindow.cs
@@ -324,7 +324,7 @@ public class MergeTwoSubtitlesWindow : Window
         {
             Source = vm,
             Mode = BindingMode.TwoWay,
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
         });
         var alignPanel = new StackPanel
         {

--- a/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
+++ b/src/ui/Features/Video/BlankVideo/BlankVideoWindow.cs
@@ -32,9 +32,9 @@ public class BlankVideoWindow : Window
         var progressView = MakeProgressView(vm);
 
         var buttonGenerate = UiUtil.MakeButton(Se.Language.General.Generate, vm.GenerateCommand)
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
 
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonGenerate,
             buttonOk,
@@ -106,7 +106,7 @@ public class BlankVideoWindow : Window
                 textBoxHeight,
                 buttonResolution,
             }
-        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), new InverseBooleanConverter());
+        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), InverseBooleanConverter.Instance);
 
         var labelSourceResolution = UiUtil.MakeLabel(Se.Language.General.UseSourceResolution).WithBindVisible(vm, nameof(vm.UseSourceResolution));
         var buttonResolutionSource = UiUtil.MakeButtonBrowse(vm.BrowseResolutionCommand, accessibleName: Se.Language.General.Resolution);

--- a/src/ui/Features/Video/BurnIn/BurnInWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInWindow.cs
@@ -81,16 +81,16 @@ public class BurnInWindow : Window
                 }
             }
         };
-        buttonGenerate.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsGenerating)) { Converter = new InverseBooleanConverter() });
+        buttonGenerate.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsGenerating)) { Converter = InverseBooleanConverter.Instance });
 
         var buttonBatchMode = UiUtil.MakeButton(Se.Language.General.BatchMode, vm.BatchModeCommand)
-            .WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter())
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.IsBatchMode), InverseBooleanConverter.Instance)
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonHelp = UiUtil.MakeButton(Se.Language.General.Help, vm.HelpCommand);
         var buttonSingleMode = UiUtil.MakeButton(Se.Language.General.SingleMode, vm.SingleModeCommand)
             .WithBindIsVisible(nameof(vm.IsSingleModeVisible))
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonGenerate,
             buttonHelp,
@@ -625,7 +625,7 @@ public class BurnInWindow : Window
         // label aligned with the text rows when both are shown.
         grid.Name = TextSettingsName;
         grid.ColumnDefinitions[0].SharedSizeGroup = LabelColumnGroup;
-        grid.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsImageSubtitle)) { Converter = new InverseBooleanConverter() });
+        grid.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsImageSubtitle)) { Converter = InverseBooleanConverter.Instance });
 
         var logoGrid = new Grid
         {
@@ -678,7 +678,7 @@ public class BurnInWindow : Window
                 textBoxHeight,
                 buttonResolution,
             }
-        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), new InverseBooleanConverter());
+        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), InverseBooleanConverter.Instance);
 
         var labelSourceResolution = UiUtil.MakeLabel("Use source resolution").WithBindVisible(vm, nameof(vm.UseSourceResolution));
         var buttonResolutionSource = UiUtil.MakeButtonBrowse(vm.BrowseResolutionCommand, accessibleName: Se.Language.General.Resolution);
@@ -1041,7 +1041,7 @@ public class BurnInWindow : Window
         var labelTargetFileSize = UiUtil.MakeLabel(Se.Language.Video.BurnIn.FileSizeMb).WithMarginLeft(10);
         var numericUpDownTargetFileSize = UiUtil.MakeNumericUpDownInt(1, 1000_000_000, 0, 150, vm, nameof(vm.TargetFileSize));
         numericUpDownTargetFileSize.ValueChanged += vm.NumericUpDownTargetFileSizeChanged;
-        numericUpDownTargetFileSize.Bind(NumericUpDown.IsEnabledProperty, new Binding(nameof(vm.MatchSourceVideoSize)) { Converter = new InverseBooleanConverter() });
+        numericUpDownTargetFileSize.Bind(NumericUpDown.IsEnabledProperty, new Binding(nameof(vm.MatchSourceVideoSize)) { Converter = InverseBooleanConverter.Instance });
         var labelVideoBitRate = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(vm.TargetVideoBitRateInfo));
         labelVideoBitRate.FontSize = 10;
         labelVideoBitRate.Opacity = 0.7;
@@ -1119,7 +1119,7 @@ public class BurnInWindow : Window
         grid.Add(labelVideoSizeValue, 1, 1);
 
         return UiUtil.MakeBorderForControl(grid)
-            .WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter())
+            .WithBindIsVisible(nameof(vm.IsBatchMode), InverseBooleanConverter.Instance)
             .WithMarginBottom(5)
             .WithMarginRight(5);
     }

--- a/src/ui/Features/Video/Chapters/ChaptersWindow.cs
+++ b/src/ui/Features/Video/Chapters/ChaptersWindow.cs
@@ -301,7 +301,7 @@ public class ChaptersWindow : Window
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center,
             IsHitTestVisible = false,
-            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.HasChapters)) { Converter = new InverseBooleanConverter() },
+            [!Visual.IsVisibleProperty] = new Binding(nameof(vm.HasChapters)) { Converter = InverseBooleanConverter.Instance },
         };
 
         return UiUtil.MakeBorderForControl(new Panel { Children = { tableView, emptyHint } });

--- a/src/ui/Features/Video/Chapters/WriteChaptersToVideoWindow.cs
+++ b/src/ui/Features/Video/Chapters/WriteChaptersToVideoWindow.cs
@@ -77,7 +77,7 @@ public class WriteChaptersToVideoWindow : Window
 
         var buttonWrite = UiUtil.MakeButton(language.WriteToVideo, vm.WriteCommand)
             .WithIconLeft(IconNames.Export)
-            .WithBindIsEnabled(nameof(vm.IsWriting), new InverseBooleanConverter());
+            .WithBindIsEnabled(nameof(vm.IsWriting), InverseBooleanConverter.Instance);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonWrite, buttonCancel);
 

--- a/src/ui/Features/Video/CutVideo/CutVideoWindow.cs
+++ b/src/ui/Features/Video/CutVideo/CutVideoWindow.cs
@@ -53,10 +53,10 @@ public class CutVideoWindow : Window
         checkBoxCutSubtitle[!Visual.IsVisibleProperty] = new Binding(nameof(vm.IsCutSubtitleVisible));
 
         var buttonGenerate = UiUtil.MakeButton(Se.Language.General.Generate, vm.GenerateCommand)
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonConfig = UiUtil.MakeButton(vm.OkCommand, IconNames.Settings, Se.Language.General.Settings)
             .WithMarginRight(5)
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonPanel = UiUtil.MakeButtonBar(
             checkBoxCutSubtitle,
             comboBoxCutType,

--- a/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
+++ b/src/ui/Features/Video/ReEncodeVideo/ReEncodeVideoWindow.cs
@@ -48,9 +48,9 @@ public class ReEncodeVideoWindow : Window
                 }
             }
         };
-        buttonGenerate.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsGenerating)) { Converter = new InverseBooleanConverter() });
+        buttonGenerate.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsGenerating)) { Converter = InverseBooleanConverter.Instance });
 
-        var buttonDone = UiUtil.MakeButtonDone(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+        var buttonDone = UiUtil.MakeButtonDone(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonGenerate,
             buttonDone,
@@ -103,7 +103,7 @@ public class ReEncodeVideoWindow : Window
                 textBoxHeight,
                 buttonResolution,
             }
-        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), new InverseBooleanConverter());
+        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), InverseBooleanConverter.Instance);
 
         var labelSourceResolution = UiUtil.MakeLabel(Se.Language.General.UseSourceResolution).WithBindVisible(vm, nameof(vm.UseSourceResolution));
         var buttonResolutionSource = UiUtil.MakeButtonBrowse(vm.BrowseResolutionCommand, accessibleName: Se.Language.General.Resolution);

--- a/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangesWindow.cs
@@ -29,7 +29,7 @@ public class ShotChangesWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).BindIsEnabled(vm, nameof(vm.IsGenerating), new InverseBooleanConverter());
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).BindIsEnabled(vm, nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
 
@@ -144,12 +144,12 @@ public class ShotChangesWindow : Window
         });
         sliderSensitivity.Bind(Slider.IsEnabledProperty, new Binding(nameof(vm.IsGenerating))
         {
-            Converter = new InverseBooleanConverter(),
+            Converter = InverseBooleanConverter.Instance,
             Source = vm,
             Mode = BindingMode.TwoWay,
         });
         var labelSensitivityValue = UiUtil.MakeLabel(string.Empty).WithBindText(vm, nameof(ShotChangesViewModel.Sensitivity), new DoubleToTwoDecimalConverter());
-        var buttonGenerate = UiUtil.MakeButton(Se.Language.Video.ShotChanges.GenerateShotChangesWithFfmpeg, vm.GenerateShotChangesFfmpegCommand).WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+        var buttonGenerate = UiUtil.MakeButton(Se.Language.Video.ShotChanges.GenerateShotChangesWithFfmpeg, vm.GenerateShotChangesFfmpegCommand).WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var panelSensitivity = new StackPanel
         {
             Orientation = Orientation.Horizontal,

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -635,7 +635,7 @@ public class SpeechToTextWindow : Window
             Source = vm,
             UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
         });
-        textBoxConsoleLog.WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter());
+        textBoxConsoleLog.WithBindIsVisible(nameof(vm.IsBatchMode), InverseBooleanConverter.Instance);
         vm.TextBoxConsoleLogSingle = textBoxConsoleLog;
 
         return textBoxConsoleLog;

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeech/ReviewSpeechWindow.cs
@@ -151,7 +151,7 @@ public class ReviewSpeechWindow : Window
                 buttonHistory.Bind(Button.OpacityProperty, new Binding(nameof(ReviewRow.HistoryButtonOpacity)));
 
                 var buttonPlay = UiUtil.MakeButton(vm.PlayRowCommand,"fa-solid fa-play")
-                .WithBindIsVisible(nameof(item.IsPlaying), new InverseBooleanConverter())
+                .WithBindIsVisible(nameof(item.IsPlaying), InverseBooleanConverter.Instance)
                 .WithBindEnabled(nameof(item.IsPlayingEnabled));
                 buttonPlay.CommandParameter = item;
 

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryWindow.cs
@@ -99,7 +99,7 @@ public class ReviewSpeechHistoryWindow : Window
             CellTemplate = new FuncDataTemplate<ReviewHistoryRow>((item, _) =>
             {
                 var buttonPlay = UiUtil.MakeButton(vm.PlayItemCommand,"fa-solid fa-play")
-                    .WithBindIsVisible(nameof(item.IsPlaying), new InverseBooleanConverter())
+                    .WithBindIsVisible(nameof(item.IsPlaying), InverseBooleanConverter.Instance)
                     .WithBindEnabled(nameof(item.IsPlayingEnabled));
                 buttonPlay.CommandParameter = item;
 

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSubtitlesWindow.cs
@@ -65,15 +65,15 @@ public class TransparentSubtitlesWindow : Window
                 }
             }
         };
-        buttonGenerate.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsGenerating)) { Converter = new InverseBooleanConverter() });
+        buttonGenerate.Bind(SplitButton.IsEnabledProperty, new Binding(nameof(vm.IsGenerating)) { Converter = InverseBooleanConverter.Instance });
 
         var buttonBatchMode = UiUtil.MakeButton(Se.Language.General.BatchMode, vm.BatchModeCommand)
-            .WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter())
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindIsVisible(nameof(vm.IsBatchMode), InverseBooleanConverter.Instance)
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonSingleMode = UiUtil.MakeButton(Se.Language.General.SingleMode, vm.SingleModeCommand)
             .WithBindIsVisible(nameof(vm.IsSingleModeVisible))
-            .WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), new InverseBooleanConverter());
+            .WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindEnabled(nameof(vm.IsGenerating), InverseBooleanConverter.Instance);
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonGenerate,
             buttonBatchMode,
@@ -408,7 +408,7 @@ public class TransparentSubtitlesWindow : Window
                 textBoxHeight,
                 buttonResolution,
             }
-        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), new InverseBooleanConverter());
+        }.WithBindVisible(vm, nameof(vm.UseSourceResolution), InverseBooleanConverter.Instance);
 
         var labelSourceResolution = UiUtil.MakeLabel("Use source resolution").WithBindVisible(vm, nameof(vm.UseSourceResolution));
         var buttonResolutionSource = UiUtil.MakeButtonBrowse(vm.BrowseResolutionCommand, accessibleName: Se.Language.General.Resolution);
@@ -535,7 +535,7 @@ public class TransparentSubtitlesWindow : Window
         vm.VideoPlayerControl.HorizontalAlignment = HorizontalAlignment.Stretch;
         vm.VideoPlayerControl.VerticalAlignment = VerticalAlignment.Stretch;
         vm.VideoPlayerControl.Bind(Visual.IsVisibleProperty,
-            new Binding(nameof(vm.IsBatchMode)) { Source = vm, Converter = new InverseBooleanConverter() });
+            new Binding(nameof(vm.IsBatchMode)) { Source = vm, Converter = InverseBooleanConverter.Instance });
 
         // Batch mode fallback: batch items are separate files (possibly with no video at
         // all), so show a static image rendered from the current style settings instead.
@@ -726,7 +726,7 @@ public class TransparentSubtitlesWindow : Window
         grid.Add(labelVideoSizeValue, 1, 1);
 
         return UiUtil.MakeBorderForControl(grid)
-            .WithBindIsVisible(nameof(vm.IsBatchMode), new InverseBooleanConverter())
+            .WithBindIsVisible(nameof(vm.IsBatchMode), InverseBooleanConverter.Instance)
             .WithMarginRight(5);
     }
 

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -44,7 +44,7 @@ public class VideoOcrWindow : Window
         var progressView = MakeProgressView(vm);
 
         var buttonStart = UiUtil.MakeButton(Se.Language.Video.VideoOcr.StartOcr, vm.StartOcrCommand)
-            .WithBindEnabled(nameof(vm.IsRunning), new InverseBooleanConverter());
+            .WithBindEnabled(nameof(vm.IsRunning), InverseBooleanConverter.Instance);
         var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand)
             .WithBindEnabled(nameof(vm.IsOkEnabled));
         var buttonPanel = UiUtil.MakeButtonBar(
@@ -179,7 +179,7 @@ public class VideoOcrWindow : Window
             Children =
             {
                 UiUtil.MakeButton(Se.Language.Video.VideoOcr.TestOcr, vm.TestOcrCommand)
-                    .WithBindEnabled(nameof(vm.IsRunning), new InverseBooleanConverter()),
+                    .WithBindEnabled(nameof(vm.IsRunning), InverseBooleanConverter.Instance),
             },
         };
 

--- a/src/ui/Logic/ValueConverters/InverseBooleanConverter.cs
+++ b/src/ui/Logic/ValueConverters/InverseBooleanConverter.cs
@@ -6,6 +6,8 @@ namespace Nikse.SubtitleEdit.Logic.ValueConverters;
 
 public class InverseBooleanConverter : IValueConverter
 {
+    public static readonly InverseBooleanConverter Instance = new();
+
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is bool boolValue)


### PR DESCRIPTION
## Summary

`InverseBooleanConverter` is stateless, but 109 bindings each allocated their own instance with `new InverseBooleanConverter()`.

- Expose `public static readonly InverseBooleanConverter Instance` and use it at every site in `src/ui`.
- Behavior is unchanged. Avalonia's built-in `BoolConverters.Not` was considered and rejected: it returns unset for null and throws on `ConvertBack`, whereas this converter returns `false` and round-trips, and several of these bindings are still declared TwoWay.

Note: `refactor/oneway-display-bindings` touches some of the same view lines. Merge one, then rebase the other.

## Test plan

- [x] `UI.csproj` and `UITests.csproj` build in Release with 0 warnings
- [x] `git show` contains no changed line other than the converter swap and the new field
- [ ] Open Batch Convert and start a conversion; confirm the Remove menu item disables while converting and re-enables afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYrDKC6UJJFmDhxQXh7ywg
