### PR TITLE
Fix SCC import timing: apply control codes at their frame within the line

### DIFF
--- a/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
+++ b/src/libse/SubtitleFormats/ScenaristClosedCaptions.cs
@@ -1321,63 +1321,76 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             {
                 var s = line.Trim();
                 var match = RegexTimeCodes.Match(s);
-                if (match.Success)
+                if (!match.Success)
                 {
-                    var startTime = ParseTimeCode(s.Substring(0, match.Length - 1));
-                    var payload = s.Substring(match.Length).Trim().ToLowerInvariant();
-                    var parts = payload.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                    var text = GetSccText(payload, ref _errorCount);
+                    continue;
+                }
 
-                    // Reject rows that are raw CEA-608 data words rendered as text instead of
-                    // valid captions (#11341). Real caption text is positioned with a Preamble
-                    // Address Code and is at most 32 columns wide, so a row with no PAC that
-                    // decodes to an over-long line is garbage and must not be emitted as a cue.
-                    if (!string.IsNullOrWhiteSpace(text) && !HasPreambleAddressCode(parts) && AnyLineTooLong(text))
+                var lineTimeCode = s.Substring(0, match.Length - 1);
+                var payload = s.Substring(match.Length).Trim().ToLowerInvariant();
+                var parts = payload.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                var text = GetSccText(payload, ref _errorCount);
+
+                // Reject rows that are raw CEA-608 data words rendered as text instead of
+                // valid captions (#11341). Real caption text is positioned with a Preamble
+                // Address Code and is at most 32 columns wide, so a row with no PAC that
+                // decodes to an over-long line is garbage and must not be emitted as a cue.
+                if (!string.IsNullOrWhiteSpace(text) && !HasPreambleAddressCode(parts) && AnyLineTooLong(text))
+                {
+                    _errorCount++;
+                    text = string.Empty;
+                }
+
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    loadedText = text;
+                }
+
+                // A line's timecode is the time of its first byte pair only: CEA-608 carries one
+                // pair per frame, so a control code takes effect at the line time plus its index
+                // in the line. Files that pack a whole pop-on caption onto one line put the
+                // display code 20-30 pairs in, which is where broadcast decoders show it (#14703).
+                // Codes are applied in line order - a clear before a display ends the previous
+                // caption first - and the doubled code is the 608 redundancy copy, which a
+                // decoder ignores, so only the first of a pair counts.
+                var hasDisplay = false;
+                for (var i = 0; i < parts.Length; i++)
+                {
+                    var part = parts[i];
+                    var isRepeat = i > 0 && parts[i - 1] == part;
+                    if (part == "942f" && !isRepeat)
                     {
-                        _errorCount++;
-                        text = string.Empty;
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(text))
-                    {
-                        loadedText = text;
-                    }
-
-                    var hasDisplay = ContainsSccCommand(parts, "942f");
-                    var hasClear = ContainsSccCommand(parts, "942c");
-                    var hasEraseNonDisplayedMemory = ContainsSccCommand(parts, "94ae");
-
-                    if (hasDisplay)
-                    {
+                        hasDisplay = true;
+                        var displayTime = ParseTimeCode(lineTimeCode, i);
                         if (p != null && p.EndTime.TotalMilliseconds <= p.StartTime.TotalMilliseconds)
                         {
-                            p.EndTime.TotalMilliseconds = startTime.TotalMilliseconds;
+                            p.EndTime.TotalMilliseconds = displayTime.TotalMilliseconds;
                         }
 
                         if (!string.IsNullOrWhiteSpace(loadedText))
                         {
-                            p = new Paragraph(startTime, new TimeCode(startTime.TotalMilliseconds), loadedText);
+                            p = new Paragraph(displayTime, new TimeCode(displayTime.TotalMilliseconds), loadedText);
                             subtitle.Paragraphs.Add(p);
                         }
 
                         loadedText = null;
                     }
-
-                    if (hasClear)
+                    else if (part == "942c" && !isRepeat)
                     {
                         if (p != null)
                         {
-                            p.EndTime.TotalMilliseconds = startTime.TotalMilliseconds;
+                            p.EndTime.TotalMilliseconds = ParseTimeCode(lineTimeCode, i).TotalMilliseconds;
                             p = null;
                         }
                     }
+                }
 
