### PR TITLE
feat(tools): add checkbox column to select lines in Merge short lines

### DIFF
--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesHelper.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesHelper.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -23,6 +23,11 @@ public class MergeShortLinesResult
 
 public static class MergeShortLinesHelper
 {
+    /// <param name="excludedLineIds">
+    /// Lines the user has unticked: such a line is not merged into the line before it and
+    /// starts a group of its own instead. A refused merge is still reported as an unticked
+    /// fix so it stays in the list and can be ticked again.
+    /// </param>
     public static MergeShortLinesResult Merge(
         List<SubtitleLineViewModel> subtitles,
         List<double> shotChanges,
@@ -30,7 +35,7 @@ public static class MergeShortLinesHelper
         int maxNumberOfLines,
         int gapThresholdMs,
         int unbreakLinesShorterThan,
-        Func<int, int, bool>? isMergeAllowed = null)
+        ISet<Guid>? excludedLineIds = null)
     {
         var fixes = new List<MergeShortLinesItem>();
         var mergeCount = 0;
@@ -47,11 +52,6 @@ public static class MergeShortLinesHelper
             while (j < subtitles.Count)
             {
                 var next = subtitles[j];
-
-                if (isMergeAllowed != null && !isMergeAllowed(index, j))
-                {
-                    break;
-                }
 
                 // stop if there is a shot change between current and next
                 var hasShotChangeBetween = shotChanges != null && shotChanges.Any(s =>
@@ -93,6 +93,21 @@ public static class MergeShortLinesHelper
                     break;
                 }
 
+                var fixText = string.Format(Se.Language.Tools.MergeShortLines.MergedLineInfo, j + 1, index + 1, wrapped.Replace(Environment.NewLine, " ⏎ "));
+
+                if (excludedLineIds != null && excludedLineIds.Contains(next.Id))
+                {
+                    // Unticked by the user: keep the candidate visible, but leave `next` alone
+                    // so it heads the next group.
+                    var refused = new SubtitleLineViewModel(current) { Text = wrapped, EndTime = next.EndTime };
+                    refused.UpdateDuration();
+                    fixes.Add(new MergeShortLinesItem(Se.Language.Tools.MergeShortLines.Title, index + 1, fixText, refused, next.Id)
+                    {
+                        Apply = false,
+                    });
+                    break;
+                }
+
                 // Merge
                 current.Text = wrapped;
                 current.EndTime = next.EndTime;
@@ -100,14 +115,7 @@ public static class MergeShortLinesHelper
                 mergeCount++;
 
                 // fix item for this merge step
-                var fix = new MergeShortLinesItem(
-                    Se.Language.Tools.MergeShortLines.Title,
-                    index + 1,
-                    string.Format(Se.Language.Tools.MergeShortLines.MergedLineInfo, j + 1, index + 1, current.Text.Replace(Environment.NewLine, " ⏎ ")),
-                    new SubtitleLineViewModel(current),
-                    index,
-                    j);
-                fixes.Add(fix);
+                fixes.Add(new MergeShortLinesItem(Se.Language.Tools.MergeShortLines.Title, index + 1, fixText, new SubtitleLineViewModel(current), next.Id));
 
                 j++;
             }
@@ -120,6 +128,7 @@ public static class MergeShortLinesHelper
         return new MergeShortLinesResult(result, fixes, mergeCount);
     }
 
+    /// <param name="excludedLineIds">See <see cref="Merge"/>.</param>
     public static MergeShortLinesResult MergeWithHighlights(
         List<SubtitleLineViewModel> subtitles,
         List<double> shotChanges,
@@ -127,7 +136,7 @@ public static class MergeShortLinesHelper
         int maxNumberOfLines,
         int gapThresholdMs,
         int unbreakLinesShorterThan,
-        Func<int, int, bool>? isMergeAllowed = null)
+        ISet<Guid>? excludedLineIds = null)
     {
         var fixes = new List<MergeShortLinesItem>();
         var mergeCount = 0;
@@ -142,16 +151,12 @@ public static class MergeShortLinesHelper
             // Collect all lines that can be merged together
             var mergeGroup = new List<SubtitleLineViewModel> { new SubtitleLineViewModel(baseVm) };
             var combinedText = (baseVm.Text ?? string.Empty).TrimEnd();
+            SubtitleLineViewModel? refused = null;
 
             var j = index + 1;
             while (j < subtitles.Count)
             {
                 var next = subtitles[j];
-
-                if (isMergeAllowed != null && !isMergeAllowed(index, j))
-                {
-                    break;
-                }
 
                 // stop if there is a shot change between current and next
                 var lastInGroup = mergeGroup[^1];
@@ -191,6 +196,12 @@ public static class MergeShortLinesHelper
                 var anyLineTooLong = lines.Any(line => HtmlUtil.RemoveHtmlTags(line, true).Length > singleLineMaxLength);
                 if (anyLineTooLong)
                 {
+                    break;
+                }
+
+                if (excludedLineIds != null && excludedLineIds.Contains(next.Id))
+                {
+                    refused = next;
                     break;
                 }
 
@@ -239,19 +250,36 @@ public static class MergeShortLinesHelper
 
                     result.Add(highlightedVm);
 
+                    // The first line of a group is merged into by the others, not merged
+                    // itself, so its row carries no checkbox.
                     fixes.Add(new MergeShortLinesItem(
                         Se.Language.Tools.MergeShortLines.Title,
                         index + k + 1,
                         $"Line {index + k + 1} - {highlightedVm.Text.Replace(Environment.NewLine, " ⏎ ")}",
                         highlightedVm,
-                        index,
-                        index + k));
+                        originalVm.Id,
+                        canToggle: k > 0));
                 }
             }
             else
             {
                 // No merge, just add the original line
                 result.Add(mergeGroup[0]);
+            }
+
+            if (refused != null)
+            {
+                // Unticked by the user: keep the candidate visible, but leave the line alone so
+                // it heads the next group.
+                fixes.Add(new MergeShortLinesItem(
+                    Se.Language.Tools.MergeShortLines.Title,
+                    j + 1,
+                    $"Line {j + 1} - {(refused.Text ?? string.Empty).Replace(Environment.NewLine, " ⏎ ")}",
+                    new SubtitleLineViewModel(refused),
+                    refused.Id)
+                {
+                    Apply = false,
+                });
             }
 
             // Skip the lines we processed

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesHelper.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesHelper.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -29,7 +29,8 @@ public static class MergeShortLinesHelper
         int singleLineMaxLength,
         int maxNumberOfLines,
         int gapThresholdMs,
