### PR TITLE
fix(shortcuts): allow fluent repeated shortcuts while holding modifiers and preserve focus after undo/redo

### DIFF
--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -64,6 +64,8 @@ public class MainView : ViewBase
             };
             _vm.Window.Closed += (_, _) => _vm.StopBackgroundWork();
 
+            AttachKeyHandlers(hostWindow);
+
             // Clipboard-manager compatibility (Ditto, CopyQ, ClipClip, ...) - see the
             // hook for what it intercepts and why (#13822).
             if (OperatingSystem.IsWindows())
@@ -124,20 +126,30 @@ public class MainView : ViewBase
                 _vm.ContentGrid.InvalidateMeasure();
                 _vm.ContentGrid.InvalidateArrange();
                 Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(_vm.SubtitleGrid));
+                if (TopLevel.GetTopLevel(this) is Window w)
+                {
+                    AttachKeyHandlers(w);
+                }
             }, DispatcherPriority.Loaded);
         };
 
         root.Children.Add(_vm.ContentGrid);
 
-        AddHandler(KeyDownEvent, _vm.OnKeyDownHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: false);
-        AddHandler(KeyUpEvent, _vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
-
-        // Tunnelling, and handledEventsToo since controls like the waveform mark their presses handled:
-        // needed to see that Alt was held for a mouse gesture and cancel the menu-bar activation that
-        // would otherwise fire on the Alt release (discussion #11744).
-        AddHandler(PointerPressedEvent, _vm.OnPointerPressedHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
-
         return root;
+    }
+
+    private bool _keyHandlersAttached;
+    private void AttachKeyHandlers(Window window)
+    {
+        if (_keyHandlersAttached || _vm == null)
+        {
+            return;
+        }
+
+        window.AddHandler(KeyDownEvent, _vm.OnKeyDownHandler, RoutingStrategies.Tunnel, handledEventsToo: false);
+        window.AddHandler(KeyUpEvent, _vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
+        window.AddHandler(PointerPressedEvent, _vm.OnPointerPressedHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
+        _keyHandlersAttached = true;
     }
 
     // Whether the window has seen (and passed through) an Alt key-down whose release is still

--- a/src/ui/Features/Main/MainView.cs
+++ b/src/ui/Features/Main/MainView.cs
@@ -64,7 +64,7 @@ public class MainView : ViewBase
             };
             _vm.Window.Closed += (_, _) => _vm.StopBackgroundWork();
 
-            AttachKeyHandlers(hostWindow);
+            AttachKeyHandlers(hostWindow, _vm);
 
             // Clipboard-manager compatibility (Ditto, CopyQ, ClipClip, ...) - see the
             // hook for what it intercepts and why (#13822).
@@ -126,10 +126,6 @@ public class MainView : ViewBase
                 _vm.ContentGrid.InvalidateMeasure();
                 _vm.ContentGrid.InvalidateArrange();
                 Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(_vm.SubtitleGrid));
-                if (TopLevel.GetTopLevel(this) is Window w)
-                {
-                    AttachKeyHandlers(w);
-                }
             }, DispatcherPriority.Loaded);
         };
 
@@ -138,18 +134,19 @@ public class MainView : ViewBase
         return root;
     }
 
