### PR TITLE
seconv: don't parse input paths in the summary table as markup (fix #14692)

### DIFF
--- a/src/seconv/Commands/ConvertCommand.cs
+++ b/src/seconv/Commands/ConvertCommand.cs
@@ -802,53 +802,9 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             var extension = LibSEIntegration.GetExtensionForFormat(settings.Format);
             var formatDisplay = $"{normalizedFormat} (*{extension})";
 
-            var table = new Table();
-            table.AddColumn("[yellow]Parameter[/]");
-            table.AddColumn("[green]Value[/]");
-            table.AddRow("Pattern", string.Join(", ", settings.Pattern));
-            table.AddRow("Format", formatDisplay);
-
-            if (!string.IsNullOrEmpty(settings.InputFolder))
-                table.AddRow("Input Folder", settings.InputFolder);
-
-            if (!string.IsNullOrEmpty(settings.OutputFolder))
-                table.AddRow("Output Folder", settings.OutputFolder);
-
-            if (settings.Fps.HasValue)
-                table.AddRow("FPS", settings.Fps.Value.ToString());
-
-            if (settings.TargetFps.HasValue)
-                table.AddRow("Target FPS", settings.TargetFps.Value.ToString());
-
-            if (!string.IsNullOrEmpty(settings.Encoding))
-                table.AddRow("Encoding", settings.Encoding);
-
-            if (string.IsNullOrEmpty(settings.Encoding) && !string.IsNullOrEmpty(settings.InputEncodingFallback))
-                table.AddRow("Input encoding fallback", settings.InputEncodingFallback);
-
-            if (operations.Count > 0)
-                table.AddRow("Operations", string.Join(", ", operations));
-
-            if (!string.IsNullOrWhiteSpace(settings.TranslateTo))
-            {
-                var translateEngine = string.IsNullOrWhiteSpace(settings.TranslateEngine) ? "llamacpp" : settings.TranslateEngine.Trim().ToLowerInvariant();
-                var translateFrom = string.IsNullOrWhiteSpace(settings.TranslateFrom) ? "auto" : settings.TranslateFrom;
-                var customPrompt = string.IsNullOrWhiteSpace(settings.TranslatePrompt) ? string.Empty : ", custom prompt";
-                table.AddRow("Translate", $"{translateFrom} -> {settings.TranslateTo} ({translateEngine}{customPrompt})");
-            }
-
-            if (settings.DeleteFirst.HasValue)
-                table.AddRow("Delete First", settings.DeleteFirst.Value.ToString());
-
-            if (settings.DeleteLast.HasValue)
-                table.AddRow("Delete Last", settings.DeleteLast.Value.ToString());
-
-            if (!string.IsNullOrEmpty(settings.DeleteContains))
-                table.AddRow("Delete Contains", settings.DeleteContains);
-
             if (!silent)
             {
-                AnsiConsole.Write(table);
+                AnsiConsole.Write(BuildSummaryTable(settings, operations, formatDisplay));
                 AnsiConsole.WriteLine();
             }
 
@@ -940,6 +896,65 @@ internal sealed class ConvertCommand : AsyncCommand<ConvertCommand.Settings>
             }
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Builds the "Parameter / Value" table shown before a conversion. Every user-supplied
+    /// value is escaped: Spectre parses table cells as markup, so an unescaped path such as
+    /// "input [test].json" threw "Could not find color or style 'test'" (issue #14692).
+    /// </summary>
+    internal static Table BuildSummaryTable(Settings settings, IReadOnlyList<string> operations, string formatDisplay)
+    {
+        var table = new Table();
+        table.AddColumn("[yellow]Parameter[/]");
+        table.AddColumn("[green]Value[/]");
+        AddRow(table, "Pattern", string.Join(", ", settings.Pattern));
+        AddRow(table, "Format", formatDisplay);
+
+        if (!string.IsNullOrEmpty(settings.InputFolder))
+            AddRow(table, "Input Folder", settings.InputFolder);
+
+        if (!string.IsNullOrEmpty(settings.OutputFolder))
+            AddRow(table, "Output Folder", settings.OutputFolder);
+
+        if (settings.Fps.HasValue)
+            AddRow(table, "FPS", settings.Fps.Value.ToString());
+
+        if (settings.TargetFps.HasValue)
+            AddRow(table, "Target FPS", settings.TargetFps.Value.ToString());
+
+        if (!string.IsNullOrEmpty(settings.Encoding))
+            AddRow(table, "Encoding", settings.Encoding);
+
+        if (string.IsNullOrEmpty(settings.Encoding) && !string.IsNullOrEmpty(settings.InputEncodingFallback))
+            AddRow(table, "Input encoding fallback", settings.InputEncodingFallback);
+
+        if (operations.Count > 0)
+            AddRow(table, "Operations", string.Join(", ", operations));
+
+        if (!string.IsNullOrWhiteSpace(settings.TranslateTo))
+        {
+            var translateEngine = string.IsNullOrWhiteSpace(settings.TranslateEngine) ? "llamacpp" : settings.TranslateEngine.Trim().ToLowerInvariant();
+            var translateFrom = string.IsNullOrWhiteSpace(settings.TranslateFrom) ? "auto" : settings.TranslateFrom;
+            var customPrompt = string.IsNullOrWhiteSpace(settings.TranslatePrompt) ? string.Empty : ", custom prompt";
+            AddRow(table, "Translate", $"{translateFrom} -> {settings.TranslateTo} ({translateEngine}{customPrompt})");
+        }
+
+        if (settings.DeleteFirst.HasValue)
+            AddRow(table, "Delete First", settings.DeleteFirst.Value.ToString());
+
+        if (settings.DeleteLast.HasValue)
+            AddRow(table, "Delete Last", settings.DeleteLast.Value.ToString());
+
+        if (!string.IsNullOrEmpty(settings.DeleteContains))
+            AddRow(table, "Delete Contains", settings.DeleteContains);
+
+        return table;
+    }
+
+    private static void AddRow(Table table, string name, string value)
+    {
+        table.AddRow(new Text(name), new Text(value));
     }
 
     /// <summary>