-        int unbreakLinesShorterThan)
+        int unbreakLinesShorterThan,
+        Func<int, int, bool>? isMergeAllowed = null)
     {
         var fixes = new List<MergeShortLinesItem>();
         var mergeCount = 0;
@@ -46,6 +47,11 @@ public static class MergeShortLinesHelper
             while (j < subtitles.Count)
             {
                 var next = subtitles[j];
+
+                if (isMergeAllowed != null && !isMergeAllowed(index, j))
+                {
+                    break;
+                }
 
                 // stop if there is a shot change between current and next
                 var hasShotChangeBetween = shotChanges != null && shotChanges.Any(s =>
@@ -98,7 +104,9 @@ public static class MergeShortLinesHelper
                     Se.Language.Tools.MergeShortLines.Title,
                     index + 1,
                     string.Format(Se.Language.Tools.MergeShortLines.MergedLineInfo, j + 1, index + 1, current.Text.Replace(Environment.NewLine, " ⏎ ")),
-                    new SubtitleLineViewModel(current));
+                    new SubtitleLineViewModel(current),
+                    index,
+                    j);
                 fixes.Add(fix);
 
                 j++;
@@ -118,7 +126,8 @@ public static class MergeShortLinesHelper
         int singleLineMaxLength,
         int maxNumberOfLines,
         int gapThresholdMs,
-        int unbreakLinesShorterThan)
+        int unbreakLinesShorterThan,
+        Func<int, int, bool>? isMergeAllowed = null)
     {
         var fixes = new List<MergeShortLinesItem>();
         var mergeCount = 0;
@@ -138,6 +147,11 @@ public static class MergeShortLinesHelper
             while (j < subtitles.Count)
             {
                 var next = subtitles[j];
+
+                if (isMergeAllowed != null && !isMergeAllowed(index, j))
+                {
+                    break;
+                }
 
                 // stop if there is a shot change between current and next
                 var lastInGroup = mergeGroup[^1];
@@ -229,7 +243,9 @@ public static class MergeShortLinesHelper
                         Se.Language.Tools.MergeShortLines.Title,
                         index + k + 1,
                         $"Line {index + k + 1} - {highlightedVm.Text.Replace(Environment.NewLine, " ⏎ ")}",
-                        highlightedVm));
+                        highlightedVm,
+                        index,
+                        index + k));
                 }
             }
             else

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesItem.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesItem.cs
@@ -1,19 +1,25 @@
-﻿using Nikse.SubtitleEdit.Features.Main;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Features.Main;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
-public class MergeShortLinesItem
+public partial class MergeShortLinesItem : ObservableObject
 {
+    [ObservableProperty] private bool _apply = true;
     public string Name { get; set; }
     public int Number { get; set; }
     public string Fix { get; set; }
     public SubtitleLineViewModel SubtitleLine { get; set; }
+    public int TargetLineIndex { get; set; }
+    public int SourceLineIndex { get; set; }
 
-    public MergeShortLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine)
+    public MergeShortLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine, int targetLineIndex = -1, int sourceLineIndex = -1)
     {
         Name = name;
         Number = number;
         Fix = fix;
         SubtitleLine = subtitleLine;
+        TargetLineIndex = targetLineIndex;
+        SourceLineIndex = sourceLineIndex;
     }
 }

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesItem.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesItem.cs
@@ -1,25 +1,39 @@
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Nikse.SubtitleEdit.Features.Main;
+using System;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
 public partial class MergeShortLinesItem : ObservableObject
 {
+    /// <summary>
+    /// Whether the line identified by <see cref="SourceLineId"/> may be merged into the line
+    /// before it. Rows that do not represent such a merge (the first line of a highlighted
+    /// group) have <see cref="CanToggle"/> false and no checkbox.
+    /// </summary>
     [ObservableProperty] private bool _apply = true;
+
     public string Name { get; set; }
     public int Number { get; set; }
     public string Fix { get; set; }
     public SubtitleLineViewModel SubtitleLine { get; set; }
-    public int TargetLineIndex { get; set; }
-    public int SourceLineIndex { get; set; }
 
-    public MergeShortLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine, int targetLineIndex = -1, int sourceLineIndex = -1)
+    /// <summary>
+    /// Id of the subtitle line this row would merge into the preceding line. Indices shift
+    /// when the settings regroup lines and when a refused merge turns a line into a new group
+    /// head, so the line's Guid is the identity the untick has to follow.
+    /// </summary>
+    public Guid SourceLineId { get; }
+
+    public bool CanToggle { get; }
+
+    public MergeShortLinesItem(string name, int number, string fix, SubtitleLineViewModel subtitleLine, Guid sourceLineId, bool canToggle = true)
     {
         Name = name;
         Number = number;
         Fix = fix;
         SubtitleLine = subtitleLine;
-        TargetLineIndex = targetLineIndex;
-        SourceLineIndex = sourceLineIndex;
+        SourceLineId = sourceLineId;
+        CanToggle = canToggle;
     }
 }

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -8,6 +8,7 @@ using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
@@ -88,6 +89,9 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
                 return; // must not overwrite the final result Ok() just computed
             }
 
