### PR TITLE
OCR fix engine: apostrophe straightening honors "use hardcoded rules" and only collapses its own pair

### DIFF
--- a/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
+++ b/src/libuilogic/Ocr/FixEngine/OcrFixEngine.cs
@@ -77,7 +77,11 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
         var wordsToIgnore = new List<string>();
 
         var replacedLine = ReplaceLineFixes(index, text, wordsToIgnore);
-        replacedLine = NormalizeApostrophes(replacedLine);
+        if (Configuration.Settings.Tools.OcrFixUseHardcodedRules)
+        {
+            replacedLine = NormalizeApostrophes(replacedLine);
+        }
+
         replacedLine = FixStartWithUppercaseLetterAfterSentenceEnd(index, replacedLine);
         var splitLine = SplitLine(replacedLine, index);
         if (replacedLine != text)
@@ -204,9 +208,11 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
 
     /// <summary>
     /// Tesseract emits typographic single quotes for apostrophes ("‘cause", "didn’t"); subtitles
-    /// use the plain apostrophe, and SE4 straightened them too. A line holding both an opening
-    /// and a closing curly quote is quoting something ("La lettera ‘E’") and is left alone. Runs
-    /// after the replace list so entries written with the curly forms still match.
+    /// use the plain apostrophe. A line holding both an opening and a closing curly quote is
+    /// quoting something ("La lettera ‘E’") and is left alone. Runs after the replace list so
+    /// entries written with the curly forms still match. Like the per-word straightening in
+    /// <see cref="OcrFixReplaceList2.FixCommonWordErrors"/> it is one of the hardcoded rules, so
+    /// "use hardcoded rules" turns both off together.
     /// </summary>
     internal static string NormalizeApostrophes(string text)
     {
@@ -222,8 +228,10 @@ public partial class OcrFixEngine : IOcrFixEngine, IDoSpell
             return text; // neither, or a quotation pair
         }
 
-        // Tesseract also emits both forms side by side ("'‘cause", "ma‘'am") - collapse the pair.
-        return text.Replace('‘', '\'').Replace('’', '\'').Replace("''", "'");
+        // Tesseract also emits both forms side by side ("'‘cause", "ma‘'am") - collapse that pair,
+        // but only that pair: a straight '' elsewhere on the line is not the OCR's doing.
+        return text.Replace("'‘", "'").Replace("‘'", "'").Replace("'’", "'").Replace("’'", "'")
+            .Replace('‘', '\'').Replace('’', '\'');
     }
 
     private string ReplaceLineFixes(int index, string text, List<string> wordsToIgnore)

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixApostropheHardcodedRulesTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixApostropheHardcodedRulesTests.cs
@@ -1,0 +1,68 @@
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.UiLogic.Ocr.FixEngine;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace UITests.Features.Ocr.FixEngine;
+
+// Straightening typographic apostrophes is one of the hardcoded OCR rules: the per-word rule in
+// OcrFixReplaceList2 has always honored "use hardcoded rules", and the line-level rule must too,
+// or turning the setting off still rewrites a subtitle's typography.
+public class OcrFixApostropheHardcodedRulesTests : IDisposable
+{
+    private readonly Func<string> _originalSpellCheckDictionariesFolder;
+    private readonly string _tempDictionariesFolder;
+
+    public OcrFixApostropheHardcodedRulesTests()
+    {
+        _originalSpellCheckDictionariesFolder = SpellCheckConfig.DictionariesFolder;
+        _tempDictionariesFolder = Path.Combine(Path.GetTempPath(), "SeOcrFixApostropheHardcodedRules_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDictionariesFolder);
+        SpellCheckConfig.DictionariesFolder = () => _tempDictionariesFolder;
+        File.WriteAllText(Path.Combine(_tempDictionariesFolder, "eng_OCRFixReplaceList.xml"), "<ReplaceList></ReplaceList>");
+    }
+
+    [Fact]
+    public void FixOcrErrors_StraightensApostrophes_OnlyWithHardcodedRules()
+    {
+        var previous = Configuration.Settings.Tools.OcrFixUseHardcodedRules;
+        try
+        {
+            var engine = MakeEngine();
+
+            Configuration.Settings.Tools.OcrFixUseHardcodedRules = false;
+            Assert.Equal("‘cause I promised", engine.FixOcrErrors(0, "‘cause I promised", doTryToGuessUnknownWords: false).GetText());
+
+            Configuration.Settings.Tools.OcrFixUseHardcodedRules = true;
+            Assert.Equal("'cause I promised", engine.FixOcrErrors(0, "‘cause I promised", doTryToGuessUnknownWords: false).GetText());
+        }
+        finally
+        {
+            Configuration.Settings.Tools.OcrFixUseHardcodedRules = previous;
+        }
+    }
+
+    private static IOcrFixEngine MakeEngine()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph(string.Empty, 0, 1000));
+        IOcrFixEngine engine = new OcrFixEngine(new AcceptAllSpellChecker());
+        engine.Initialize(subtitle, "eng", new SpellCheckDictionaryDisplay { DictionaryFileName = "en_US" });
+        return engine;
+    }
+
+    private sealed class AcceptAllSpellChecker : ISpellChecker
+    {
+        public bool Initialize(string dictionaryFile, string twoLetterLanguageCode) => true;
+        public bool IsWordCorrect(string word) => true;
+        public List<string> GetSuggestions(string word) => new();
+    }
+
+    public void Dispose()
+    {
+        SpellCheckConfig.DictionariesFolder = _originalSpellCheckDictionariesFolder;
+        try { Directory.Delete(_tempDictionariesFolder, true); } catch { /* best effort */ }
+    }
+}

--- a/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
+++ b/tests/UI/Features/Ocr/FixEngine/OcrFixEngineSplitLineTests.cs
@@ -50,6 +50,7 @@ public class OcrFixEngineSplitLineTests
     [InlineData("plain 'text' stays", "plain 'text' stays")]
     [InlineData("“double” stays", "“double” stays")]
     [InlineData("La lettera ‘E’ canta", "La lettera ‘E’ canta")] // opening + closing = a quotation
+    [InlineData("He said ''hi'' and didn’t leave.", "He said ''hi'' and didn't leave.")] // only the OCR's own pair collapses
     public void NormalizeApostrophes_CurlySingleQuotes_BecomePlain(string input, string expected)
     {
         Assert.Equal(expected, OcrFixEngine.NormalizeApostrophes(input));


### PR DESCRIPTION
Follow-up to #14644.

`NormalizeApostrophes` runs inside `FixOcrErrors`, which Fix Common Errors ("Fix common OCR errors") and seconv's fix-common-errors runner also call on ordinary, non-OCR subtitles. The per-word straightening it extends (`OcrFixReplaceList2.FixCommonWordErrors`, inherited from SE4) has always been gated on *Use hardcoded rules*; the new line-level rule ran unconditionally, so turning that setting off no longer kept a file's typography. It now honors the same setting, so the two rules switch together.

It also collapsed every `''` on the line whenever a curly quote was present: `He said ''hi'' and didn’t leave.` became `He said 'hi' and didn't leave.`. Only the mixed pair Tesseract emits (`'‘cause`, `ma‘'am`) is collapsed now.

Tests added for both; they fail on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)