-                    if (hasEraseNonDisplayedMemory && !hasDisplay && string.IsNullOrWhiteSpace(text))
-                    {
-                        loadedText = null;
-                    }
+                if (!hasDisplay && string.IsNullOrWhiteSpace(text) && ContainsSccCommand(parts, "94ae"))
+                {
+                    loadedText = null;
                 }
             }
+
             for (int i = subtitle.Paragraphs.Count - 2; i >= 0; i--)
             {
                 p = subtitle.GetParagraphOrDefault(i);
@@ -1875,10 +1888,50 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             return alignment + HtmlUtil.FixInvalidItalicTags(res);
         }
 
-        private static TimeCode ParseTimeCode(string start)
+        /// <summary>
+        /// Time of the byte pair <paramref name="frameOffset"/> frames after the line timecode.
+        /// The frame field follows the current frame rate like the other frame-based formats
+        /// (SCC is 29.97 by spec, but 23.976/25 fps files exist), and it is not capped at
+        /// 999 ms: frame 29 of a 29.97 file loaded at 23.976 is still a real time.
+        /// </summary>
+        private TimeCode ParseTimeCode(string start, int frameOffset)
         {
             var arr = start.Split(new[] { ':', ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
-            return new TimeCode(int.Parse(arr[0]), int.Parse(arr[1]), int.Parse(arr[2]), FramesToMillisecondsMax999(int.Parse(arr[3])));
+            var hours = int.Parse(arr[0]);
+            var minutes = int.Parse(arr[1]);
+            var seconds = int.Parse(arr[2]);
+            var frames = int.Parse(arr[3]);
+            var framesPerSecond = Math.Max(1, (int)Math.Round(Configuration.Settings.General.CurrentFrameRate));
+            for (var i = 0; i < frameOffset; i++)
+            {
+                frames++;
+                if (frames < framesPerSecond)
+                {
+                    continue;
+                }
+
+                frames = 0;
+                seconds++;
+                if (seconds >= 60)
+                {
+                    seconds = 0;
+                    minutes++;
+                    if (minutes >= 60)
+                    {
+                        minutes = 0;
+                        hours++;
+                    }
+
+                    // Drop-frame labels skip 00 and 01 at the start of every minute except every tenth.
+                    if (DropFrame && minutes % 10 != 0)
+                    {
+                        frames = 2;
+                    }
+                }
+            }
+
+            var totalMilliseconds = hours * 3600000.0 + minutes * 60000.0 + seconds * 1000.0 + FramesToMilliseconds(frames);
+            return new TimeCode(totalMilliseconds);
         }
 
         private static int CalculatePreRollMilliseconds(string loadData)

--- a/tests/libse/SubtitleFormats/ScenaristClosedCaptionsTest.cs
+++ b/tests/libse/SubtitleFormats/ScenaristClosedCaptionsTest.cs
@@ -22,6 +22,136 @@ public class ScenaristClosedCaptionsTest
         return subtitle;
     }
 
+    private static Subtitle LoadSccDropFrame(params string[] timedRows)
+    {
+        var lines = new List<string> { "Scenarist_SCC V1.0", "" };
+        foreach (var row in timedRows)
+        {
+            lines.Add(row);
+            lines.Add(string.Empty);
+        }
+
+        var subtitle = new Subtitle();
+        new ScenaristClosedCaptionsDropFrame().LoadSubtitle(subtitle, lines, "test.scc");
+        return subtitle;
+    }
+
+    private static void WithFrameRate(double frameRate, Action action)
+    {
+        var savedRate = Configuration.Settings.General.CurrentFrameRate;
+        try
+        {
+            Configuration.Settings.General.CurrentFrameRate = frameRate;
+            action();
+        }
+        finally
+        {
+            Configuration.Settings.General.CurrentFrameRate = savedRate;
+        }
+    }
+
+    // Lines from the #14703 sample: a whole pop-on caption packed onto one line, the display
+    // code (942f) 25 byte pairs in. One pair is sent per frame, so the caption shows at
+    // 01:02:40:02, not at the line's 01:02:39:07 - which is what Telestream Switch shows.
+    private const string ChatterLine = "01:02:37:14\t9420 9420 94f2 94f2 97a2 97a2 5be9 6e64 e973 f4e9 6ee3 f420 e368 61f4 f4e5 f25d 942c 942c 942f 942f";
+    private const string HorsesLine = "01:02:39:07\t9420 9420 94d0 94d0 c2f2 e96e 6720 f468 e520 68ef f273 e573 20f2 ef75 6e64 2c80 9470 9470 f7ef 75ec 6420 79ef 75bf 942c 942c 942f 942f";
+    private const string LaughsLine = "01:02:41:10\t9420 9420 9476 9476 5bec 6175 6768 735d 942c 942c 942f 942f";
+
+    [Fact]
+    public void PackedPopOnLineDisplaysAtTheEndOfCaptionFrame()
+    {
+        WithFrameRate(29.97, () =>
+        {
+            var subtitle = LoadScc(ChatterLine, HorsesLine, LaughsLine, "01:02:42:21\t942c 942c 8080 8080");
+
+            Assert.Equal(3, subtitle.Paragraphs.Count);
+            Assert.Equal("01:02:40:02", subtitle.Paragraphs[1].StartTime.ToHHMMSSFF());
+            Assert.Contains("Bring the horses", subtitle.Paragraphs[1].Text);
+        });
+    }
+
+    [Fact]
+    public void ClearBeforeDisplayOnTheSameLineEndsThePreviousCaptionAtTheClearFrame()
+    {
+        WithFrameRate(29.97, () =>
+        {
+            var subtitle = LoadScc(ChatterLine, HorsesLine, LaughsLine, "01:02:42:21\t942c 942c 8080 8080");
+
+            // 942c is pair 23 of the horses line: 01:02:39:07 + 23 frames.
+            Assert.Equal("01:02:40:00", subtitle.Paragraphs[0].EndTime.ToHHMMSSFF());
+        });
+    }
+
+    [Fact]
+    public void StandaloneClearLineEndsTheDisplayedCaption()
+    {
+        WithFrameRate(29.97, () =>
+        {
+            var subtitle = LoadScc(
+                "01:02:26:20\t9420 9420 94f2 94f2 9723 9723 57e5 a7f2 e520 64ef e96e 6720 61ec f2e9 6768 f42c 2068 7568 bf80 942c 942c 942f 942f",
+                "01:02:29:11\t942c 942c 8080 8080",
+                "01:02:30:16\t9420 9420 94f2 94f2 9723 9723 d9ef 7520 6861 76e5 20f4 68e5 2067 68f4 2068 ef75 73e5 ae80 942c 942c 942f 942f");
+
+            Assert.Equal(2, subtitle.Paragraphs.Count);
+            Assert.Equal("01:02:29:11", subtitle.Paragraphs[0].EndTime.ToHHMMSSFF());
+        });
+    }
+
+    [Fact]
+    public void DoubledControlCodeCountsOnce()
+    {
+        WithFrameRate(29.97, () =>
+        {
+            // 942f is pair 5; its redundancy copy at pair 6 must not start a second caption or move the time.
+            var subtitle = LoadScc("00:00:10:00\t94ae 94ae 9420 9420 9470 9470 4fcb 942f 942f", "00:00:12:00\t942c 942c");
+
+            Assert.Single(subtitle.Paragraphs);
+            Assert.Equal("00:00:10:07", subtitle.Paragraphs[0].StartTime.ToHHMMSSFF());
+            Assert.Equal("00:00:12:00", subtitle.Paragraphs[0].EndTime.ToHHMMSSFF());
+        });
+    }
+
+    [Fact]
+    public void FrameOffsetRollsOverAtTheFrameRate()
+    {
+        WithFrameRate(29.97, () =>
+        {
+            var subtitle = LoadScc("00:00:59:27\t9420 9420 9470 9470 4fcb 942f 942f", "00:01:05:00\t942c 942c");
+
+            Assert.Equal("00:01:00:02", subtitle.Paragraphs[0].StartTime.ToHHMMSSFF());
+        });
+
+        WithFrameRate(25, () =>
+        {
+            var subtitle = LoadScc("00:00:59:22\t9420 9420 9470 9470 4fcb 942f 942f", "00:01:05:00\t942c 942c");
+
+            Assert.Equal("00:01:00:02", subtitle.Paragraphs[0].StartTime.ToHHMMSSFF());
+        });
+    }
+
+    [Fact]
+    public void DropFrameOffsetSkipsTheTwoDroppedFrameNumbers()
+    {
+        WithFrameRate(29.97, () =>
+        {
+            var subtitle = LoadSccDropFrame("00:00:59;27\t9420 9420 9470 9470 4fcb 942f 942f", "00:01:05;00\t942c 942c");
+
+            Assert.Equal("00:01:00:04", subtitle.Paragraphs[0].StartTime.ToHHMMSSFF());
+        });
+    }
+
+    [Fact]
+    public void FrameFieldIsNotCappedAt999Milliseconds()
+    {
+        // A 29.97 file loaded at 23.976: frame 28 is a real time past the second, not 999 ms.
+        WithFrameRate(23.976, () =>
+        {
+            var subtitle = LoadScc("00:00:00:00\t9420 9420 9470 9470 4fcb", "00:00:00:28\t942f 942f", "00:00:04:00\t942c 942c");
+
+            Assert.Equal(1168, subtitle.Paragraphs[0].StartTime.TotalMilliseconds, 0);
+        });
+    }
+
     [Fact]
     public void ImportValidCaption()
     {

--- a/tests/seconv/Core/MalformedSccTest.cs
+++ b/tests/seconv/Core/MalformedSccTest.cs
@@ -69,7 +69,9 @@ public class MalformedSccTest : IDisposable
         Assert.IsType<ScenaristClosedCaptions>(format);
         var paragraph = Assert.Single(subtitle.Paragraphs);
         Assert.Equal("Hello world", paragraph.Text);
-        Assert.Equal(1000, paragraph.StartTime.TotalMilliseconds, precision: 0);
+        // The display code (942f) is byte pair 14 of the line and CEA-608 sends one pair per
+        // frame, so the caption shows 14 frames after the line's 00:00:01:00 (#14703).
+        Assert.Equal(1000 + SubtitleFormat.FramesToMilliseconds(14), paragraph.StartTime.TotalMilliseconds, precision: 0);
         Assert.Equal(3000, paragraph.EndTime.TotalMilliseconds, precision: 0);
         Assert.Empty(warnings);
     }


### PR DESCRIPTION
Fixes #14703

## What was wrong

CEA-608 transmits one byte pair per frame, so an SCC line's timecode is only the time of its **first** pair. The reader applied every control code on a line at the line's timecode. Files that pack a whole pop-on caption onto one line (RCL, PAC, text, `942c 942c 942f 942f`) put the display code 20-30 pairs in, so SE showed the caption up to a second before broadcast decoders. On the issue's sample line at `01:02:39:07` the first `942f` is pair 25, which is `01:02:40:02` - exactly what Telestream Switch shows.

Two more defects surfaced on the same path:

- **Standalone clear lines were ignored.** The reader processed display before clear regardless of line order, so for `942c 942c 942f 942f` the clear nulled the paragraph the display had just created. A later `01:02:29:11  942c 942c 8080 8080` line then found nothing to end, and the post-pass extended the caption to the next caption's start.
- **Frame field capped at 999 ms.** The shared helper caps a frame value at 999 ms, so with a 23.976 setting frames 24-29 of a 29.97 file all collapsed to the same millisecond.

## Fix

- Walk each line's pairs and apply `942c` / `942f` at the line time plus the pair index, in line order. The doubled code is the 608 redundancy copy and counts once.
- Frame arithmetic rolls over at the current frame rate's frame count, with the drop-frame skip of frame numbers 00/01 at minute boundaries. The frame field follows the current frame rate like SE's other frame-based formats (SCC is 29.97 by spec, but 23.976/25 fps files exist), and is no longer capped.
- The writer already pre-rolls load data and puts `942f` first on its own line, so SE-written files are unaffected.

Sample (lines from the issue's screenshot) at 29.97:

| Caption | Before | After | Switch |
|---|---|---|---|
| "Bring the horses round" start | 01:02:39:07 | 01:02:40:02 | 01:02:40:02 |
| "[indistinct chatter]" end | 01:02:39:07 | 01:02:40:00 | |
| "We're doing alright, huh?" end | 01:02:30:16 | 01:02:29:11 | |

## Tests

Seven new tests in `ScenaristClosedCaptionsTest`: packed pop-on line, clear-before-display on one line, standalone clear line, doubled code counted once, rollover at 29.97 and 25, drop-frame skip, uncapped frame field. 108 SCC/broadcast/sweep tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)