+            var unapplied = new HashSet<(int Target, int Source)>(
+                Fixes.Where(f => !f.Apply).Select(f => (f.TargetLineIndex, f.SourceLineIndex)));
+
             Subtitles.Clear();
             AllSubtitlesFixed.Clear();
             Fixes.Clear();
@@ -116,24 +120,40 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
                     gapThresholdMs,
                     unbreakLinesShorterThan);
             }
-            
 
             AllSubtitlesFixed.AddRange(mergeResult.MergedSubtitles);
 
             foreach (var fix in mergeResult.Fixes)
             {
+                if (unapplied.Contains((fix.TargetLineIndex, fix.SourceLineIndex)))
+                {
+                    fix.Apply = false;
+                }
+                fix.PropertyChanged += (_, e) =>
+                {
+                    if (e.PropertyName == nameof(MergeShortLinesItem.Apply))
+                    {
+                        UpdateFixesInfo();
+                    }
+                };
                 Fixes.Add(fix);
             }
 
-            if (mergeResult.MergeCount == 0)
-            {
-                FixesInfo = Se.Language.Tools.ApplyDurationLimits.NoChangesNeeded;
-            }
-            else
-            {
-                FixesInfo = string.Format(Se.Language.Tools.MergeShortLines.LinesMergedX, mergeResult.MergeCount);
-            }
+            UpdateFixesInfo();
         });
+    }
+
+    private void UpdateFixesInfo()
+    {
+        var appliedCount = Fixes.Count(f => f.Apply);
+        if (Fixes.Count == 0)
+        {
+            FixesInfo = Se.Language.Tools.ApplyDurationLimits.NoChangesNeeded;
+        }
+        else
+        {
+            FixesInfo = string.Format(Se.Language.Tools.MergeShortLines.LinesMergedX, appliedCount);
+        }
     }
 
     private void LoadSettings()
@@ -155,6 +175,36 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
     }
 
     [RelayCommand]
+    private void SelectAll()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = true;
+        }
+        UpdateFixesInfo();
+    }
+
+    [RelayCommand]
+    private void SelectNone()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = false;
+        }
+        UpdateFixesInfo();
+    }
+
+    [RelayCommand]
+    private void InvertSelection()
+    {
+        foreach (var fix in Fixes)
+        {
+            fix.Apply = !fix.Apply;
+        }
+        UpdateFixesInfo();
+    }
+
+    [RelayCommand]
     private void Ok()
     {
         if (Window == null)
@@ -169,13 +219,17 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
         {
             var gapThresholdMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
             var unbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
+            var allowedSet = new HashSet<(int Target, int Source)>(
+                Fixes.Where(f => f.Apply).Select(f => (f.TargetLineIndex, f.SourceLineIndex)));
+
             var mergeResult = MergeShortLinesHelper.Merge(
                 _allSubtitles,
                 _shotChanges,
                 SingleLineMaxLength,
                 MaxNumberOfLines,
                 gapThresholdMs,
-                unbreakLinesShorterThan);
+                unbreakLinesShorterThan,
+                (tgt, src) => allowedSet.Contains((tgt, src)));
             AllSubtitlesFixed.Clear();
             AllSubtitlesFixed.AddRange(mergeResult.MergedSubtitles);
         }

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesViewModel.cs
@@ -6,9 +6,10 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
+using System.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
@@ -36,6 +37,11 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
     private volatile bool _isClosing;
     private bool _isDirty;
     private List<double> _shotChanges;
+
+    // Lines the user unticked in the "Apply" column. This, not the preview list, is what OK
+    // applies: the preview is filled by the 250 ms timer, so it is empty right after opening
+    // and stale right after a settings change, while this set is always current.
+    private readonly HashSet<Guid> _excludedLineIds = new();
 
     public MergeShortLinesViewModel()
     {
@@ -80,6 +86,16 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
         _previewTimer.StopAndDispose(PreviewTimerElapsed);
     }
 
