### PR TITLE
Use nameof for the remaining string-literal binding paths

### DIFF
--- a/src/ui/Features/Edit/MultipleReplace/FindRuleWindow.cs
+++ b/src/ui/Features/Edit/MultipleReplace/FindRuleWindow.cs
@@ -74,7 +74,7 @@ public class FindRuleWindow : Window
             Header = Se.Language.General.Category,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding("Parent.CategoryName"),
+            Binding = new Binding($"{nameof(RuleTreeNode.Parent)}.{nameof(RuleTreeNode.CategoryName)}"),
             Width = new GridLength(1, GridUnitType.Star),
         };
         var columnFind = new SeTableViewColumn

--- a/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingWindow.cs
+++ b/src/ui/Features/Files/ManualChosenEncoding/ManualChosenEncodingWindow.cs
@@ -89,7 +89,7 @@ public class ManualChosenEncodingWindow : Window
             Header = Se.Language.File.ManualChosenEncoding.CodePage,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding("Encoding.CodePage"),
+            Binding = new Binding($"{nameof(TextEncoding.Encoding)}.{nameof(System.Text.Encoding.CodePage)}"),
             // Content-sized (Auto) on the DataGrid; TableView treats Auto as star.
             Width = new GridLength(100),
         };
@@ -106,7 +106,7 @@ public class ManualChosenEncodingWindow : Window
             Header = Se.Language.General.Group,
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-            Binding = new Binding("Encoding.BodyName"),
+            Binding = new Binding($"{nameof(TextEncoding.Encoding)}.{nameof(System.Text.Encoding.BodyName)}"),
             Width = new GridLength(180),
         };
         dataGrid.Columns.AddRange(new TableViewColumn[] { columnCodePage, columnName, columnGroup });

--- a/src/ui/Features/Video/BurnIn/BurnInLogoWindow.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInLogoWindow.cs
@@ -69,7 +69,7 @@ public class BurnInLogoWindow : Window
             Maximum = 100,
             Width = 150,
             VerticalAlignment = VerticalAlignment.Center,
-            [!Slider.ValueProperty] = new Binding("BurnInLogo.Alpha"),
+            [!Slider.ValueProperty] = new Binding($"{nameof(vm.BurnInLogo)}.{nameof(vm.BurnInLogo.Alpha)}"),
         };
         sliderAlpha.ValueChanged += (_, _) => vm.UpdateOverlayOpacity();
 
@@ -77,7 +77,7 @@ public class BurnInLogoWindow : Window
         labelAlphaValue.VerticalAlignment = VerticalAlignment.Center;
         labelAlphaValue.Margin = new Thickness(5, 0, 0, 0);
         labelAlphaValue.MinWidth = 35;
-        labelAlphaValue[!TextBlock.TextProperty] = new Binding("BurnInLogo.Alpha") { StringFormat = "{0}%" };
+        labelAlphaValue[!TextBlock.TextProperty] = new Binding($"{nameof(vm.BurnInLogo)}.{nameof(vm.BurnInLogo.Alpha)}") { StringFormat = "{0}%" };
 
         // Logo size slider
         var labelSize = UiUtil.MakeLabel(Se.Language.General.Size);
@@ -90,7 +90,7 @@ public class BurnInLogoWindow : Window
             Maximum = 200,
             Width = 150,
             VerticalAlignment = VerticalAlignment.Center,
-            [!Slider.ValueProperty] = new Binding("BurnInLogo.Size"),
+            [!Slider.ValueProperty] = new Binding($"{nameof(vm.BurnInLogo)}.{nameof(vm.BurnInLogo.Size)}"),
         };
         sliderSize.ValueChanged += (_, _) => vm.UpdateLogoSize();
 
@@ -98,7 +98,7 @@ public class BurnInLogoWindow : Window
         labelSizeValue.VerticalAlignment = VerticalAlignment.Center;
         labelSizeValue.Margin = new Thickness(5, 0, 0, 0);
         labelSizeValue.MinWidth = 35;
-        labelSizeValue[!TextBlock.TextProperty] = new Binding("BurnInLogo.Size") { StringFormat = "{0}%" };
+        labelSizeValue[!TextBlock.TextProperty] = new Binding($"{nameof(vm.BurnInLogo)}.{nameof(vm.BurnInLogo.Size)}") { StringFormat = "{0}%" };
 
         topPanel.Children.Add(buttonPickLogo);
         topPanel.Children.Add(labelLogoPosition);

--- a/src/ui/Features/Video/SpeechToText/OpenAiCompatible/TranscriptionProgressWindow.axaml.cs
+++ b/src/ui/Features/Video/SpeechToText/OpenAiCompatible/TranscriptionProgressWindow.axaml.cs
@@ -39,7 +39,7 @@ public class TranscriptionProgressWindow : Window
             Margin = new Thickness(0, 0, 0, 2),
             TextWrapping = TextWrapping.Wrap
         };
