### PR TITLE
Auto-translate: do not re-break lyrics or CJK results

### DIFF
--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Text;
 using System.Text.RegularExpressions;
 using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
 using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common.TextLengthCalculator;
 using Nikse.SubtitleEdit.Core.Dictionaries;
 using Nikse.SubtitleEdit.Core.Settings;
 using Nikse.SubtitleEdit.UiLogic.Translate;
@@ -1290,7 +1292,14 @@ public static partial class MergeAndSplitHelper
     /// </summary>
     public static string RebalanceLines(string text, TranslationPair target)
     {
-        if (string.IsNullOrWhiteSpace(text) || IsNonMergeLanguage(target))
+        if (string.IsNullOrWhiteSpace(text) || IsNonMergeLanguage(target) || IsCjkTarget(target) || ContainsCjk(text))
+        {
+            return text;
+        }
+
+        // Lyrics keep one line per phrase; AutoBreakLine's own ♪ guard only fires on text that
+        // still holds line breaks, which the UnbreakLine below removes, so guard here.
+        if (text.IndexOf('♪') >= 0 || text.IndexOf('♫') >= 0)
         {
             return text;
         }
@@ -1306,6 +1315,38 @@ public static partial class MergeAndSplitHelper
         var language = target.TwoLetterIsoLanguageName ?? target.Code;
         var rebalanced = Utilities.AutoBreakLine(Utilities.UnbreakLine(text), language);
         return string.IsNullOrWhiteSpace(rebalanced) ? text : rebalanced;
+    }
+
+    /// <summary>
+    /// CJK targets by code: the engines emit many variants ("zh-Hans", "zh-HK", "yue", "kor",
+    /// "th") beyond the handful <see cref="IsNonMergeLanguage"/> knows, and re-breaking any of
+    /// them inserts ASCII spaces into text that has none.
+    /// </summary>
+    private static bool IsCjkTarget(TranslationPair language)
+    {
+        var code = (language.TwoLetterIsoLanguageName ?? language.Code ?? string.Empty).ToLowerInvariant();
+        return code.StartsWith("zh", StringComparison.Ordinal) ||
+               code.StartsWith("zho", StringComparison.Ordinal) ||
+               code.StartsWith("yue", StringComparison.Ordinal) ||
+               code.StartsWith("ja", StringComparison.Ordinal) ||
+               code.StartsWith("jpn", StringComparison.Ordinal) ||
+               code.StartsWith("ko", StringComparison.Ordinal) ||
+               code.StartsWith("kor", StringComparison.Ordinal) ||
+               code.StartsWith("th", StringComparison.Ordinal) ||
+               code.StartsWith("tha", StringComparison.Ordinal);
+    }
+
+    private static bool ContainsCjk(string text)
+    {
+        foreach (var c in text)
+        {
+            if (CalcCjk.IsCjk(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsNonMergeLanguage(TranslationPair language)

--- a/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
+++ b/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
@@ -328,6 +328,59 @@ public class MergeAndSplitHelperTests
         }
     }
 
+    [Theory]
+    [InlineData("zh-Hans")]
+    [InlineData("zh-HK")]
+    [InlineData("yue")]
+    [InlineData("ko")]
+    [InlineData("th")]
+    public void RebalanceLines_SkipsEveryCjkTargetCode(string code)
+    {
+        var previousMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        Configuration.Settings.General.MaxNumberOfLines = 2;
+        try
+        {
+            var input = "abc" + Environment.NewLine + "def" + Environment.NewLine + "ghi";
+            Assert.Equal(input, MergeAndSplitHelper.RebalanceLines(input, new TranslationPair("X", code)));
+        }
+        finally
+        {
+            Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
+        }
+    }
+
+    [Fact]
+    public void RebalanceLines_SkipsCjkTextWhateverTheCode()
+    {
+        var previousMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        Configuration.Settings.General.MaxNumberOfLines = 2;
+        try
+        {
+            var input = "你好世界" + Environment.NewLine + "我很好" + Environment.NewLine + "谢谢你";
+            Assert.Equal(input, MergeAndSplitHelper.RebalanceLines(input, new TranslationPair("Dutch", "nl")));
+        }
+        finally
+        {
+            Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
+        }
+    }
+
+    [Fact]
+    public void RebalanceLines_LeavesLyricsAlone()
+    {
+        var previousMaxLines = Configuration.Settings.General.MaxNumberOfLines;
+        Configuration.Settings.General.MaxNumberOfLines = 2;
+        try
+        {
+            var input = "♪ La la la ♪" + Environment.NewLine + "♪ La la ♪" + Environment.NewLine + "♪ La ♪";
+            Assert.Equal(input, MergeAndSplitHelper.RebalanceLines(input, new TranslationPair("French", "fr")));
+        }
+        finally
+        {
+            Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
+        }
+    }
+
     [Fact]
     public void RebalanceLines_SkipsCjkTargets()
     {


### PR DESCRIPTION
Follow-up to #14681.

Two gaps in `RebalanceLines`:

- It calls `UnbreakLine` before `AutoBreakLine`, so the ♪/dialog guards inside `AutoBreakLine` (which only fire on text that still holds line breaks) never see the lyric layout. `♪ La la la ♪` / `♪ La la ♪` / `♪ La ♪` came back as one line with `♪ ♪` seams. Rows holding ♪ or ♫ are now left alone.
- The CJK skip reused `IsNonMergeLanguage`, which knows only `zh`, `zh-cn`, `zh-tw`, `yue_hant`, `zho_*`, `jpn_jpan` and `ja`. The engines also emit `zh-Hans`, `zh-Hant`, `zh-HK`, `yue`, `ko` and `th`, and any 3-line Chinese result for those became one line with ASCII spaces inside the text. Now every CJK code prefix is skipped, and so is any text containing CJK characters regardless of the code.

Tests added for lyrics, the extra codes and CJK content under a non-CJK code; they fail on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)