+    private MergeShortLinesResult RunMerge(bool highlight)
+    {
+        var gapThresholdMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
+        var unbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
+
+        return highlight
+            ? MergeShortLinesHelper.MergeWithHighlights(_allSubtitles, _shotChanges, SingleLineMaxLength, MaxNumberOfLines, gapThresholdMs, unbreakLinesShorterThan, _excludedLineIds)
+            : MergeShortLinesHelper.Merge(_allSubtitles, _shotChanges, SingleLineMaxLength, MaxNumberOfLines, gapThresholdMs, unbreakLinesShorterThan, _excludedLineIds);
+    }
+
     private void UpdatePreview()
     {
         Dispatcher.UIThread.Post(() =>
@@ -89,71 +105,90 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
                 return; // must not overwrite the final result Ok() just computed
             }
 
-            var unapplied = new HashSet<(int Target, int Source)>(
-                Fixes.Where(f => !f.Apply).Select(f => (f.TargetLineIndex, f.SourceLineIndex)));
-
             Subtitles.Clear();
             AllSubtitlesFixed.Clear();
-            Fixes.Clear();
 
-            var gapThresholdMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
-            var unbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
-
-            var mergeResult = new MergeShortLinesResult(new List<SubtitleLineViewModel>(), new List<MergeShortLinesItem>(), 0);
-            if (HighLight)
-            {
-                mergeResult = MergeShortLinesHelper.MergeWithHighlights(
-                    _allSubtitles,
-                    _shotChanges,
-                    SingleLineMaxLength,
-                    MaxNumberOfLines,
-                    gapThresholdMs,
-                    unbreakLinesShorterThan);
-            }
-            else
-            {
-                mergeResult = MergeShortLinesHelper.Merge(
-                    _allSubtitles,
-                    _shotChanges,
-                    SingleLineMaxLength,
-                    MaxNumberOfLines,
-                    gapThresholdMs,
-                    unbreakLinesShorterThan);
-            }
+            var mergeResult = RunMerge(HighLight);
 
             AllSubtitlesFixed.AddRange(mergeResult.MergedSubtitles);
 
-            foreach (var fix in mergeResult.Fixes)
+            // The preview re-runs when a checkbox is toggled, so only the rows that actually
+            // changed are replaced - a full clear would throw away the grid's scroll position
+            // and selection under the user's pointer.
+            var replaced = ReplaceChangedRows(Fixes, mergeResult.Fixes);
+            foreach (var fix in replaced)
             {
-                if (unapplied.Contains((fix.TargetLineIndex, fix.SourceLineIndex)))
-                {
-                    fix.Apply = false;
-                }
-                fix.PropertyChanged += (_, e) =>
-                {
-                    if (e.PropertyName == nameof(MergeShortLinesItem.Apply))
-                    {
-                        UpdateFixesInfo();
-                    }
-                };
-                Fixes.Add(fix);
+                fix.PropertyChanged += FixPropertyChanged;
             }
 
-            UpdateFixesInfo();
+            FixesInfo = Fixes.Count == 0
+                ? Se.Language.Tools.ApplyDurationLimits.NoChangesNeeded
+                : string.Format(Se.Language.Tools.MergeShortLines.LinesMergedX, mergeResult.MergeCount);
         });
     }
 
-    private void UpdateFixesInfo()
+    /// <summary>
+    /// Makes <paramref name="target"/> equal to <paramref name="fresh"/> by replacing only the
+    /// rows between the unchanged prefix and suffix. Returns the rows that were inserted.
+    /// </summary>
+    internal static List<MergeShortLinesItem> ReplaceChangedRows(ObservableCollection<MergeShortLinesItem> target, List<MergeShortLinesItem> fresh)
     {
-        var appliedCount = Fixes.Count(f => f.Apply);
-        if (Fixes.Count == 0)
+        var prefix = 0;
+        while (prefix < target.Count && prefix < fresh.Count && IsSameRow(target[prefix], fresh[prefix]))
         {
-            FixesInfo = Se.Language.Tools.ApplyDurationLimits.NoChangesNeeded;
+            prefix++;
+        }
+
+        var suffix = 0;
+        while (suffix < target.Count - prefix && suffix < fresh.Count - prefix &&
+               IsSameRow(target[target.Count - 1 - suffix], fresh[fresh.Count - 1 - suffix]))
+        {
+            suffix++;
+        }
+
+        for (var i = target.Count - 1 - suffix; i >= prefix; i--)
+        {
+            target.RemoveAt(i);
+        }
+
+        var inserted = new List<MergeShortLinesItem>();
+        for (var i = prefix; i < fresh.Count - suffix; i++)
+        {
+            target.Insert(i, fresh[i]);
+            inserted.Add(fresh[i]);
+        }
+
+        return inserted;
+    }
+
+    private static bool IsSameRow(MergeShortLinesItem a, MergeShortLinesItem b)
+    {
+        return a.SourceLineId == b.SourceLineId &&
+               a.CanToggle == b.CanToggle &&
+               a.Apply == b.Apply &&
+               a.Number == b.Number &&
+               a.Fix == b.Fix;
+    }
+
+    private void FixPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(MergeShortLinesItem.Apply) || sender is not MergeShortLinesItem fix || !fix.CanToggle)
+        {
+            return;
+        }
+
+        if (fix.Apply)
+        {
+            _excludedLineIds.Remove(fix.SourceLineId);
         }
         else
         {
-            FixesInfo = string.Format(Se.Language.Tools.MergeShortLines.LinesMergedX, appliedCount);
+            _excludedLineIds.Add(fix.SourceLineId);
         }
+
+        // Refusing a merge can make the line head its own group, so the candidates after it
+        // change: let the preview timer re-run the merge (it coalesces bulk toggles).
+        SetChanged();
     }
 
     private void LoadSettings()
