### PR TITLE
Auto-translate: re-break translated rows that break the line profile

### DIFF
--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -78,7 +78,7 @@ public static partial class MergeAndSplitHelper
 
         if (forceSingleLineMode || mergeResult.ParagraphCount == 1)
         {
-            return ApplySingleLineTranslation(rows, index, formattingList, mergedTranslation, applyRowUpdate);
+            return ApplySingleLineTranslation(rows, target, index, formattingList, mergedTranslation, applyRowUpdate);
         }
 
         return TrySplitStrategies(rows, target, index, tempSubtitle, formattingList, mergeResult, mergedTranslation, applyRowUpdate);
@@ -172,6 +172,7 @@ public static partial class MergeAndSplitHelper
 
     private static int ApplySingleLineTranslation(
         ObservableCollection<TranslateRow> rows,
+        TranslationPair target,
         int index,
         List<Formatting> formattingList,
         string mergedTranslation,
@@ -181,7 +182,7 @@ public static partial class MergeAndSplitHelper
         // caller's no-progress counter, so the retry never fired and the row was left blank.
         if (index < rows.Count && formattingList.Count > 0 && !string.IsNullOrWhiteSpace(mergedTranslation))
         {
-            applyRowUpdate(() => rows[index].TranslatedText = formattingList[0].ReAddFormatting(mergedTranslation));
+            applyRowUpdate(() => rows[index].TranslatedText = RebalanceLines(formattingList[0].ReAddFormatting(mergedTranslation), target));
             return 1;
         }
         return 0;
@@ -207,7 +208,7 @@ public static partial class MergeAndSplitHelper
         if (IsSplitValid(splitResult, mergeCount, sourceTexts, index) &&
             HasMatchingPeriodCount(mergeResult.Text, mergedTranslation, sourceAbbreviations, targetAbbreviations))
         {
-            return ApplySplitResult(rows, index, formattingList, splitResult, applyRowUpdate);
+            return ApplySplitResult(rows, target, index, formattingList, splitResult, applyRowUpdate);
         }
 
         // Strategy 2: Split per number of lines
@@ -223,7 +224,7 @@ public static partial class MergeAndSplitHelper
         if (IsSplitValid(splitResult, mergeCount, sourceTexts, index) &&
             HasMatchingPeriodCount(mergeResult.Text, noPeriodsInNumbersTranslation, sourceAbbreviations, targetAbbreviations))
         {
-            return ApplySplitResult(rows, index, formattingList, splitResult, applyRowUpdate, restorePeriodPlaceholder: true);
+            return ApplySplitResult(rows, target, index, formattingList, splitResult, applyRowUpdate, restorePeriodPlaceholder: true);
         }
 
         // Strategy 4: Split by line ending chars (relaxed - no period count check). Without
@@ -236,7 +237,7 @@ public static partial class MergeAndSplitHelper
         if (IsSplitValid(splitResult, mergeCount, sourceTexts, index) &&
             HasPlausibleProportions(mergeResult, splitResult))
         {
-            return ApplySplitResult(rows, index, formattingList, splitResult, applyRowUpdate);
+            return ApplySplitResult(rows, target, index, formattingList, splitResult, applyRowUpdate);
         }
 
         MergeSplitProblems = true;
@@ -378,6 +379,7 @@ public static partial class MergeAndSplitHelper
 
     private static int ApplySplitResult(
         ObservableCollection<TranslateRow> rows,
+        TranslationPair target,
         int index,
         List<Formatting> formattingList,
         List<string> splitResult,
@@ -397,7 +399,7 @@ public static partial class MergeAndSplitHelper
                 }
 
                 var text = restorePeriodPlaceholder ? line.Replace(PeriodPlaceholder, '.') : line;
-                rows[index].TranslatedText = formattingList[idx].ReAddFormatting(text);
+                rows[index].TranslatedText = RebalanceLines(formattingList[idx].ReAddFormatting(text), target);
                 index++;
                 linesTranslated++;
                 idx++;
@@ -453,7 +455,7 @@ public static partial class MergeAndSplitHelper
                 }
             });
 
-            return ApplyFormattingToExistingTranslations(rows, index, formattingList, mergeResult.ParagraphCount, applyRowUpdate);
+            return ApplyFormattingToExistingTranslations(rows, target, index, formattingList, mergeResult.ParagraphCount, applyRowUpdate);
         }
 
         return 0;
@@ -490,6 +492,7 @@ public static partial class MergeAndSplitHelper
 
     private static int ApplyFormattingToExistingTranslations(
         ObservableCollection<TranslateRow> rows,
+        TranslationPair target,
         int index,
         List<Formatting> formattingList,
         int count,
@@ -506,7 +509,7 @@ public static partial class MergeAndSplitHelper
                     break;
                 }
 
-                rows[index].TranslatedText = formattingList[i].ReAddFormatting(rows[index].TranslatedText);
+                rows[index].TranslatedText = RebalanceLines(formattingList[i].ReAddFormatting(rows[index].TranslatedText), target);
                 index++;
                 linesTranslated++;
             }
@@ -1275,6 +1278,34 @@ public static partial class MergeAndSplitHelper
         public double Cps2 { get; init; }
         public SplitStrategy Strategy { get; init; }
         public double Score { get; set; }
