### PR TITLE
OCR: keep a row selected after deleting lines

### DIFF
--- a/src/ui/Features/Ocr/OcrViewModel.cs
+++ b/src/ui/Features/Ocr/OcrViewModel.cs
@@ -2372,39 +2372,34 @@ public partial class OcrViewModel : ObservableObject
             return;
         }
 
-        var selectedIndices = new List<int>();
-        foreach (var selectedItem in selectedItems)
+        var itemsToRemove = selectedItems
+            .OfType<OcrSubtitleItem>()
+            .Where(item => OcrSubtitleItems.Contains(item))
+            .ToList();
+        if (itemsToRemove.Count == 0)
         {
-            if (selectedItem is OcrSubtitleItem item)
-            {
-                var idx = OcrSubtitleItems.IndexOf(item);
-                if (idx >= 0)
-                {
-                    selectedIndices.Add(idx);
-
-                    var remov = UnknownWords.Where(uw => uw.Item == item).ToList();
-                    foreach (var unknownWord in remov)
-                    {
-                        UnknownWords.Remove(unknownWord);
-                    }
-                }
-            }
+            return;
         }
 
-        var itemsToRemove = selectedIndices
-            .Select(idx => OcrSubtitleItems[idx])
-            .ToList();
+        // Removing the focused row's container drops keyboard focus to null synchronously,
+        // so decide whether the grid should get it back before anything is removed.
+        var gridHadFocus = IsSubtitleGridFocusedOrFocusDropped();
+        var survivor = PickRowToSelectAfterRemoval(itemsToRemove);
+
+        // Hand the selection to the survivor before the rows go (#14708). Removing the selected
+        // rows first emptied the selection, which the TwoWay SelectedItem binding wrote back as
+        // null - the row highlight vanished and the grid scrolled to wherever its own fallback
+        // landed. With the survivor already the single selected row, the selection never empties.
+        if (survivor != null)
+        {
+            SubtitleGrid.SelectedItem = survivor;
+        }
 
         foreach (var item in itemsToRemove)
         {
             OcrSubtitleItems.Remove(item);
             _allOcrSubtitleItems.Remove(item);
         }
-
-        //foreach (var index in selectedIndices.OrderByDescending(p => p))
-        //{
-        //    _ocrSubtitle?.Delete(index);
-        //}
 
         Renumber();
 
@@ -2421,6 +2416,81 @@ public partial class OcrViewModel : ObservableObject
         {
             UnknownWords.Remove(item);
         }