@@ -179,9 +214,11 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
     {
         foreach (var fix in Fixes)
         {
-            fix.Apply = true;
+            if (fix.CanToggle)
+            {
+                fix.Apply = true;
+            }
         }
-        UpdateFixesInfo();
     }
 
     [RelayCommand]
@@ -189,9 +226,11 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
     {
         foreach (var fix in Fixes)
         {
-            fix.Apply = false;
+            if (fix.CanToggle)
+            {
+                fix.Apply = false;
+            }
         }
-        UpdateFixesInfo();
     }
 
     [RelayCommand]
@@ -199,9 +238,45 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
     {
         foreach (var fix in Fixes)
         {
-            fix.Apply = !fix.Apply;
+            if (fix.CanToggle)
+            {
+                fix.Apply = !fix.Apply;
+            }
         }
-        UpdateFixesInfo();
+    }
+
+    /// <summary>
+    /// The gestures advertised by the fixes grid context menu: tick all, untick all and invert
+    /// the "Apply" column. Called both from the window (focus sits on a button) and from a
+    /// tunneling handler on the grid, which would otherwise swallow Ctrl+A as "select all rows".
+    /// </summary>
+    internal bool HandleFixesSelectionKey(KeyEventArgs e)
+    {
+        var isCommand = e.KeyModifiers.HasFlag(KeyModifiers.Control) || e.KeyModifiers.HasFlag(KeyModifiers.Meta);
+        if (!isCommand || e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            return false;
+        }
+
+        var isShift = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
+        if (e.Key == Key.A && !isShift)
+        {
+            SelectAll();
+        }
+        else if (e.Key == Key.D && !isShift)
+        {
+            SelectNone();
+        }
+        else if (e.Key == Key.I && isShift)
+        {
+            InvertSelection();
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
     }
 
     [RelayCommand]
@@ -215,24 +290,11 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
         // Always recompute the real merge from the current settings instead of handing back
         // what the 250 ms preview timer last produced: the preview is empty when OK comes
         // right after opening, stale when it comes right after a settings change, and in
-        // "highlight parts" mode it is not the real merge at all.
-        {
-            var gapThresholdMs = Se.Settings.Tools.BridgeGaps.BridgeGapsSmallerThanMs;
-            var unbreakLinesShorterThan = Se.Settings.General.UnbreakLinesShorterThan;
-            var allowedSet = new HashSet<(int Target, int Source)>(
-                Fixes.Where(f => f.Apply).Select(f => (f.TargetLineIndex, f.SourceLineIndex)));
-
-            var mergeResult = MergeShortLinesHelper.Merge(
-                _allSubtitles,
-                _shotChanges,
-                SingleLineMaxLength,
-                MaxNumberOfLines,
-                gapThresholdMs,
-                unbreakLinesShorterThan,
-                (tgt, src) => allowedSet.Contains((tgt, src)));
-            AllSubtitlesFixed.Clear();
-            AllSubtitlesFixed.AddRange(mergeResult.MergedSubtitles);
-        }
+        // "highlight parts" mode it is not the real merge at all. The user's unticks are
+        // carried by _excludedLineIds, which does not depend on the preview.
+        var mergeResult = RunMerge(highlight: false);
+        AllSubtitlesFixed.Clear();
+        AllSubtitlesFixed.AddRange(mergeResult.MergedSubtitles);
 
         SaveSettings();
         OkPressed = true;
@@ -256,6 +318,10 @@ public partial class MergeShortLinesViewModel : ObservableObject, IClosingCleanu
         {
             e.Handled = true;
             UiUtil.ShowHelp("features/merge-short-lines");
+        }
+        else if (HandleFixesSelectionKey(e))
+        {
+            e.Handled = true;
         }
     }
 

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
@@ -11,7 +11,6 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
@@ -160,6 +159,8 @@ public class MergeShortLinesWindow : Window
                                 {
                                     Mode = BindingMode.TwoWay,
                                 },
+                                // The first line of a highlighted group is merged into, not merged: no checkbox.
+                                [!Visual.IsVisibleProperty] = new Binding(nameof(MergeShortLinesItem.CanToggle)),
                                 HorizontalAlignment = HorizontalAlignment.Center,
                             }
                         }),
@@ -186,8 +187,14 @@ public class MergeShortLinesWindow : Window
 
         // Space toggles the checkbox of every selected row
         TableViewExtras.AddSpaceToggle<MergeShortLinesItem>(dataGrid,
-            item => item.Apply,
-            (item, value) => item.Apply = value);
+            item => !item.CanToggle || item.Apply,
+            (item, value) =>
+            {
+                if (item.CanToggle)
+                {
+                    item.Apply = value;
+                }
+            });
 
         var commandModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
         dataGrid.ContextMenu = new ContextMenu
@@ -218,6 +225,16 @@ public class MergeShortLinesWindow : Window
             },
         };
 
+        // The context menu gestures must mean the same with the grid focused, so take them
+        // before the TableView (a ListBox) turns Ctrl+A into "select all rows".
+        dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
+        {
+            if (vm.HandleFixesSelectionKey(e))
+            {
+                e.Handled = true;
+            }
+        }, RoutingStrategies.Tunnel);
+
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
             if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
@@ -235,4 +252,3 @@ public class MergeShortLinesWindow : Window
         return grid;
     }
 }
