### PR TITLE
Bind negated state instead of mirroring it in IsNotX properties

### DIFF
--- a/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantViewModel.cs
@@ -34,7 +34,6 @@ public partial class AiAssistantViewModel : ObservableObject
     [ObservableProperty] private string _resultText;
     [ObservableProperty] private string _statusText;
     [ObservableProperty] private bool _isBusy;
-    [ObservableProperty] private bool _isNotBusy = true;
     [ObservableProperty] private bool _hasResult;
     [ObservableProperty] private string _thinkText = string.Empty;
     [ObservableProperty] private bool _hasThink;
@@ -117,11 +116,6 @@ public partial class AiAssistantViewModel : ObservableObject
     partial void OnSelectedEngineChanged(string value)
     {
         UpdateEngineVisibility();
-    }
-
-    partial void OnIsBusyChanged(bool value)
-    {
-        IsNotBusy = !value;
     }
 
     partial void OnResultTextChanged(string value)

--- a/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
+++ b/src/ui/Features/Main/AiAssistant/AiAssistantWindow.cs
@@ -167,7 +167,7 @@ public class AiAssistantWindow : Window
         };
         var askButton = UiUtil.MakeButton(l.Ask, vm.AskCommand)
             .WithIconLeft("mdi-send")
-            .WithBindEnabled(nameof(vm.IsNotBusy));
+            .WithBindEnabled("!" + nameof(vm.IsBusy));
         var questionRow = new Grid
         {
             ColumnDefinitions = new ColumnDefinitions("*,Auto"),
@@ -331,7 +331,7 @@ public class AiAssistantWindow : Window
     {
         var button = UiUtil.MakeButton(text, command)
             .WithIconLeft(iconName)
-            .WithBindEnabled(nameof(vm.IsNotBusy))
+            .WithBindEnabled("!" + nameof(vm.IsBusy))
             .Compact();
         button.Margin = new Thickness(0, 0, 6, 6);
         return button;

--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -48,7 +48,6 @@ public partial class AiReviewViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(PlayCurrentLineCommand))]
     private ReviewSuggestionItem? _selectedSuggestion;
     [ObservableProperty] private bool _isReviewing;
-    [ObservableProperty] private bool _isNotReviewing = true;
     [ObservableProperty] private double _progressValue;
     [ObservableProperty] private string _statusText;
     [ObservableProperty] private string _reasonText;
@@ -186,11 +185,6 @@ public partial class AiReviewViewModel : ObservableObject
     partial void OnSelectedEngineChanged(string value)
     {
         UpdateEngineVisibility();
-    }
-
-    partial void OnIsReviewingChanged(bool value)
-    {
-        IsNotReviewing = !value;
     }
 
     partial void OnReasonTextChanged(string value)

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -91,7 +91,7 @@ public class AiReviewWindow : Window
         // model's VRAM) could only be released by closing Subtitle Edit (#13969).
         var buttonLlamaCppServer = UiUtil.MakeButton(string.Empty, vm.ToggleLlamaCppServerCommand);
         buttonLlamaCppServer.Bind(Button.ContentProperty, new Binding(nameof(vm.LlamaCppServerButtonText)));
-        buttonLlamaCppServer.Bind(IsEnabledProperty, new Binding(nameof(vm.IsNotReviewing)));
+        buttonLlamaCppServer.Bind(IsEnabledProperty, new Binding("!" + nameof(vm.IsReviewing)));
 
         var panelLlamaCpp = new StackPanel
         {
@@ -463,7 +463,7 @@ public class AiReviewWindow : Window
 
         var buttonReview = UiUtil.MakeButton(l.Review, vm.ReviewCommand)
             .WithIconLeft("fa-solid fa-robot");
-        buttonReview.Bind(IsVisibleProperty, new Binding(nameof(vm.IsNotReviewing)));
+        buttonReview.Bind(IsVisibleProperty, new Binding("!" + nameof(vm.IsReviewing)));
 
         var buttonStop = UiUtil.MakeButton(Se.Language.General.Stop, vm.StopReviewCommand)
             .WithIconLeft("fa-solid fa-stop");

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -97,7 +97,6 @@ public partial class TextToSpeechViewModel : ObservableObject
     [ObservableProperty] private bool _doGenerateVideoFile;
     [ObservableProperty] private bool _isEdgeTtsEngine;
     [ObservableProperty] private bool _isGenerating;
-    [ObservableProperty] private bool _isNotGenerating;
     [ObservableProperty] private bool _isEngineSettingsVisible;
     [ObservableProperty] private bool _isModelDownloadVisible;
     [ObservableProperty] private string _progressText;
@@ -187,7 +186,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         IsVoiceTestEnabled = true;
         IsVoiceComboEnabled = true;
         IsGenerating = false;
-        IsNotGenerating = true;
         KeyFile = string.Empty;
         Instruction = string.Empty;
         CastButtonText = Se.Language.Video.TextToSpeech.SetupCast;
@@ -1012,7 +1010,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         _cancellationTokenSource = new CancellationTokenSource();
         _cancellationToken = _cancellationTokenSource.Token;
         IsGenerating = false;
-        IsNotGenerating = true;
         IsEngineSettingsVisible = false;
         IsModelDownloadVisible = false;
         ProgressText = string.Empty;
@@ -1470,7 +1467,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressEtaText = string.Empty;
         _generateStopwatch.Restart();
         IsGenerating = true;
-        IsNotGenerating = false;
         ProgressOpacity = 1.0;
         SaveSettings();
 
@@ -1571,7 +1567,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         ProgressPercentText = string.Empty;
         ProgressEtaText = string.Empty;
         IsGenerating = false;
-        IsNotGenerating = true;
         ProgressOpacity = 0;
     }
 