-    private bool _keyHandlersAttached;
-    private void AttachKeyHandlers(Window window)
+    /// <summary>
+    /// Key and pointer handlers live on the window rather than on this control so shortcuts
+    /// keep working when focus lands outside the user control (window root, layout host).
+    /// </summary>
+    private static void AttachKeyHandlers(Window window, MainViewModel vm)
     {
-        if (_keyHandlersAttached || _vm == null)
-        {
-            return;
-        }
+        window.AddHandler(KeyDownEvent, vm.OnKeyDownHandler, RoutingStrategies.Tunnel, handledEventsToo: false);
+        window.AddHandler(KeyUpEvent, vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
 
-        window.AddHandler(KeyDownEvent, _vm.OnKeyDownHandler, RoutingStrategies.Tunnel, handledEventsToo: false);
-        window.AddHandler(KeyUpEvent, _vm.OnKeyUpHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble, handledEventsToo: true);
-        window.AddHandler(PointerPressedEvent, _vm.OnPointerPressedHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
-        _keyHandlersAttached = true;
+        // Tunnelling, and handledEventsToo since controls like the waveform mark their presses handled:
+        // needed to see that Alt was held for a mouse gesture and cancel the menu-bar activation that
+        // would otherwise fire on the Alt release (discussion #11744).
+        window.AddHandler(PointerPressedEvent, vm.OnPointerPressedHandler, RoutingStrategies.Tunnel, handledEventsToo: true);
     }
 
     // Whether the window has seen (and passed through) an Alt key-down whose release is still

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.UiLogic.Export;
+﻿using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -20806,10 +20806,7 @@ public partial class MainViewModel :
         {
             var preIndex = SelectedSubtitleIndex ?? 0;
             var preRowTop = GetSelectedRowViewportTop();
-            var preGridFocus = IsSubtitleGridFocused();
-            var preEditBoxFocus = EditTextBox.IsFocused;
-            var preEditBoxOriginalFocus = EditTextBoxOriginal.IsFocused;
-            var preAudioFocus = AudioVisualizer != null && AudioVisualizer.IsFocused;
+            var preFocus = CaptureUndoRedoFocus();
 
             var undoRedoObject = _undoRedoManager.Undo()!;
             if (undoRedoObject?.Subtitles == null)
@@ -20818,21 +20815,8 @@ public partial class MainViewModel :
             }
 
             RestoreUndoRedoState(undoRedoObject, scrollToSelected: false);
-            RestoreSelectionToPreviousIndex(preIndex, preRowTop, restoreGridFocus: preGridFocus || (!preEditBoxFocus && !preEditBoxOriginalFocus && !preAudioFocus));
-
-            if (preEditBoxFocus)
-            {
-                Dispatcher.UIThread.Post(() => EditTextBox.Focus());
-            }
-            else if (preEditBoxOriginalFocus)
-            {
-                Dispatcher.UIThread.Post(() => EditTextBoxOriginal.Focus());
-            }
-            else if (preAudioFocus)
-            {
-                Dispatcher.UIThread.Post(() => AudioVisualizer?.Focus());
-            }
-
+            RestoreSelectionToPreviousIndex(preIndex, preRowTop, restoreGridFocus: preFocus == UndoRedoFocus.Grid);
+            RestoreUndoRedoFocus(preFocus);
             ShowUndoStatus();
         });
     }
@@ -20872,10 +20856,7 @@ public partial class MainViewModel :
         {
             var preIndex = SelectedSubtitleIndex ?? 0;
             var preRowTop = GetSelectedRowViewportTop();
-            var preGridFocus = IsSubtitleGridFocused();
-            var preEditBoxFocus = EditTextBox.IsFocused;
-            var preEditBoxOriginalFocus = EditTextBoxOriginal.IsFocused;
-            var preAudioFocus = AudioVisualizer != null && AudioVisualizer.IsFocused;
+            var preFocus = CaptureUndoRedoFocus();
 
             var undoRedoObject = _undoRedoManager.Redo();
             if (undoRedoObject?.Subtitles == null)
@@ -20884,21 +20865,8 @@ public partial class MainViewModel :
             }
 
             RestoreUndoRedoState(undoRedoObject, scrollToSelected: false);
-            RestoreSelectionToPreviousIndex(preIndex, preRowTop, restoreGridFocus: preGridFocus || (!preEditBoxFocus && !preEditBoxOriginalFocus && !preAudioFocus));
-
-            if (preEditBoxFocus)
-            {
-                Dispatcher.UIThread.Post(() => EditTextBox.Focus());
-            }
-            else if (preEditBoxOriginalFocus)
-            {
-                Dispatcher.UIThread.Post(() => EditTextBoxOriginal.Focus());
-            }
-            else if (preAudioFocus)
-            {
-                Dispatcher.UIThread.Post(() => AudioVisualizer?.Focus());
-            }
-
+            RestoreSelectionToPreviousIndex(preIndex, preRowTop, restoreGridFocus: preFocus == UndoRedoFocus.Grid);
+            RestoreUndoRedoFocus(preFocus);
             ShowRedoStatus();
         });
     }
@@ -20926,6 +20894,56 @@ public partial class MainViewModel :
     /// the current line at the top of the grid on every Undo - disorienting when the user was
     /// working near the bottom of the view (#14517).
     /// </summary>