-

--- a/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
+++ b/src/ui/Features/Tools/MergeShortLines/MergeShortLinesWindow.cs
@@ -1,11 +1,17 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
 
@@ -130,13 +136,35 @@ public class MergeShortLinesWindow : Window
 
         // Sorting dropped in the DataGrid -> TableView conversion: the grid previews
         // merge candidates in subtitle order.
-        var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        var dataGrid = TableViewExtras.MakeTableView();
         dataGrid.Width = double.NaN;
         dataGrid.Height = double.NaN;
         dataGrid.DataContext = vm;
         dataGrid.ItemsSource = vm.Fixes;
         dataGrid.Columns.AddRange(new TableViewColumn[]
         {
+                new SeTableViewColumn
+                {
+                    Header = Se.Language.General.Apply,
+                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                    CellTemplate = new FuncDataTemplate<MergeShortLinesItem>((item, _) =>
+                        new Border
+                        {
+                            Background = Brushes.Transparent, // Prevents highlighting
+                            Padding = new Thickness(4),
+                            Child = new CheckBox
+                            {
+                                Focusable = false,
+                                [!ToggleButton.IsCheckedProperty] = new Binding(nameof(MergeShortLinesItem.Apply))
+                                {
+                                    Mode = BindingMode.TwoWay,
+                                },
+                                HorizontalAlignment = HorizontalAlignment.Center,
+                            }
+                        }),
+                    Width = new GridLength(70),
+                },
                 new SeTableViewColumn
                 {
                     Header = Se.Language.General.NumberSymbol,
@@ -156,6 +184,40 @@ public class MergeShortLinesWindow : Window
                 },
         });
 
+        // Space toggles the checkbox of every selected row
+        TableViewExtras.AddSpaceToggle<MergeShortLinesItem>(dataGrid,
+            item => item.Apply,
+            (item, value) => item.Apply = value);
+
+        var commandModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+        dataGrid.ContextMenu = new ContextMenu
+        {
+            Items =
+            {
+                new MenuItem
+                {
+                    Header = Se.Language.General.SelectAll,
+                    DataContext = vm,
+                    Command = vm.SelectAllCommand,
+                    InputGesture = new KeyGesture(Key.A, commandModifier),
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.SelectNone,
+                    DataContext = vm,
+                    Command = vm.SelectNoneCommand,
+                    InputGesture = new KeyGesture(Key.D, commandModifier),
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.General.InvertSelection,
+                    DataContext = vm,
+                    Command = vm.InvertSelectionCommand,
+                    InputGesture = new KeyGesture(Key.I, commandModifier | KeyModifiers.Shift),
+                },
+            },
+        };
+
         dataGrid.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
             if (e.Key is Key.Home or Key.End && dataGrid.ItemsSource is IList items && items.Count > 0)
@@ -173,3 +235,4 @@ public class MergeShortLinesWindow : Window
         return grid;
     }
 }
+

