### PR TITLE
Opt-in: let shortcuts fire on Ctrl+Left/Right and Home/End in text box (#14654)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -28943,9 +28943,20 @@ public partial class MainViewModel :
                 // Bare and Ctrl+Left/Right are fundamental caret navigation in any
                 // text input — never override them with shortcuts even when
                 // "allow single-letter shortcuts in text box" is on (#11357).
+                // Bare Left/Right always stay with the caret; the modified chords (and
+                // Home/End below) are handed to bound shortcuts when the opt-in
+                // AllowTextNavigationShortcutsInTextbox setting is on (#14654).
+                var allowTextNavigationShortcuts = Se.Settings.Tools.AllowTextNavigationShortcutsInTextbox;
                 if ((keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
-                    && (keyEventArgs.KeyModifiers == KeyModifiers.None
-                        || keyEventArgs.KeyModifiers == KeyModifiers.Control
+                    && keyEventArgs.KeyModifiers == KeyModifiers.None)
+                {
+                    _shortcutManager.ClearKeys();
+                    return;
+                }
+
+                if (!allowTextNavigationShortcuts
+                    && (keyEventArgs.Key == Key.Left || keyEventArgs.Key == Key.Right)
+                    && (keyEventArgs.KeyModifiers == KeyModifiers.Control
                         || (OperatingSystem.IsMacOS()
                             && (keyEventArgs.KeyModifiers == KeyModifiers.Alt
                                 || keyEventArgs.KeyModifiers == (KeyModifiers.Shift | KeyModifiers.Alt)))))
@@ -28957,7 +28968,8 @@ public partial class MainViewModel :
                 // Home/End (with or without Ctrl/Cmd/Shift) is likewise standard text editing -
                 // line/document start/end and selection. The "go to first/last line" shortcuts
                 // default to Ctrl+Home/End (#13194) but must stay out of text inputs.
-                if ((keyEventArgs.Key == Key.Home || keyEventArgs.Key == Key.End)
+                if (!allowTextNavigationShortcuts
+                    && (keyEventArgs.Key == Key.Home || keyEventArgs.Key == Key.End)
                     && (keyEventArgs.KeyModifiers & ~(KeyModifiers.Control | KeyModifiers.Shift | KeyModifiers.Meta)) == KeyModifiers.None)
                 {
                     _shortcutManager.ClearKeys();

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -185,6 +185,13 @@ public class SeTools
     public List<string> FindHistory { get; set; } = new List<string>();
     public bool AllowSingleLetterShortcutsInTextbox { get; set; }
 
+    /// <summary>
+    /// Let shortcuts bound to the text-navigation chords (Ctrl+Left/Right, Home/End with or
+    /// without Ctrl/Shift) fire while a text input has focus, instead of reserving those keys
+    /// for caret movement (#11357). Off by default; Settings.json only for now (#14654).
+    /// </summary>
+    public bool AllowTextNavigationShortcutsInTextbox { get; set; }
+
     // Auto-break (auto br) - defaults must match libse ToolsSettings
     public bool AutoBreakLineEndingEarly { get; set; } = false;
     public bool AutoBreakCommaBreakEarly { get; set; } = false;
@@ -265,6 +272,7 @@ public class SeTools
         MultipleReplaceShowDotDotDotButtons = true;
         GridFocusTextboxAfterInsertNew = true;
         AllowSingleLetterShortcutsInTextbox = false;
+        AllowTextNavigationShortcutsInTextbox = false;
         TextToSpeechPromptMergeContinuationLines = true;
         TextToSpeechPromptSkipNoiseLines = true;
         TextToSpeechPromptDetectSpeakers = true;


### PR DESCRIPTION
Fixes #14654 (opt-in).

**Problem:** since #11428 (Ctrl+Left/Right) and #13198 (Home/End), the key handler reserves the text-navigation chords for caret movement whenever a text input has focus. A shortcut like "Move start one frame back/forward" bound to Ctrl+Left/Right therefore never fires from the text box. SE4 had no such guard, which is why the reporter's SE4 video works. The opposite behaviour was explicitly requested in #11357, so this must not simply be reverted.

**Change:**
- New `AllowTextNavigationShortcutsInTextbox` in `SeTools` (Settings.json only, default `false`, no UI or language entries yet).
- When `true`, the Ctrl/Alt+Left/Right and Home/End guards in `MainViewModel` are skipped and the chord falls through to normal shortcut resolution. Unbound chords still reach the text box as usual.
- Bare Left/Right always stay with the caret regardless of the setting.
- Default behaviour is unchanged, so #11357 still holds.

To try it: set `"AllowTextNavigationShortcutsInTextbox": true` under `Tools` in Settings.json and restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