--- a/src/seconv/Helpers/InfoLintReporter.cs
+++ b/src/seconv/Helpers/InfoLintReporter.cs
@@ -34,15 +34,15 @@ internal static class InfoLintReporter
         table.AddColumn("[yellow]Field[/]");
         table.AddColumn("[green]Value[/]");
 
-        table.AddRow("Format", info.Format);
-        table.AddRow("Extension", info.Extension);
-        table.AddRow("Encoding", info.Encoding);
+        table.AddRow(new Text("Format"), new Text(info.Format));
+        table.AddRow(new Text("Extension"), new Text(info.Extension));
+        table.AddRow(new Text("Encoding"), new Text(info.Encoding));
         table.AddRow("File size", FormatBytes(info.FileSizeBytes));
         table.AddRow("Paragraphs", info.ParagraphCount.ToString());
         if (info.FirstStartMs.HasValue) table.AddRow("First start", FormatMs(info.FirstStartMs.Value));
         if (info.LastEndMs.HasValue) table.AddRow("Last end", FormatMs(info.LastEndMs.Value));
         if (info.DurationMs.HasValue) table.AddRow("Duration", FormatMs(info.DurationMs.Value));
-        if (!string.IsNullOrEmpty(info.Language)) table.AddRow("Language", info.Language);
+        if (!string.IsNullOrEmpty(info.Language)) table.AddRow(new Text("Language"), new Text(info.Language));
 
         AnsiConsole.Write(table);
     }

--- a/tests/seconv/Commands/ConvertCommandTest.cs
+++ b/tests/seconv/Commands/ConvertCommandTest.cs
@@ -1,0 +1,62 @@
+using SeConv.Commands;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using Xunit;
+
+namespace SeConvTests.Commands;
+
+public class ConvertCommandTest
+{
+    [Fact]
+    public void BuildSummaryTable_SquareBracketsInUserValues_AreNotParsedAsMarkup()
+    {
+        // Regression for #14692: Spectre parses table cells as markup, so an input file named
+        // "input [test].json" threw "Could not find color or style 'test'" before any
+        // conversion ran - even under --json/--quiet, where the table is never displayed.
+        var settings = new ConvertCommand.Settings
+        {
+            Pattern = ["input [test].json", "[red]other[/].srt"],
+            InputFolder = "Title [1080p Bluray]",
+            OutputFolder = "out [done]",
+            Encoding = "[bold]utf-8",
+            TranslateTo = "[green]da",
+            DeleteContains = "[/]",
+        };
+
+        var table = ConvertCommand.BuildSummaryTable(settings, ["FixCommonErrors"], "SubRip (*.srt)");
+
+        var console = new TestConsole();
+        console.Write(table);
+        var output = console.Output;
+
+        Assert.Contains("input [test].json", output);
+        Assert.Contains("[red]other[/].srt", output);
+        Assert.Contains("Title [1080p Bluray]", output);
+        Assert.Contains("out [done]", output);
+        Assert.Contains("[bold]utf-8", output);
+        Assert.Contains("[green]da", output);
+        Assert.Contains("[/]", output);
+    }
+
+    private sealed class TestConsole
+    {
+        private readonly IAnsiConsole _console;
+        private readonly StringWriter _writer = new();
+
+        public TestConsole()
+        {
+            _console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(_writer),
+                Interactive = InteractionSupport.No,
+            });
+            _console.Profile.Width = 200;
+        }
+
+        public void Write(IRenderable renderable) => _console.Write(renderable);
+
+        public string Output => _writer.ToString();
+    }
+}


### PR DESCRIPTION
Fixes #14692.

## Cause
The "Parameter / Value" table seconv prints before converting used `Table.AddRow(string[])`, which parses every cell as Spectre markup. A pattern like `input [test].json` was read as a style tag and threw `Could not find color or style 'test'`. The table was built unconditionally and only its `Write` was gated on `silent`, so `--json` and `--quiet` runs failed the same way with `totalFiles: 0`.

#11866 fixed the per-file progress lines and error handlers but never touched this table, and its regression test sits at the `SubtitleConverter` level, one layer below the crash.

## Fix
- Move the table into `ConvertCommand.BuildSummaryTable` and pass every cell as a `Text` widget, so paths, encodings, translate values and `--delete-contains` are never parsed as markup.
- Only build the table when it will be shown.
- Escape the `seconv info` table rows the same way.
- Add `ConvertCommandTest` covering brackets and literal style tags in every user-supplied cell.

## Verification
Reporter's repro (`input [test].json` → subrip) now succeeds with `--json`, `--quiet` and plain output; the plain run shows `Pattern │ input [test].json` in the table. Full seconv test suite: 477 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)