-        connectionInfoText.Bind(TextBlock.TextProperty, new Binding("ServerUrl") { StringFormat = Se.Language.General.TranscriptionProgressServerFormat });
+        connectionInfoText.Bind(TextBlock.TextProperty, new Binding(nameof(TranscriptionProgressViewModel.ServerUrl)) { StringFormat = Se.Language.General.TranscriptionProgressServerFormat });
 
         var modelInfoText = new TextBlock
         {
@@ -47,14 +47,14 @@ public class TranscriptionProgressWindow : Window
             Foreground = Brushes.Gray,
             Margin = new Thickness(0, 0, 0, 10)
         };
-        modelInfoText.Bind(TextBlock.TextProperty, new Binding("ModelName") { StringFormat = Se.Language.General.TranscriptionProgressModelFormat });
+        modelInfoText.Bind(TextBlock.TextProperty, new Binding(nameof(TranscriptionProgressViewModel.ModelName)) { StringFormat = Se.Language.General.TranscriptionProgressModelFormat });
 
         var statusText = new TextBlock
         {
             FontWeight = FontWeight.Bold,
             Margin = new Thickness(0, 0, 0, 10)
         };
-        statusText.Bind(TextBlock.TextProperty, new Binding("StatusText"));
+        statusText.Bind(TextBlock.TextProperty, new Binding(nameof(TranscriptionProgressViewModel.StatusText)));
 
         var streamedTextBlock = new TextBlock
         {
@@ -69,14 +69,14 @@ public class TranscriptionProgressWindow : Window
             Padding = new Thickness(5),
             Child = new ScrollViewer { Content = streamedTextBlock }
         };
-        streamedTextBlock.Bind(TextBlock.TextProperty, new Binding("StreamedText"));
+        streamedTextBlock.Bind(TextBlock.TextProperty, new Binding(nameof(TranscriptionProgressViewModel.StreamedText)));
 
         var segmentsList = new ListBox
         {
             MaxHeight = 150,
             Margin = new Thickness(0, 5, 0, 0)
         };
-        segmentsList.Bind(ItemsControl.ItemsSourceProperty, new Binding("ReceivedSegments"));
+        segmentsList.Bind(ItemsControl.ItemsSourceProperty, new Binding(nameof(TranscriptionProgressViewModel.ReceivedSegments)));
 
         var expander = new Expander
         {
@@ -85,7 +85,7 @@ public class TranscriptionProgressWindow : Window
             Content = segmentsList
         };
         expander.Bind(HeaderedContentControl.HeaderProperty,
-            new Binding("SegmentCount") { StringFormat = Se.Language.General.TranscriptionProgressReceivedSegmentsFormat });
+            new Binding(nameof(TranscriptionProgressViewModel.SegmentCount)) { StringFormat = Se.Language.General.TranscriptionProgressReceivedSegmentsFormat });
 
         var cancelButton = new Button
         {
@@ -93,8 +93,8 @@ public class TranscriptionProgressWindow : Window
             HorizontalAlignment = HorizontalAlignment.Right,
             Margin = new Thickness(0, 10, 0, 0)
         };
-        cancelButton.Bind(Button.CommandProperty, new Binding("CancelCommand"));
-        cancelButton.Bind(Button.IsVisibleProperty, new Binding("!IsCompleted"));
+        cancelButton.Bind(Button.CommandProperty, new Binding(nameof(TranscriptionProgressViewModel.CancelCommand)));
+        cancelButton.Bind(Button.IsVisibleProperty, new Binding("!" + nameof(TranscriptionProgressViewModel.IsCompleted)));
 
         var closeButton = new Button
         {
@@ -103,8 +103,8 @@ public class TranscriptionProgressWindow : Window
             Margin = new Thickness(0, 10, 0, 0),
             IsDefault = true
         };
-        closeButton.Bind(Button.CommandProperty, new Binding("CloseCommand"));
-        closeButton.Bind(Button.IsVisibleProperty, new Binding("IsCompleted"));
+        closeButton.Bind(Button.CommandProperty, new Binding(nameof(TranscriptionProgressViewModel.CloseCommand)));
+        closeButton.Bind(Button.IsVisibleProperty, new Binding(nameof(TranscriptionProgressViewModel.IsCompleted)));
 
         var buttonPanel = new StackPanel
         {


### PR DESCRIPTION
## Summary

Seventeen bindings still addressed view-model members with string literals, so a rename would fail silently at runtime instead of at compile time.

- `FindRuleWindow`, `ManualChosenEncodingWindow`, `BurnInLogoWindow`: nested paths become interpolated `nameof` segments (`RuleTreeNode.Parent.CategoryName`, `TextEncoding.Encoding.CodePage/BodyName`, `vm.BurnInLogo.Alpha/Size`).
- `TranscriptionProgressWindow`: ten bindings become `nameof(TranscriptionProgressViewModel.X)`; the negated one keeps the `!` prefix.
- Self-bindings (`new Binding(".")`) are intentional and untouched.

## Test plan

- [x] `UI.csproj` and `UITests.csproj` build in Release with 0 warnings (`nameof` is compile-checked)
- [ ] Multiple Replace > Find rule: category column populates
- [ ] File > Manual chosen encoding: code page and group columns populate
- [ ] Burn-in > Logo: alpha and size sliders update their percentage labels
- [ ] Speech to text with an OpenAI-compatible server: progress window shows server, model, status, segments, and Cancel/Close swap on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYrDKC6UJJFmDhxQXh7ywg