+
+        if (survivor != null)
+        {
+            SelectedOcrSubtitleItem = survivor;
+            SubtitleGrid.SelectedItem = survivor;
+            SelectAndScrollToRow(OcrSubtitleItems.IndexOf(survivor));
+        }
+        else
+        {
+            SelectedOcrSubtitleItem = null;
+            SubtitleGrid.SelectedItem = null;
+        }
+
+        if (gridHadFocus)
+        {
+            Dispatcher.UIThread.Post(() => TableViewExtras.FocusRow(SubtitleGrid), DispatcherPriority.Background);
+        }
+    }
+
+    /// <summary>
+    /// The row that becomes current once <paramref name="rowsToRemove"/> are gone: the first
+    /// surviving row below the first removed one (the line that visually takes its place),
+    /// else the last surviving row above it. Null when nothing is left to select.
+    /// </summary>
+    private OcrSubtitleItem? PickRowToSelectAfterRemoval(IReadOnlyCollection<OcrSubtitleItem> rowsToRemove)
+    {
+        var removeSet = new HashSet<OcrSubtitleItem>(rowsToRemove);
+
+        var firstIndex = -1;
+        for (var i = 0; i < OcrSubtitleItems.Count; i++)
+        {
+            if (removeSet.Contains(OcrSubtitleItems[i]))
+            {
+                firstIndex = i;
+                break;
+            }
+        }
+
+        if (firstIndex < 0)
+        {
+            return null;
+        }
+
+        for (var i = firstIndex + 1; i < OcrSubtitleItems.Count; i++)
+        {
+            if (!removeSet.Contains(OcrSubtitleItems[i]))
+            {
+                return OcrSubtitleItems[i];
+            }
+        }
+
+        for (var i = firstIndex - 1; i >= 0; i--)
+        {
+            if (!removeSet.Contains(OcrSubtitleItems[i]))
+            {
+                return OcrSubtitleItems[i];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// True when keyboard focus is on the subtitle grid (or one of its rows), or on nothing
+    /// in particular (the window root), which is where focus lands after a row removal.
+    /// </summary>
+    private bool IsSubtitleGridFocusedOrFocusDropped()
+    {
+        var focused = Window?.FocusManager?.GetFocusedElement();
+        if (focused == null || ReferenceEquals(focused, Window))
+        {
+            return true;
+        }
+
+        return SubtitleGrid.IsFocused || SubtitleGrid.IsKeyboardFocusWithin;
     }
 
     private void Renumber()

--- a/tests/UI/Features/Ocr/OcrTableViewTests.cs
+++ b/tests/UI/Features/Ocr/OcrTableViewTests.cs
@@ -338,4 +338,109 @@ public class OcrTableViewTests
 
         window.Close();
     }
+
+    [AvaloniaFact]
+    public void OcrWindow_DeleteSelectedLine_SelectsTheRowThatTakesItsPlace()
+    {
+        var vm = MakeViewModel(6);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        tableView.SelectedIndex = 2;
+        Dispatcher.UIThread.RunJobs();
+        var survivor = vm.OcrSubtitleItems[3];
+
+        vm.DeleteSelectedLinesCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(5, vm.OcrSubtitleItems.Count);
+        Assert.Same(survivor, vm.SelectedOcrSubtitleItem);
+        Assert.Equal(2, tableView.SelectedIndex);
+        Assert.Single(tableView.SelectedItems!);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_DeleteLastLine_SelectsTheNewLastRow()
+    {
+        var vm = MakeViewModel(4);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        tableView.SelectedIndex = 3;
+        Dispatcher.UIThread.RunJobs();
+        var survivor = vm.OcrSubtitleItems[2];
+
+        vm.DeleteSelectedLinesCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(3, vm.OcrSubtitleItems.Count);
+        Assert.Same(survivor, vm.SelectedOcrSubtitleItem);
+        Assert.Equal(2, tableView.SelectedIndex);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_DeleteMultipleLines_SelectsRowAfterTheBlock()
+    {
+        var vm = MakeViewModel(8);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+
+        tableView.SelectedItems!.Clear();
+        tableView.SelectedItems.Add(vm.OcrSubtitleItems[4]);
+        tableView.SelectedItems.Add(vm.OcrSubtitleItems[2]);
+        tableView.SelectedItems.Add(vm.OcrSubtitleItems[3]);
+        Dispatcher.UIThread.RunJobs();
+        var survivor = vm.OcrSubtitleItems[5];
+
+        vm.DeleteSelectedLinesCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(5, vm.OcrSubtitleItems.Count);
+        Assert.Same(survivor, vm.SelectedOcrSubtitleItem);
+        Assert.Equal(2, tableView.SelectedIndex);
+        Assert.Single(tableView.SelectedItems);
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void OcrWindow_DeleteLineFarDown_KeepsTheViewportWhereItWas()
+    {
+        var vm = MakeViewModel(400);
+        var window = ShowWindow(vm);
+        var tableView = GetTableView(window);
+        var scrollViewer = tableView.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        tableView.ScrollIntoView(250);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        tableView.SelectedIndex = 250;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var topBefore = FirstVisibleIndex(tableView, scrollViewer);
+        Assert.True(topBefore > 200, $"Expected to be scrolled near row 250, top row was {topBefore}");
+
+        vm.DeleteSelectedLinesCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        // The row below took the deleted one's place and the list did not jump to the top.
+        Assert.Equal(250, tableView.SelectedIndex);
+        var topAfter = FirstVisibleIndex(tableView, scrollViewer);
+        Assert.True(Math.Abs(topAfter - topBefore) <= 2, $"Viewport moved from row {topBefore} to row {topAfter}");
+
+        window.Close();
+    }
 }


### PR DESCRIPTION
Fixes #14708

**Problem:** deleting a line in the OCR window removed the selected rows first, which emptied the grid selection. The TwoWay `SelectedItem` binding wrote that back as null, so the row highlight vanished and the grid scrolled to wherever its own fallback landed.

**Fix:** hand the selection to the survivor before the rows go, the same pattern the main grid uses (PR #13968): the row below the first removed one, else the row above. Then scroll to it and give the grid keyboard focus back so a repeated Delete keeps working.

**Tests:** four new headless probes in `OcrTableViewTests` (single delete, last row, multi-row block, viewport stays put on a 400-row list). The first three fail on main with `SelectedOcrSubtitleItem == null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)