+    private enum UndoRedoFocus
+    {
+        Grid,
+        EditTextBox,
+        EditTextBoxOriginal,
+        AudioVisualizer,
+    }
+
+    /// <summary>
+    /// Which control should get focus back after undo/redo reloads the rows. Capture this
+    /// before the reload: rebuilding the grid drops focus synchronously. Nothing focused
+    /// (window root, layout host) counts as the grid, matching
+    /// <see cref="IsSubtitleGridFocusedOrFocusDropped"/>.
+    /// </summary>
+    private UndoRedoFocus CaptureUndoRedoFocus()
+    {
+        if (EditTextBox.IsFocused)
+        {
+            return UndoRedoFocus.EditTextBox;
+        }
+
+        if (EditTextBoxOriginal.IsFocused)
+        {
+            return UndoRedoFocus.EditTextBoxOriginal;
+        }
+
+        if (AudioVisualizer is { IsFocused: true })
+        {
+            return UndoRedoFocus.AudioVisualizer;
+        }
+
+        return UndoRedoFocus.Grid;
+    }
+
+    private void RestoreUndoRedoFocus(UndoRedoFocus focus)
+    {
+        switch (focus)
+        {
+            case UndoRedoFocus.EditTextBox:
+                Dispatcher.UIThread.Post(() => EditTextBox.Focus());
+                break;
+            case UndoRedoFocus.EditTextBoxOriginal:
+                Dispatcher.UIThread.Post(() => EditTextBoxOriginal.Focus());
+                break;
+            case UndoRedoFocus.AudioVisualizer:
+                Dispatcher.UIThread.Post(() => AudioVisualizer?.Focus());
+                break;
+        }
+    }
+
     private void RestoreSelectionToPreviousIndex(int preIndex, double? preRowTop = null, bool? restoreGridFocus = null)
     {
         if (Subtitles.Count == 0)
@@ -28059,13 +28077,8 @@ public partial class MainViewModel :
     private bool IsSubtitleGridFocused()
     {
         var focusedElement = Window?.FocusManager?.GetFocusedElement();
-        if (focusedElement == null || focusedElement == Window || focusedElement is LayoutTransformControl || focusedElement is MainView)
+        if (focusedElement == null)
         {
-            if (!IsTextInputFocused() && (AudioVisualizer == null || !AudioVisualizer.IsFocused) && !IsMainMenuFocused())
-            {
-                return true;
-            }
-
             return false;
         }
 

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Nikse.SubtitleEdit.UiLogic.Export;
+using Nikse.SubtitleEdit.UiLogic.Export;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -20806,6 +20806,10 @@ public partial class MainViewModel :
         {
             var preIndex = SelectedSubtitleIndex ?? 0;
             var preRowTop = GetSelectedRowViewportTop();
+            var preGridFocus = IsSubtitleGridFocused();
+            var preEditBoxFocus = EditTextBox.IsFocused;
+            var preEditBoxOriginalFocus = EditTextBoxOriginal.IsFocused;
+            var preAudioFocus = AudioVisualizer != null && AudioVisualizer.IsFocused;
 
             var undoRedoObject = _undoRedoManager.Undo()!;
             if (undoRedoObject?.Subtitles == null)
@@ -20814,7 +20818,21 @@ public partial class MainViewModel :
             }
 
             RestoreUndoRedoState(undoRedoObject, scrollToSelected: false);
-            RestoreSelectionToPreviousIndex(preIndex, preRowTop);
+            RestoreSelectionToPreviousIndex(preIndex, preRowTop, restoreGridFocus: preGridFocus || (!preEditBoxFocus && !preEditBoxOriginalFocus && !preAudioFocus));
+
+            if (preEditBoxFocus)
+            {
+                Dispatcher.UIThread.Post(() => EditTextBox.Focus());
+            }
+            else if (preEditBoxOriginalFocus)
+            {
+                Dispatcher.UIThread.Post(() => EditTextBoxOriginal.Focus());
+            }
+            else if (preAudioFocus)
+            {
+                Dispatcher.UIThread.Post(() => AudioVisualizer?.Focus());
+            }
+
             ShowUndoStatus();
         });
     }
@@ -20854,6 +20872,10 @@ public partial class MainViewModel :
         {
             var preIndex = SelectedSubtitleIndex ?? 0;
             var preRowTop = GetSelectedRowViewportTop();
+            var preGridFocus = IsSubtitleGridFocused();
+            var preEditBoxFocus = EditTextBox.IsFocused;
+            var preEditBoxOriginalFocus = EditTextBoxOriginal.IsFocused;
+            var preAudioFocus = AudioVisualizer != null && AudioVisualizer.IsFocused;
 
             var undoRedoObject = _undoRedoManager.Redo();
             if (undoRedoObject?.Subtitles == null)
@@ -20862,7 +20884,21 @@ public partial class MainViewModel :
             }
 
             RestoreUndoRedoState(undoRedoObject, scrollToSelected: false);