--- a/tests/UI/Features/Tools/MergeShortLines/MergeShortLinesHelperTests.cs
+++ b/tests/UI/Features/Tools/MergeShortLines/MergeShortLinesHelperTests.cs
@@ -1,13 +1,13 @@
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
-using System;
-using System.Collections.Generic;
-using Xunit;
+using System.Collections.ObjectModel;
 
 namespace UITests.Features.Tools.MergeShortLines;
 
 public class MergeShortLinesHelperTests
 {
+    private static string Flat(string text) => text.Replace("\r\n", " ").Replace('\n', ' ');
+
     private static SubtitleLineViewModel MakeSubtitle(string text, double startSec, double endSec) =>
         new()
         {
@@ -16,50 +16,142 @@ public class MergeShortLinesHelperTests
             EndTime = TimeSpan.FromSeconds(endSec),
         };
 
-    [Fact]
-    public void Merge_RespectsIsMergeAllowedFilter()
+    private static List<SubtitleLineViewModel> ThreeMergeableLines() => new()
     {
-        var subtitles = new List<SubtitleLineViewModel>
-        {
-            MakeSubtitle("Line one", 1.0, 2.0),
-            MakeSubtitle("Line two", 2.1, 3.0),
-            MakeSubtitle("Line three", 3.1, 4.0),
-        };
+        MakeSubtitle("Line one", 1.0, 2.0),
+        MakeSubtitle("Line two", 2.1, 3.0),
+        MakeSubtitle("Line three", 3.1, 4.0),
+    };
 
-        // All allowed
-        var resultAll = MergeShortLinesHelper.Merge(
-            subtitles,
-            shotChanges: new List<double>(),
-            singleLineMaxLength: 50,
-            maxNumberOfLines: 2,
-            gapThresholdMs: 500,
-            unbreakLinesShorterThan: 10);
+    private static MergeShortLinesResult Merge(List<SubtitleLineViewModel> subtitles, ISet<Guid>? excluded = null) =>
+        MergeShortLinesHelper.Merge(subtitles, new List<double>(), singleLineMaxLength: 50, maxNumberOfLines: 2, gapThresholdMs: 500, unbreakLinesShorterThan: 10, excluded);
 
-        Assert.True(resultAll.MergeCount > 0);
+    private static MergeShortLinesResult MergeWithHighlights(List<SubtitleLineViewModel> subtitles, ISet<Guid>? excluded = null) =>
+        MergeShortLinesHelper.MergeWithHighlights(subtitles, new List<double>(), singleLineMaxLength: 50, maxNumberOfLines: 2, gapThresholdMs: 500, unbreakLinesShorterThan: 10, excluded);
 
-        // Disallow merging into line 0
-        var resultDisallowed = MergeShortLinesHelper.Merge(
-            subtitles,
-            shotChanges: new List<double>(),
-            singleLineMaxLength: 50,
-            maxNumberOfLines: 2,
-            gapThresholdMs: 500,
-            unbreakLinesShorterThan: 10,
-            isMergeAllowed: (target, source) => false);
+    [Fact]
+    public void Merge_NoExclusions_MergesChain()
+    {
+        var subtitles = ThreeMergeableLines();
 
-        Assert.Equal(0, resultDisallowed.MergeCount);
-        Assert.Equal(3, resultDisallowed.MergedSubtitles.Count);
+        var result = Merge(subtitles);
+
+        Assert.Equal(2, result.MergeCount);
+        Assert.Single(result.MergedSubtitles);
+        Assert.Equal(new[] { subtitles[1].Id, subtitles[2].Id }, result.Fixes.Select(f => f.SourceLineId));
+        Assert.All(result.Fixes, f => Assert.True(f.Apply && f.CanToggle));
+    }
+
+    [Fact]
+    public void Merge_ExcludedLine_HeadsItsOwnGroup()
+    {
+        var subtitles = ThreeMergeableLines();
+
+        // Untick "line two into line one": line two must not be merged into line one, but it
+        // may still absorb line three.
+        var result = Merge(subtitles, new HashSet<Guid> { subtitles[1].Id });
+
+        Assert.Equal(1, result.MergeCount);
+        Assert.Equal(2, result.MergedSubtitles.Count);
+        Assert.Equal("Line one", result.MergedSubtitles[0].Text);
+        Assert.Equal("Line two Line three", Flat(result.MergedSubtitles[1].Text));
+
+        // The refused candidate stays in the list, unticked, so it can be ticked again.
+        Assert.Equal(2, result.Fixes.Count);
+        Assert.Equal(subtitles[1].Id, result.Fixes[0].SourceLineId);
+        Assert.False(result.Fixes[0].Apply);
+        Assert.Equal(subtitles[2].Id, result.Fixes[1].SourceLineId);
+        Assert.True(result.Fixes[1].Apply);
+    }
+
+    [Fact]
+    public void Merge_ExcludedLastLine_MergesTheRest()
+    {
+        var subtitles = ThreeMergeableLines();
+
+        var result = Merge(subtitles, new HashSet<Guid> { subtitles[2].Id });
+
+        Assert.Equal(1, result.MergeCount);
+        Assert.Equal(2, result.MergedSubtitles.Count);
+        Assert.Equal("Line one Line two", Flat(result.MergedSubtitles[0].Text));
+        Assert.Equal("Line three", result.MergedSubtitles[1].Text);
+    }
+
+    [Fact]
+    public void Merge_AllExcluded_ChangesNothing()
+    {
+        var subtitles = ThreeMergeableLines();
+
+        var result = Merge(subtitles, new HashSet<Guid> { subtitles[1].Id, subtitles[2].Id });
+
+        Assert.Equal(0, result.MergeCount);
+        Assert.Equal(3, result.MergedSubtitles.Count);
+        Assert.Equal(2, result.Fixes.Count);
+        Assert.All(result.Fixes, f => Assert.False(f.Apply));
+    }
+
+    [Fact]
+    public void MergeWithHighlights_HeadRowHasNoCheckbox()
+    {
+        var subtitles = ThreeMergeableLines();
+
+        var result = MergeWithHighlights(subtitles);
+
+        Assert.Equal(2, result.MergeCount);
+        Assert.Equal(3, result.Fixes.Count);
+        Assert.False(result.Fixes[0].CanToggle);
+        Assert.Equal(subtitles[0].Id, result.Fixes[0].SourceLineId);
+        Assert.True(result.Fixes[1].CanToggle);
+        Assert.Equal(subtitles[1].Id, result.Fixes[1].SourceLineId);
+        Assert.True(result.Fixes[2].CanToggle);
+        Assert.Equal(subtitles[2].Id, result.Fixes[2].SourceLineId);
+    }
+
+    [Fact]
+    public void MergeWithHighlights_ExcludedLine_ReportedUntickedAndHeadsNextGroup()
+    {
+        var subtitles = ThreeMergeableLines();
+
+        var result = MergeWithHighlights(subtitles, new HashSet<Guid> { subtitles[1].Id });
+
+        Assert.Equal(1, result.MergeCount);
+        Assert.Equal(3, result.MergedSubtitles.Count); // line one alone, lines two and three highlighted
+        Assert.Equal("Line one", result.MergedSubtitles[0].Text);
+        Assert.Contains("<u>Line two</u>", result.MergedSubtitles[1].Text);
+
+        // Refused row for line two, then the head + member rows of the new group.
+        Assert.Equal(3, result.Fixes.Count);
+        Assert.Equal(subtitles[1].Id, result.Fixes[0].SourceLineId);
+        Assert.False(result.Fixes[0].Apply);
+        Assert.True(result.Fixes[0].CanToggle);
+        Assert.False(result.Fixes[1].CanToggle);
+        Assert.Equal(subtitles[2].Id, result.Fixes[2].SourceLineId);
+    }
+
+    [Fact]
+    public void ReplaceChangedRows_KeepsUnchangedRowInstances()
+    {
+        var subtitles = ThreeMergeableLines();
+        var first = Merge(subtitles).Fixes;
+        var target = new ObservableCollection<MergeShortLinesItem>(first);
+
+        // Untick line three: the row for line two is unchanged and must keep its instance.
+        var fresh = Merge(subtitles, new HashSet<Guid> { subtitles[2].Id }).Fixes;
+        var inserted = MergeShortLinesViewModel.ReplaceChangedRows(target, fresh);
+
+        Assert.Equal(2, target.Count);
+        Assert.Same(first[0], target[0]);
+        Assert.Same(fresh[1], target[1]);
+        Assert.Equal(new[] { fresh[1] }, inserted);
     }
 
     [Fact]
     public void MergeShortLinesItem_ApplyDefaultsToTrue()
     {
-        var item = new MergeShortLinesItem("Title", 1, "Fix description", new SubtitleLineViewModel(), 0, 1);
+        var id = Guid.NewGuid();
+        var item = new MergeShortLinesItem("Title", 1, "Fix description", new SubtitleLineViewModel(), id);
         Assert.True(item.Apply);
-        Assert.Equal(0, item.TargetLineIndex);
-        Assert.Equal(1, item.SourceLineIndex);
-
-        item.Apply = false;
-        Assert.False(item.Apply);
+        Assert.True(item.CanToggle);
+        Assert.Equal(id, item.SourceLineId);
     }
 }