+    }
+
+    /// <summary>
+    /// Re-breaks a translated row that violates the active profile: more lines than
+    /// "maximum number of lines", or a line longer than "single line maximum length".
+    /// Engines keep the source's line breaks and add their own, so a two-line French source
+    /// came back as three short Dutch lines that no tool would fix, since none of them was
+    /// too long on its own (#14673). A result that already fits is left untouched so
+    /// intentional breaks and dialog layouts survive; CJK targets are never re-broken.
+    /// </summary>
+    public static string RebalanceLines(string text, TranslationPair target)
+    {
+        if (string.IsNullOrWhiteSpace(text) || IsNonMergeLanguage(target))
+        {
+            return text;
+        }
+
+        var maxLines = Configuration.Settings.General.MaxNumberOfLines;
+        var maxLineLength = Configuration.Settings.General.SubtitleLineMaximumLength;
+        var lines = HtmlUtil.RemoveHtmlTags(text, true).SplitToLines();
+        if (lines.Count <= maxLines && lines.All(l => l.Length <= maxLineLength))
+        {
+            return text;
+        }
+
+        var language = target.TwoLetterIsoLanguageName ?? target.Code;
+        var rebalanced = Utilities.AutoBreakLine(Utilities.UnbreakLine(text), language);
+        return string.IsNullOrWhiteSpace(rebalanced) ? text : rebalanced;
     }
 
     private static bool IsNonMergeLanguage(TranslationPair language)

--- a/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
+++ b/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
@@ -1,4 +1,5 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.UiLogic.Translate;
 
@@ -269,5 +270,77 @@ public class MergeAndSplitHelperTests
         Assert.Equal(2, count);
         Assert.Equal("A city runabout?" + Environment.NewLine + "Really, I mean it.", rows[0].TranslatedText);
         Assert.Equal("Yes, Mr. Smith.", rows[1].TranslatedText);
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_ThreeLineReplyIsRebalancedToProfile()
+    {
+        // #14673: a two-line source whose first line ends in a comma is not un-broken, the
+        // engine keeps the break and adds one of its own, and the 47-char result sat on
+        // three lines that no long-line tool would touch.
+        var previousMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        var previousMaxLength = Configuration.Settings.General.SubtitleLineMaximumLength;
+        Configuration.Settings.General.MaxNumberOfLines = 2;
+        Configuration.Settings.General.SubtitleLineMaximumLength = 42;
+        try
+        {
+            var rows = MakeRows("Comme vous le savez," + Environment.NewLine + "personne ne peut aller au-delà du récif.");
+            var translator = new FixedResultTranslator { Result = "Zoals je weet," + Environment.NewLine + "kan niemand" + Environment.NewLine + "voorbij het rif komen." };
+
+            var count = await MergeAndSplitHelper.MergeAndTranslateIfPossible(
+                rows,
+                new TranslationPair("French", "fr"),
+                new TranslationPair("Dutch", "nl"),
+                0,
+                translator,
+                false,
+                CancellationToken.None);
+
+            Assert.Equal(1, count);
+            Assert.Equal("Zoals je weet, kan niemand" + Environment.NewLine + "voorbij het rif komen.", rows[0].TranslatedText);
+        }
+        finally
+        {
+            Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
+            Configuration.Settings.General.SubtitleLineMaximumLength = previousMaxLength;
+        }
+    }
+
+    [Theory]
+    [InlineData("Zoals je weet, kan niemand\nvoorbij het rif komen.")]
+    [InlineData("- Ga je mee?\n- Nee, ik blijf hier.")]
+    [InlineData("<i>Zoals je weet,</i>\nkan niemand het.")]
+    public void RebalanceLines_LeavesResultsThatFitTheProfileAlone(string text)
+    {
+        var previousMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        var previousMaxLength = Configuration.Settings.General.SubtitleLineMaximumLength;
+        Configuration.Settings.General.MaxNumberOfLines = 2;
+        Configuration.Settings.General.SubtitleLineMaximumLength = 42;
+        try
+        {
+            var input = text.Replace("\n", Environment.NewLine);
+            Assert.Equal(input, MergeAndSplitHelper.RebalanceLines(input, new TranslationPair("Dutch", "nl")));
+        }
+        finally
+        {
+            Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
+            Configuration.Settings.General.SubtitleLineMaximumLength = previousMaxLength;
+        }
+    }
+
+    [Fact]
+    public void RebalanceLines_SkipsCjkTargets()
+    {
+        var previousMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        Configuration.Settings.General.MaxNumberOfLines = 2;
+        try
+        {
+            var input = "一" + Environment.NewLine + "二" + Environment.NewLine + "三";
+            Assert.Equal(input, MergeAndSplitHelper.RebalanceLines(input, new TranslationPair("Chinese", "zh")));
+        }
+        finally
+        {
+            Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
+        }
     }
 }


### PR DESCRIPTION
Fixes #14673

## Problem
Auto-translate often produced three-line rows even when the text fit in two. A two-line source whose first line ends in a comma is not un-broken before sending, the engine keeps that break and adds its own, and the result is stored as-is. None of the lines exceeds the single-line limit, so "split/rebalance long lines" does not touch it either. SE4 ran `AutoBreakLine` on every translated row; SE5 dropped that.

## Fix
`MergeAndSplitHelper.RebalanceLines` runs after `ReAddFormatting` at all three places a translated row is written. When the row has more lines than *maximum number of lines* or a line longer than *single line maximum length*, it is un-broken and auto-broken with the target language. Rows that already fit are left untouched, so intentional breaks and dialog layouts survive. CJK targets are skipped, matching the existing merge gate.

Reporter's example now yields:
```
Zoals je weet, kan niemand
voorbij het rif komen.
```

## Tests
- End-to-end through `MergeAndTranslateIfPossible` with the reporter's French/Dutch example.
- Fitting two-line, dialog, and italic rows are left alone.
- CJK target is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)