-            RestoreSelectionToPreviousIndex(preIndex, preRowTop);
+            RestoreSelectionToPreviousIndex(preIndex, preRowTop, restoreGridFocus: preGridFocus || (!preEditBoxFocus && !preEditBoxOriginalFocus && !preAudioFocus));
+
+            if (preEditBoxFocus)
+            {
+                Dispatcher.UIThread.Post(() => EditTextBox.Focus());
+            }
+            else if (preEditBoxOriginalFocus)
+            {
+                Dispatcher.UIThread.Post(() => EditTextBoxOriginal.Focus());
+            }
+            else if (preAudioFocus)
+            {
+                Dispatcher.UIThread.Post(() => AudioVisualizer?.Focus());
+            }
+
             ShowRedoStatus();
         });
     }
@@ -20890,14 +20926,14 @@ public partial class MainViewModel :
     /// the current line at the top of the grid on every Undo - disorienting when the user was
     /// working near the bottom of the view (#14517).
     /// </summary>
-    private void RestoreSelectionToPreviousIndex(int preIndex, double? preRowTop = null)
+    private void RestoreSelectionToPreviousIndex(int preIndex, double? preRowTop = null, bool? restoreGridFocus = null)
     {
         if (Subtitles.Count == 0)
         {
             return;
         }
 
-        SelectAndScrollToRow(Math.Clamp(preIndex, 0, Subtitles.Count - 1), null, keepRowViewportTop: preRowTop);
+        SelectAndScrollToRow(Math.Clamp(preIndex, 0, Subtitles.Count - 1), null, restoreGridFocus: restoreGridFocus, keepRowViewportTop: preRowTop);
     }
 
     public UndoRedoItem MakeUndoRedoObject(string description)
@@ -28023,8 +28059,13 @@ public partial class MainViewModel :
     private bool IsSubtitleGridFocused()
     {
         var focusedElement = Window?.FocusManager?.GetFocusedElement();
-        if (focusedElement == null)
+        if (focusedElement == null || focusedElement == Window || focusedElement is LayoutTransformControl || focusedElement is MainView)
         {
+            if (!IsTextInputFocused() && (AudioVisualizer == null || !AudioVisualizer.IsFocused) && !IsMainMenuFocused())
+            {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Input;
+using Avalonia.Input;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -262,6 +262,8 @@ public class ShortcutManager : IShortcutManager
             Key.LeftAlt or Key.RightAlt or
             Key.LWin or Key.RWin or Key.NumLock))
         {
+            _activeKeys.Clear();
+            _activeKeyNames.Clear();
             _activeKeys.Add(key);
             _activeKeyNames.Add(GetShortcutKeyName(e));
         }
@@ -425,11 +427,23 @@ public class ShortcutManager : IShortcutManager
         // Build the current state key list with initial capacity. Read from the
         // physical-key-aware name set so numpad keys hash distinctly from their
         // main-keyboard counterparts.
-        var currentInputKeys = new List<string>(_activeKeyNames.Count + 2);
+        var currentInputKeys = new List<string>(_activeKeyNames.Count + 4);
+        var currentKeyName = GetShortcutKeyName(keyEventArgs);
+        var isModifierKey = keyEventArgs.Key is (Key.LeftCtrl or Key.RightCtrl or
+            Key.LeftShift or Key.RightShift or
+            Key.LeftAlt or Key.RightAlt or
+            Key.LWin or Key.RWin or Key.NumLock);
 
-        foreach (var keyName in _activeKeyNames)
+        if (!isModifierKey && !string.IsNullOrEmpty(currentKeyName))
         {
-            currentInputKeys.Add(keyName);
+            currentInputKeys.Add(currentKeyName);
+        }
+        else
+        {
+            foreach (var keyName in _activeKeyNames)
+            {
+                currentInputKeys.Add(keyName);
+            }
         }
 
         // Add normalized modifiers based on the event state

--- a/src/ui/Logic/ShortcutManager.cs
+++ b/src/ui/Logic/ShortcutManager.cs
@@ -1,4 +1,4 @@
-using Avalonia.Input;
+﻿using Avalonia.Input;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
 using System;
@@ -262,6 +262,9 @@ public class ShortcutManager : IShortcutManager
             Key.LeftAlt or Key.RightAlt or
             Key.LWin or Key.RWin or Key.NumLock))
         {
+            // Only the most recent non-modifier key counts: a key-up can be lost when a
+            // shortcut moves focus (e.g. undo reloading the grid), and a stale key would
+            // otherwise block every following chord until the user releases everything.
             _activeKeys.Clear();
             _activeKeyNames.Clear();
             _activeKeys.Add(key);
@@ -427,23 +430,11 @@ public class ShortcutManager : IShortcutManager
         // Build the current state key list with initial capacity. Read from the
         // physical-key-aware name set so numpad keys hash distinctly from their
         // main-keyboard counterparts.
-        var currentInputKeys = new List<string>(_activeKeyNames.Count + 4);
-        var currentKeyName = GetShortcutKeyName(keyEventArgs);
-        var isModifierKey = keyEventArgs.Key is (Key.LeftCtrl or Key.RightCtrl or
-            Key.LeftShift or Key.RightShift or
-            Key.LeftAlt or Key.RightAlt or
-            Key.LWin or Key.RWin or Key.NumLock);
+        var currentInputKeys = new List<string>(_activeKeyNames.Count + 2);
 
-        if (!isModifierKey && !string.IsNullOrEmpty(currentKeyName))
+        foreach (var keyName in _activeKeyNames)
         {
-            currentInputKeys.Add(currentKeyName);
-        }
-        else
-        {
-            foreach (var keyName in _activeKeyNames)
-            {
-                currentInputKeys.Add(keyName);
-            }
+            currentInputKeys.Add(keyName);
         }
 
         // Add normalized modifiers based on the event state

--- a/tests/UI/Logic/ShortcutManagerTests.cs
+++ b/tests/UI/Logic/ShortcutManagerTests.cs
@@ -249,4 +249,37 @@ public class ShortcutManagerTests
 
         Assert.Same(command, manager.CheckShortcuts(control, category.ToString()));
     }