--- a/tests/UI/Features/Tools/MergeShortLines/MergeShortLinesHelperTests.cs
+++ b/tests/UI/Features/Tools/MergeShortLines/MergeShortLinesHelperTests.cs
@@ -1,0 +1,65 @@
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Features.Tools.MergeShortLines;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace UITests.Features.Tools.MergeShortLines;
+
+public class MergeShortLinesHelperTests
+{
+    private static SubtitleLineViewModel MakeSubtitle(string text, double startSec, double endSec) =>
+        new()
+        {
+            Text = text,
+            StartTime = TimeSpan.FromSeconds(startSec),
+            EndTime = TimeSpan.FromSeconds(endSec),
+        };
+
+    [Fact]
+    public void Merge_RespectsIsMergeAllowedFilter()
+    {
+        var subtitles = new List<SubtitleLineViewModel>
+        {
+            MakeSubtitle("Line one", 1.0, 2.0),
+            MakeSubtitle("Line two", 2.1, 3.0),
+            MakeSubtitle("Line three", 3.1, 4.0),
+        };
+
+        // All allowed
+        var resultAll = MergeShortLinesHelper.Merge(
+            subtitles,
+            shotChanges: new List<double>(),
+            singleLineMaxLength: 50,
+            maxNumberOfLines: 2,
+            gapThresholdMs: 500,
+            unbreakLinesShorterThan: 10);
+
+        Assert.True(resultAll.MergeCount > 0);
+
+        // Disallow merging into line 0
+        var resultDisallowed = MergeShortLinesHelper.Merge(
+            subtitles,
+            shotChanges: new List<double>(),
+            singleLineMaxLength: 50,
+            maxNumberOfLines: 2,
+            gapThresholdMs: 500,
+            unbreakLinesShorterThan: 10,
+            isMergeAllowed: (target, source) => false);
+
+        Assert.Equal(0, resultDisallowed.MergeCount);
+        Assert.Equal(3, resultDisallowed.MergedSubtitles.Count);
+    }
+
+    [Fact]
+    public void MergeShortLinesItem_ApplyDefaultsToTrue()
+    {
+        var item = new MergeShortLinesItem("Title", 1, "Fix description", new SubtitleLineViewModel(), 0, 1);
+        Assert.True(item.Apply);
+        Assert.Equal(0, item.TargetLineIndex);
+        Assert.Equal(1, item.SourceLineIndex);
+
+        item.Apply = false;
+        Assert.False(item.Apply);
+    }
+}


### PR DESCRIPTION


<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/f95cfec7-1d10-479f-adf8-2f07dadf1657" />

### Summary
Adds an `Apply` checkbox column to the left of the line number column (`#`) in the **Merge short lines** window (`Tools -> Merge short lines`), allowing users to selectively include or exclude individual merge candidates.

### Key Changes
- **Checkbox Column**: Added a centered CheckBox column as the first column in the TableView, bound to `MergeShortLinesItem.Apply` with header `Se.Language.General.Apply`.
- **Selective Apply on OK**: Clicking **OK** only merges the candidate lines that have their checkbox checked. If a line in a consecutive sequence is unchecked, merging halts at that boundary to safely maintain timing and text integrity.
- **Interactive Count**: Toggling checkboxes dynamically updates the active count label (`Lines merged: X`).
- **Keyboard & Context Menu Support**:
  - `Space` key toggles checkboxes for all highlighted/selected rows via `TableViewExtras.AddSpaceToggle`.
  - Right-click context menu with **Select all** (`Ctrl+A`), **Select none** (`Ctrl+D`), and **Invert selection** (`Ctrl+Shift+I`).
- **Unit Tests**: Added automated unit tests in `MergeShortLinesHelperTests.cs` covering the merge filter predicate and item model.
