### PR TITLE
Export image: right/center justify Arabic lines precisely (fix #14696)

### DIFF
--- a/src/libuilogic/Export/ImageRenderer.cs
+++ b/src/libuilogic/Export/ImageRenderer.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using SkiaSharp;
 using SkiaSharp.HarfBuzz;
 using Nikse.SubtitleEdit.Core.BluRaySup;
@@ -525,36 +525,11 @@ public static class ImageRenderer
 
             // Calculate X position based on content alignment, relative to the widest line.
             // This keeps all lines within [textStartX, textStartX + maxLineWidth].
-            if (ip.IsRightToLeft)
-            {
-                if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
-                {
-                    currentX = textStartX + (maxLineWidth - lineWidth) / 2;
-                }
-                else if (ip.ResolvedContentAlignment == ExportContentAlignment.Left)
-                {
-                    currentX = textStartX + maxLineWidth - lineWidth;
-                }
-                else // Right (natural/default for RTL)
-                {
-                    currentX = textStartX;
-                }
-            }
-            else
-            {
-                if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
-                {
-                    currentX = textStartX + (maxLineWidth - lineWidth) / 2;
-                }
-                else if (ip.ResolvedContentAlignment == ExportContentAlignment.Right)
-                {
-                    currentX = textStartX + maxLineWidth - lineWidth;
-                }
-                else // Left (default)
-                {
-                    currentX = textStartX;
-                }
-            }
+            // "Right" is the visual right edge for right-to-left text too: DrawShapedText
+            // always draws from x rightwards, so the RTL flag changes the segment order
+            // but not which edge the lines share - and the box behind the text already
+            // used the visual edge (issue #14696).
+            currentX = GetLineStartX(ip.ResolvedContentAlignment, textStartX, maxLineWidth, lineWidth);
 
             for (var i = 0; i < segmentsToRender.Count; i++)
             {
@@ -706,20 +681,7 @@ public static class ImageRenderer
             var lineWidth = lineWidths[li];
             var currentY = baselines[li];
 
-            float currentX;
-            if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
-            {
-                currentX = textStartX + (maxLineWidth - lineWidth) / 2;
-            }
-            else if ((ip.ResolvedContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
-                     (ip.ResolvedContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
-            {
-                currentX = textStartX + maxLineWidth - lineWidth;
-            }
-            else
-            {
-                currentX = textStartX;
-            }
+            var currentX = GetLineStartX(ip.ResolvedContentAlignment, textStartX, maxLineWidth, lineWidth);
 
             for (var i = 0; i < segmentsToRender.Count; i++)
             {
@@ -824,20 +786,7 @@ public static class ImageRenderer
         for (var li = 0; li < lineGlyphs.Count; li++)
         {
             var lineWidth = lineWidths[li];
-            float lineLeft;
-            if (ip.ResolvedContentAlignment == ExportContentAlignment.Center)
-            {
-                lineLeft = textStartX + (maxLineWidth - lineWidth) / 2;
-            }
-            else if ((ip.ResolvedContentAlignment == ExportContentAlignment.Right && !ip.IsRightToLeft) ||
-                     (ip.ResolvedContentAlignment == ExportContentAlignment.Left && ip.IsRightToLeft))
-            {
-                lineLeft = textStartX + maxLineWidth - lineWidth;
-            }
-            else
-            {
-                lineLeft = textStartX;
-            }
+            var lineLeft = GetLineStartX(ip.ResolvedContentAlignment, textStartX, maxLineWidth, lineWidth);
 
             var baseline = textStartY + baselines[li];
 
@@ -1105,18 +1054,49 @@ public static class ImageRenderer
             (byte)(a.Alpha + (b.Alpha - a.Alpha) * t));
     }
 
+    /// <summary>
+    /// The x where a line starts so the lines of one subtitle share the chosen edge, relative
+    /// to the widest line. The edge is the visual one for every script: shaped text is drawn
+    /// from x rightwards whatever its direction (issue #14696).
+    /// </summary>
+    private static float GetLineStartX(ExportContentAlignment alignment, float textStartX, float maxLineWidth, float lineWidth)
+    {
+        return alignment switch
+        {
+            ExportContentAlignment.Center => textStartX + (maxLineWidth - lineWidth) / 2,
+            ExportContentAlignment.Right => textStartX + maxLineWidth - lineWidth,
+            _ => textStartX,
+        };
+    }
+
     // Helper method to measure text with HarfBuzz shaping via SKShaper
     private static float MeasureTextWithShaping(string text, SKFont font)
     {
         using var shaper = new SKShaper(font.Typeface);
         var result = shaper.Shape(text, font);
 
-        // Measure visual bounds to account for glyph overhang (important for italic text)
-        var bounds = new SKRect();
-        font.MeasureText(text, out bounds);
+        // The visual right edge (glyph overhang, e.g. italics) comes from the SHAPED glyphs.
+        // SKFont.MeasureText on the string measures the unshaped, isolated forms - for
+        // Arabic that is up to 40% wider than what is drawn, so right/center aligned lines
+        // ended at different edges (issue #14696).
+        var visualRight = 0f;
+        if (result.Codepoints.Length > 0)
+        {
+            var glyphs = new ushort[result.Codepoints.Length];
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                glyphs[i] = (ushort)result.Codepoints[i];
+            }
+
+            font.GetGlyphWidths(glyphs, out var glyphBounds);
+            for (var i = 0; i < glyphs.Length; i++)
+            {
+                visualRight = Math.Max(visualRight, result.Points[i].X + glyphBounds[i].Right);
+            }
+        }
 
         // Use the maximum of advance width and visual right edge
-        return Math.Max(result.Width, bounds.Right);
+        return Math.Max(result.Width, visualRight);
     }
 
     // Helper method to draw shaped text using SKShaper

--- a/tests/libuilogic/Export/ImageRendererRightToLeftAlignmentTests.cs
+++ b/tests/libuilogic/Export/ImageRendererRightToLeftAlignmentTests.cs
@@ -1,0 +1,96 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.Export;
+
+/// <summary>
+/// Right/center justified Arabic lines share the same edge (issue #14696): line widths come
+/// from the shaped glyphs, not the unshaped string, and "Right" is the visual right edge
+/// whether or not the right-to-left flag is on.
+/// </summary>
+public class ImageRendererRightToLeftAlignmentTests
+{
+    private static ImageParameter MakeParameter(string text, ExportContentAlignment alignment, bool isRightToLeft)
+    {
+        return new ImageParameter
+        {
+            Text = text,
+            FontName = "Arial",
+            FontSize = 40,
+            FontColor = SKColors.White,
+            OutlineColor = SKColors.Black,
+            OutlineWidth = 0,
+            ShadowColor = SKColors.Black,
+            ShadowWidth = 0,
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            LineSpacingPercent = 0,
+            ContentAlignment = alignment,
+            IsRightToLeft = isRightToLeft,
+        };
+    }
+
+    /// <summary>Rightmost/leftmost column with an opaque pixel in each half of the bitmap.</summary>
+    private static (int TopLeft, int TopRight, int BottomLeft, int BottomRight) GetInkEdges(SKBitmap bitmap)
+    {
+        var half = bitmap.Height / 2;
+        int Edge(int y0, int y1, bool right)
+        {
+            var edge = right ? -1 : int.MaxValue;
+            for (var y = y0; y < y1; y++)
+            {
+                for (var x = 0; x < bitmap.Width; x++)
+                {
+                    if (bitmap.GetPixel(x, y).Alpha > 128)
+                    {
+                        edge = right ? Math.Max(edge, x) : Math.Min(edge, x);
+                    }
+                }
+            }
+            return edge;
+        }
+
+        return (Edge(0, half, false), Edge(0, half, true), Edge(half, bitmap.Height, false), Edge(half, bitmap.Height, true));
+    }
+
+    // Two Arabic lines of very different width: unshaped measuring overestimated the long
+    // line by ~40%, so the short line ended tens of pixels away from the long line's edge.
+    private const string ArabicTwoLines = "- حسناً، استمرّ\n- (شفرة دافينشي)";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RightAlignedArabicLinesShareTheRightEdge(bool isRightToLeft)
+    {
+        using var bitmap = ImageRenderer.GenerateBitmap(MakeParameter(ArabicTwoLines, ExportContentAlignment.Right, isRightToLeft));
+
+        var edges = GetInkEdges(bitmap);
+
+        Assert.True(Math.Abs(edges.TopRight - edges.BottomRight) <= 2, $"right edges {edges.TopRight} vs {edges.BottomRight}");
+        Assert.True(edges.TopLeft != edges.BottomLeft, "lines are expected to differ in width");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LeftAlignedArabicLinesShareTheLeftEdge(bool isRightToLeft)
+    {
+        using var bitmap = ImageRenderer.GenerateBitmap(MakeParameter(ArabicTwoLines, ExportContentAlignment.Left, isRightToLeft));
+
+        var edges = GetInkEdges(bitmap);
+
+        Assert.True(Math.Abs(edges.TopLeft - edges.BottomLeft) <= 2, $"left edges {edges.TopLeft} vs {edges.BottomLeft}");
+    }
+
+    [Fact]
+    public void CenteredArabicLinesShareTheCenter()
+    {
+        using var bitmap = ImageRenderer.GenerateBitmap(MakeParameter(ArabicTwoLines, ExportContentAlignment.Center, true));
+
+        var edges = GetInkEdges(bitmap);
+        var topCenter = (edges.TopLeft + edges.TopRight) / 2.0;
+        var bottomCenter = (edges.BottomLeft + edges.BottomRight) / 2.0;
+
+        Assert.True(Math.Abs(topCenter - bottomCenter) <= 2, $"centers {topCenter} vs {bottomCenter}");
+    }
+}


### PR DESCRIPTION
Fixes #14696.

**Cause 1 - measuring the unshaped string.** `MeasureTextWithShaping` took the max of the shaped advance and `SKFont.MeasureText(text)` bounds. The latter measures the isolated, unjoined letter forms; for Arabic that is up to 40% wider than what HarfBuzz actually draws (e.g. `(شفرة دافينشي)` measured 315 px, drawn 222 px). Since every line was overestimated by a different amount, right/center justified lines ended at different edges. Punctuation and dashes made it worse because they are the parts measured "correctly", so the error varied line to line. The visual right edge is now taken from the shaped glyphs' bounds, so italic overhang is still covered.

**Cause 2 - inverted alignment with the RTL checkbox.** With "Right to left" checked, the three text paths mapped Content alignment *Right* to the visual left edge and *Left* to the visual right, while the box-per-line path used the visual edge - so text and boxes disagreed. `DrawShapedText` always draws from x rightwards regardless of script direction, so the alignment now means the visual edge everywhere, via one shared `GetLineStartX`.

Before / after with the sample from the issue (Right, RTL on):

| before | after |
|---|---|
| lines start at the left, boxes at the right | both lines share the right edge |

**Tests:** new `ImageRendererRightToLeftAlignmentTests` renders two Arabic lines of different width with Right/Left/Center (RTL on and off) and checks the ink edges line up within 2 px. All 4 alignment cases fail on the old renderer (right edges off by 32 px / 38 px) and pass with the fix. Full libuilogic suite (819) and UI ImageRenderer tests (28) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)