### PR TITLE
Tesseract OCR: match retry-merge unknown words whole, not as substrings

### DIFF
--- a/src/ui/Features/Ocr/Engines/TesseractOcr.cs
+++ b/src/ui/Features/Ocr/Engines/TesseractOcr.cs
@@ -163,11 +163,48 @@ public class TesseractOcr
         return changed ? string.Concat(first) : null;
     }
 
+    /// <summary>
+    /// Whole-word match: the token is unknown when one of its words (the runs between punctuation
+    /// and tags, e.g. "diedq" in "diedq,") equals a flagged word. A substring test would let a lone
+    /// unknown "l" claim nearly every English token and replace words the dictionary accepted.
+    /// </summary>
     private static bool ContainsUnknownWord(string token, IReadOnlyCollection<string> unknownWords)
+    {
+        var start = -1;
+        for (var i = 0; i <= token.Length; i++)
+        {
+            // Same word characters as OcrFixEngine.SplitLine, which produced the unknown words.
+            var isWordChar = i < token.Length && (char.IsLetterOrDigit(token[i]) || token[i] == '\'' || token[i] == '’' || token[i] == '-');
+            if (isWordChar)
+            {
+                if (start < 0)
+                {
+                    start = i;
+                }
+
+                continue;
+            }
+
+            if (start >= 0)
+            {
+                var word = token.AsSpan(start, i - start);
+                if (IsUnknownWord(word, unknownWords) || IsUnknownWord(word.Trim("'’-"), unknownWords))
+                {
+                    return true;
+                }
+
+                start = -1;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUnknownWord(ReadOnlySpan<char> word, IReadOnlyCollection<string> unknownWords)
     {
         foreach (var unknown in unknownWords)
         {
-            if (unknown.Length > 0 && token.Contains(unknown, StringComparison.Ordinal))
+            if (word.Length > 0 && word.Equals(unknown.AsSpan(), StringComparison.Ordinal))
             {
                 return true;
             }

--- a/tests/UI/Features/Ocr/Engines/TesseractOcrPrepareImageTests.cs
+++ b/tests/UI/Features/Ocr/Engines/TesseractOcrPrepareImageTests.cs
@@ -65,6 +65,24 @@ public class TesseractOcrPrepareImageTests
     }
 
     [Fact]
+    public void MergeRetryUnknownWords_MatchesUnknownWordsWhole_NotAsSubstrings()
+    {
+        // A lone "l" (misread "I") is the most common unknown word, and nearly every token contains
+        // an "l" - it must only claim the token that IS "l", not "fell".
+        var merged = TesseractOcr.MergeRetryUnknownWords("l fell 18 times", "I fall 718 times", new[] { "l" });
+
+        Assert.Equal("I fell 18 times", merged);
+    }
+
+    [Theory]
+    [InlineData("<i>diedq,</i>", "<i>died,</i>", "diedq", "<i>died,</i>")]
+    [InlineData("didn'tq.", "didn't.", "didn'tq", "didn't.")]
+    public void MergeRetryUnknownWords_MatchesThroughPunctuationAndTags(string firstPass, string retry, string unknown, string expected)
+    {
+        Assert.Equal(expected, TesseractOcr.MergeRetryUnknownWords(firstPass, retry, new[] { unknown }));
+    }
+
+    [Fact]
     public void MergeRetryUnknownWords_KeepsLineBreaks()
     {
         var merged = TesseractOcr.MergeRetryUnknownWords("-Yeanh.\n-You've got nothing.", "-Yeah.\n-You've got nothing.", new[] { "Yeanh" });


### PR DESCRIPTION
Follow-up to #14645.

`MergeRetryUnknownWords` is documented as taking only the tokens the dictionary flagged from the retry pass, but `ContainsUnknownWord` used a substring `Contains`. The most common unknown token from a Tesseract first pass is a lone `l` (misread `I`), and nearly every English token contains an `l`, so dictionary-accepted words were overwritten by the retry too. First pass `l fell 18 times`, retry `I fall 718 times`, unknown `["l"]` produced `I fall 18 times`; the merged-score gate cannot catch it because `fall` is also a dictionary word.

Now a token is unknown only when one of its words (the runs of letters, digits, apostrophes and hyphens, same as `OcrFixEngine.SplitLine`) equals a flagged word, so `diedq,` and `<i>diedq,</i>` still match `diedq` while `fell` no longer matches `l`. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)