+
+    [Fact]
+    public void ContinuousShortcutsWhileHoldingModifierWorkFluently()
+    {
+        var manager = new ShortcutManager();
+        var category = ShortcutCategory.General;
+        var undo = new RelayCommand(() => { });
+        var redo = new RelayCommand(() => { });
+        manager.RegisterShortcut(new ShortCut("Undo", ["Control", "Z"], category, undo));
+        manager.RegisterShortcut(new ShortCut("Redo", ["Control", "Y"], category, redo));
+
+        // 1. Hold Ctrl
+        var ctrl = KeyEvent(Key.LeftCtrl, PhysicalKey.ControlLeft, KeyModifiers.Control);
+        manager.OnKeyPressed(null, ctrl);
+
+        // 2. Press Z -> Undo
+        var z = KeyEvent(Key.Z, PhysicalKey.Z, KeyModifiers.Control);
+        manager.OnKeyPressed(null, z);
+        Assert.Same(undo, manager.CheckShortcuts(z, category.ToString()));
+
+        // 3. While still holding Ctrl, press Y -> Redo (even if Z key-up wasn't fired yet)
+        var y = KeyEvent(Key.Y, PhysicalKey.Y, KeyModifiers.Control);
+        manager.OnKeyPressed(null, y);
+        Assert.Same(redo, manager.CheckShortcuts(y, category.ToString()));
+
+        // 4. While still holding Ctrl, press Z again -> Undo
+        manager.OnKeyPressed(null, z);
+        Assert.Same(undo, manager.CheckShortcuts(z, category.ToString()));
+
+        // 5. Key auto-repeat: pressing Z again without key-up
+        manager.OnKeyPressed(null, z);
+        Assert.Same(undo, manager.CheckShortcuts(z, category.ToString()));
+    }
 }


### PR DESCRIPTION
### Summary of Changes
- **Fluid Repeated Shortcuts**: Clear previous non-modifier keys in `ShortcutManager.OnKeyPressed` when a new action key is pressed while holding modifiers, allowing continuous shortcuts (e.g., holding `Ctrl` and pressing `Z` -> `Y` -> `Z`) without getting locked out.
- **Preserve & Restore Focus**: Saved previous focus controls (grid, edit boxes, audio visualizer) across `Undo`/`Redo` cycles in `MainViewModel`, preventing the UI from losing focus when rows are reloaded.
- **Window-level Key Routing**: Attached `KeyDownEvent` (Tunnel) directly to `hostWindow` in `MainView.cs` to ensure shortcuts are consistently caught even if focus shifts out of the inner user control.
- **Tests**: Added automated test `ContinuousShortcutsWhileHoldingModifierWorkFluently` in `ShortcutManagerTests.cs`.