@@ -2201,7 +2196,6 @@ public partial class TextToSpeechViewModel : ObservableObject
             ProgressPercentText = string.Empty;
             ProgressEtaText = string.Empty;
             IsGenerating = true;
-            IsNotGenerating = false;
             ProgressOpacity = 1.0;
 
             try
@@ -2407,7 +2401,6 @@ public partial class TextToSpeechViewModel : ObservableObject
         }
 
         IsGenerating = false;
-        IsNotGenerating = true;
         ProgressOpacity = 0;
         OkPressed = true;
 
@@ -2436,7 +2429,6 @@ public partial class TextToSpeechViewModel : ObservableObject
             }
 
             IsGenerating = false;
-            IsNotGenerating = true;
             ProgressOpacity = 0;
             return;
         }

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -91,7 +91,7 @@ public class TextToSpeechWindow : Window
         // checkboxes are read once after generation, and toggling them mid-run is useful
         // (e.g. remembering to enable review during a long run).
         var engineLayout = MakeEngineControls(vm);
-        engineLayout.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsNotGenerating)));
+        engineLayout.Bind(InputElement.IsEnabledProperty, new Binding("!" + nameof(vm.IsGenerating)));
 
         var settingsLayout = MakeSettingsControls(vm);
 
@@ -101,12 +101,12 @@ public class TextToSpeechWindow : Window
 
         // OK accepts the session (the main window applies merged lines and review text edits);
         // Cancel stops a running generation, or - when idle - closes discarding those changes.
-        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindIsVisible(nameof(vm.IsNotGenerating));
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand).WithBindIsVisible("!" + nameof(vm.IsGenerating));
         var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
         var buttonCast = UiUtil.MakeButton(string.Empty, vm.ShowCastCommand)
             .WithIconLeftBindText(IconNames.PoliceBadge, nameof(vm.CastButtonText))
             .WithBindIsVisible(nameof(vm.HasCast))
-            .WithBindIsEnabled(nameof(vm.IsNotGenerating));
+            .WithBindIsEnabled("!" + nameof(vm.IsGenerating));
         if (Se.Settings.Appearance.ShowHints)
         {
             ToolTip.SetTip(buttonCast, Se.Language.Video.TextToSpeech.SetupCastHint);
@@ -115,12 +115,12 @@ public class TextToSpeechWindow : Window
         // all buttons had identical weight and Generate sat first in the row.
         var buttonGenerate = UiUtil.MakeButton(Se.Language.Video.TextToSpeech.GenerateSpeechFromText, vm.GenerateTtsCommand)
             .WithIconLeft(IconNames.Waveform)
-            .WithBindIsEnabled(nameof(vm.IsNotGenerating));
+            .WithBindIsEnabled("!" + nameof(vm.IsGenerating));
         buttonGenerate.Classes.Add("accent");
 
         var buttonPanel = UiUtil.MakeButtonBar(
             buttonCast,
-            UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.ImportCommand).WithBindIsEnabled(nameof(vm.IsNotGenerating)),
+            UiUtil.MakeButton(Se.Language.General.ImportDotDotDot, vm.ImportCommand).WithBindIsEnabled("!" + nameof(vm.IsGenerating)),
             buttonOk,
             buttonCancel,
             buttonGenerate


### PR DESCRIPTION
## Summary

`AiAssistantViewModel`, `AiReviewViewModel` and `TextToSpeechViewModel` each kept an `IsNotX` property mirrored from `IsX` by hand, through `partial void OnIsXChanged` or paired assignments. Avalonia's binding path parser negates with a `!` prefix (already used in `BinaryEditWindow`), so the views can bind `"!" + nameof(vm.IsX)` directly.

- Remove `IsNotBusy`, `IsNotReviewing`, `IsNotGenerating` and their sync code (two partial methods, seven paired assignments).
- Nine bindings in `AiAssistantWindow`, `AiReviewWindow` and `TextToSpeechWindow` negate the real property instead.
- Initial values match: every removed mirror started as `!IsX`.

## Test plan

- [x] `UI.csproj` and `UITests.csproj` build in Release with 0 warnings
- [x] No test references the removed properties
- [ ] AI Assistant: send a prompt and confirm the input controls disable while busy
- [ ] AI Review: start a review and confirm the Review button hides and the llama.cpp server button disables until it finishes
- [ ] Text To Speech: generate and confirm the engine panel, OK, Export and Import controls disable during generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYrDKC6UJJFmDhxQXh7ywg
