### PR TITLE
Waveform original overlay: do not cull a long cue overlapped by a shorter one

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -226,6 +226,13 @@ public class AudioVisualizer : Control
     public bool ShowOriginalSubtitleOverlay { get; set; }
 
     private readonly List<WaveformOriginalSubtitleCue> _originalSubtitleCues = new();
+
+    /// <summary>
+    /// Running maximum of <see cref="WaveformOriginalSubtitleCue.EndSeconds"/> over the cues in
+    /// file order. Cues overlap (SDH music lines spanning dialogue, signs), so their end times are
+    /// not monotonic and cannot be binary-searched directly; the running maximum is.
+    /// </summary>
+    private readonly List<double> _originalSubtitleCueMaxEnds = new();
     private const double OriginalSubtitleOpacity = 0.5;
     private bool IsOriginalSubtitleOverlayVisible => ShowOriginalSubtitleOverlay && _originalSubtitleCues.Count > 0;
     private bool ShowOriginalTextInWaveform => ShowOriginalText && !IsOriginalSubtitleOverlayVisible;
@@ -233,9 +240,16 @@ public class AudioVisualizer : Control
     public void SetOriginalSubtitleCues(IReadOnlyList<WaveformOriginalSubtitleCue>? cues)
     {
         _originalSubtitleCues.Clear();
+        _originalSubtitleCueMaxEnds.Clear();
         if (cues != null)
         {
             _originalSubtitleCues.AddRange(cues);
+            var maxEnd = double.MinValue;
+            foreach (var cue in cues)
+            {
+                maxEnd = Math.Max(maxEnd, cue.EndSeconds);
+                _originalSubtitleCueMaxEnds.Add(maxEnd);
+            }
         }
 
         InvalidateVisual();
@@ -3440,7 +3454,9 @@ public class AudioVisualizer : Control
     {
         var start = renderCtx.StartPositionSeconds;
         var end = RelativeXPositionToSecondsOptimized(renderCtx.Width, renderCtx.SampleRate, start, renderCtx.ZoomFactor);
-        var startIndex = FindFirstIndexAfterTime(_originalSubtitleCues, start, static cue => cue.EndSeconds);
+        // A long cue overlapped by a shorter one ends after its successor, so searching the raw
+        // end times from the viewport start would skip it whenever the view begins inside it.
+        var startIndex = FindFirstIndexAfterTime(_originalSubtitleCueMaxEnds, start, static maxEnd => maxEnd);
         var lastStart = -1d;
         var count = 0;
 

--- a/tests/UI/Controls/AudioVisualizerOriginalOverlayCullTests.cs
+++ b/tests/UI/Controls/AudioVisualizerOriginalOverlayCullTests.cs
@@ -1,0 +1,91 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Media;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// The original-subtitle overlay culls cues with a binary search on end times. Original cues are in
+/// file order (by start), and a long cue overlapped by a shorter one ends after its successor, so a
+/// search on the raw end times skipped the long cue whenever the viewport began inside it.
+/// </summary>
+public class AudioVisualizerOriginalOverlayCullTests
+{
+    private const int SampleRate = 126; // px per second at zoom 1
+    private const double WidthPx = 800;
+    private const double HeightPx = 200;
+
+    [AvaloniaFact]
+    public void LongCueOverlappedByShorterOne_IsDrawnWhenTheViewStartsInsideIt()
+    {
+        var av = new AudioVisualizer { WavePeaks = MakePeaks(60), ShowOriginalSubtitleOverlay = true };
+        var window = new Window
+        {
+            Width = WidthPx,
+            Height = HeightPx,
+            Content = av,
+        };
+
+        window.Show();
+        window.UpdateLayout();
+
+        try
+        {
+            var noLines = new List<SubtitleLineViewModel>();
+            var noSelection = new List<SubtitleLineViewModel>();
+
+            // Viewport starts at 6.5 s: A covers all of it, B and C are both out of view.
+            var longCue = new WaveformOriginalSubtitleCue(0, 30, "♪ music ♪");
+            var shortCueInsideLong = new WaveformOriginalSubtitleCue(5, 6, "Hi.");
+            var cueAfterView = new WaveformOriginalSubtitleCue(31, 32, "Bye.");
+
+            av.SetPosition(6.5, noLines, 0, -1, noSelection);
+
+            av.SetOriginalSubtitleCues(new[] { longCue });
+            var onlyLongCue = Capture(window);
+
+            av.SetOriginalSubtitleCues(new[] { longCue, shortCueInsideLong, cueAfterView });
+            var withOverlap = Capture(window);
+
+            Assert.Equal(onlyLongCue, withOverlap);
+
+            // Control: the frame really depends on the long cue being drawn.
+            av.SetOriginalSubtitleCues(new[] { shortCueInsideLong, cueAfterView });
+            Assert.NotEqual(onlyLongCue, Capture(window));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static WavePeakData2 MakePeaks(int seconds)
+    {
+        var peaks = new WavePeak2[SampleRate * seconds];
+        for (var i = 0; i < peaks.Length; i++)
+        {
+            peaks[i] = new WavePeak2(200, -200);
+        }
+
+        return new WavePeakData2(SampleRate, peaks);
+    }
+
+    private static byte[] Capture(Window window)
+    {
+        Dispatcher.UIThread.RunJobs();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+
+        using var frame = window.CaptureRenderedFrame()!;
+        using var stream = new MemoryStream();
+        frame.Save(stream, PngBitmapEncoderOptions.Default);
+        return stream.ToArray();
+    }
+}


### PR DESCRIPTION
Follow-up to #14620.

The original-subtitle overlay culls cues with a binary search on end times from the viewport start. Original cues are in file order, so a long cue overlapped by a shorter one (an SDH "♪ music ♪" line spanning dialogue, a sign) ends after its successor and the end times are not monotonic. With cues A 0–30 s, B 5–6 s, C 31–32 s and the view starting at 6.5 s, the search landed on C and A was never drawn although it covers the whole viewport.

The fix keeps a running maximum of the end times next to the cue list (computed once in `SetOriginalSubtitleCues`) and searches that instead. Headless render test added; it fails on main and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)