### PR TITLE
Qwen3 ASR CPP: opening marks and dialog dashes start the next cue

### DIFF
--- a/src/ui/Features/Video/SpeechToText/Qwen3AsrWordSegmenter.cs
+++ b/src/ui/Features/Video/SpeechToText/Qwen3AsrWordSegmenter.cs
@@ -41,6 +41,7 @@ public static class Qwen3AsrWordSegmenter
     private const string ClauseTerminators = ",;:，、；：";
     private const string ClosingMarks = "\"'”’)]】」』）";
     private const string NoSpaceBefore = ".,!?;:%)]}」』】）…" + "，。！？、；：";
+    private const string NoSpaceAfter = "“‘([{「『【（《〈¿¡";
 
     public static Subtitle BuildSubtitle(IReadOnlyList<Qwen3AsrWord> words, int maxCharsLatin = DefaultMaxCharsLatin, int maxCharsCjk = DefaultMaxCharsCjk)
     {
@@ -72,10 +73,11 @@ public static class Qwen3AsrWordSegmenter
             var breakAfter = raw.Contains('\n');
 
             var isPunctuationOnly = IsPunctuationOnly(token);
-            if (text.Length == 0 && isPunctuationOnly && subtitle.Paragraphs.Count > 0)
+            if (text.Length == 0 && isPunctuationOnly && subtitle.Paragraphs.Count > 0 && ClosesText(token))
             {
-                // A stray mark right after a sentence break (e.g. a closing quote emitted as
-                // its own token) belongs to the cue that was just closed, not to a new one.
+                // A stray closing mark right after a sentence break (e.g. a closing quote emitted
+                // as its own token) belongs to the cue that was just closed, not to a new one.
+                // An opening mark or a dialog dash ("「", "“", "-") opens the next cue instead.
                 var last = subtitle.Paragraphs[subtitle.Paragraphs.Count - 1];
                 last.Text += token;
                 if (word.EndSeconds * 1000.0 > last.EndTime.TotalMilliseconds)
@@ -131,7 +133,7 @@ public static class Qwen3AsrWordSegmenter
 
     private static bool NeedsSpace(char previous, char next)
     {
-        if (char.IsWhiteSpace(previous) || NoSpaceBefore.IndexOf(next) >= 0)
+        if (char.IsWhiteSpace(previous) || NoSpaceBefore.IndexOf(next) >= 0 || NoSpaceAfter.IndexOf(previous) >= 0)
         {
             return false;
         }
@@ -157,6 +159,12 @@ public static class Qwen3AsrWordSegmenter
         }
 
         return i >= 0 && SentenceTerminators.IndexOf(token[i]) >= 0;
+    }
+
+    /// <summary>True when the token starts with a closing mark or a terminator, i.e. it attaches to what came before it.</summary>
+    private static bool ClosesText(string token)
+    {
+        return ClosingMarks.IndexOf(token[0]) >= 0 || NoSpaceBefore.IndexOf(token[0]) >= 0;
     }
 
     private static bool IsPunctuationOnly(string token)

--- a/tests/UI/Features/Video/SpeechToText/Qwen3AsrWordSegmenterTests.cs
+++ b/tests/UI/Features/Video/SpeechToText/Qwen3AsrWordSegmenterTests.cs
@@ -151,6 +151,50 @@ public class Qwen3AsrWordSegmenterTests
     }
 
     [Fact]
+    public void OpeningMark_AfterSentenceBreak_StartsTheNextCue()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("你", 0.0, 0.2), W("好", 0.2, 0.4), W("。", 0.4, 0.4),
+            W("「", 0.5, 0.5), W("我", 0.5, 0.7), W("来", 0.7, 0.9), W("了", 0.9, 1.1), W("。", 1.1, 1.1), W("」", 1.1, 1.2),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "你好。", "「我来了。」" }, subtitle.Paragraphs.Select(p => p.Text));
+        Assert.Equal(400, subtitle.Paragraphs[0].EndTime.TotalMilliseconds);
+        Assert.Equal(500, subtitle.Paragraphs[1].StartTime.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void DialogDash_AfterSentenceBreak_StartsTheNextCue()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("-", 0.0, 0.0), W("Hi.", 0.0, 0.3),
+            W("-", 0.5, 0.5), W("Hello.", 0.5, 0.9),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "- Hi.", "- Hello." }, subtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    [Fact]
+    public void OpeningCurlyQuote_AfterSentenceBreak_StartsTheNextCue()
+    {
+        var words = new List<Qwen3AsrWord>
+        {
+            W("He", 0.0, 0.2), W("said.", 0.2, 0.4),
+            W("“", 0.5, 0.5), W("Go", 0.5, 0.7), W("home.", 0.7, 0.9), W("”", 0.9, 1.0),
+        };
+
+        var subtitle = Qwen3AsrWordSegmenter.BuildSubtitle(words);
+
+        Assert.Equal(new[] { "He said.", "“Go home.”" }, subtitle.Paragraphs.Select(p => p.Text));
+    }
+
+    [Fact]
     public void NewlineInsideToken_ForcesBreak()
     {
         var words = new List<Qwen3AsrWord>


### PR DESCRIPTION
Follow-up to #14632.

The segmenter attaches a punctuation-only token that arrives on an empty buffer to the previous cue, so a closing quote emitted as its own token after "。" lands on the right cue. It did that for every mark, opening ones included. With CJK punctuation arriving as separate tokens (which the aligner does), `你 好 。 「 我 来 了 。 」` became `你好。「` and `我来了。」`, `He said. “ Go home. ”` became `He said.“` and `Go home.”`, and `- Hi. - Hello.` became `- Hi.-` and `Hello.`.

Now only tokens that start with a closing mark or a terminator attach backwards; an opening mark or a dialog dash opens the next cue. Opening marks also no longer get a space after them (`“Go home.”`, not `“ Go home.”`). Three tests added; they fail on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)