### PR TITLE
Let the waveform paragraph footer be turned off in settings

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -13020,6 +13020,11 @@ public partial class MainViewModel :
             AudioVisualizer.ShowOriginalSubtitleOverlay = Se.Settings.Waveform.ShowOriginalSubtitle;
             AudioVisualizer.ResetCache();
 
+            // Purely visual waveform settings (paragraph footer toggles, fonts, colors) are read
+            // straight from Se.Settings while drawing, and none of them is an AffectsRender
+            // property, so ask for a repaint instead of waiting for the next selection change.
+            AudioVisualizer.InvalidateVisual();
+
             InitializeLibMpv();
             InitializeFfmpeg();
             LoadShortcuts();

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -587,6 +587,11 @@ public class SettingsPage : UserControl
                 () => UiUtil.MakeComboBox(_vm.WaveformMouseWheelVideoPositionSteps, _vm, nameof(_vm.SelectedWaveformMouseWheelVideoPositionStep))),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformCenterVideoPositionAlsoWhenPaused, nameof(_vm.WaveformCenterVideoPositionAlsoWhenPaused)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformDrawGridLines, nameof(_vm.WaveformDrawGridLines)),
+            // SE 4 parity: the per-paragraph footer in the waveform ("#43  01:10" and the
+            // chars/sec line above it) can be turned off - some users find it noisy (#14707).
+            // Composed from existing strings so no new translatable text is needed.
+            MakeCheckboxSetting($"{Se.Language.General.Show} {Se.Language.General.NumberSymbol} + {Se.Language.General.Duration}", nameof(_vm.WaveformShowNumberAndDuration)),
+            MakeCheckboxSetting($"{Se.Language.General.Show} {Se.Language.General.CharsPerSec}", nameof(_vm.WaveformShowCps)),
             new SettingsItem(Se.Language.Options.Settings.WaveformTextFontSize, () => UiUtil.MakeNumericUpDownInt(
                 10 ,
                 100,

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -270,6 +270,8 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _autoOpenVideoFile;
 
     [ObservableProperty] private bool _waveformDrawGridLines;
+    [ObservableProperty] private bool _waveformShowNumberAndDuration;
+    [ObservableProperty] private bool _waveformShowCps;
     [ObservableProperty] private bool _waveformFocusOnMouseOver;
     [ObservableProperty] private bool _waveformCenterVideoPosition;
     [ObservableProperty] private bool _waveformCenterVideoPositionAlsoWhenPaused;
@@ -950,6 +952,8 @@ public partial class SettingsViewModel : ObservableObject
         ShowUpDownLabels = appearance.ShowUpDownLabels;
 
         WaveformDrawGridLines = Se.Settings.Waveform.DrawGridLines;
+        WaveformShowNumberAndDuration = Se.Settings.Waveform.WaveformShowNumberAndDuration;
+        WaveformShowCps = Se.Settings.Waveform.WaveformShowCps;
         WaveformFocusOnMouseOver = Se.Settings.Waveform.FocusOnMouseOver;
         WaveformCenterVideoPosition = Se.Settings.Waveform.CenterVideoPosition;
         WaveformCenterVideoPositionAlsoWhenPaused = Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused;
@@ -1820,6 +1824,8 @@ public partial class SettingsViewModel : ObservableObject
         appearance.ShowHorizontalLineAboveToolbar = ShowHorizontalLineAboveToolbar;
 
         Se.Settings.Waveform.DrawGridLines = WaveformDrawGridLines;
+        Se.Settings.Waveform.WaveformShowNumberAndDuration = WaveformShowNumberAndDuration;
+        Se.Settings.Waveform.WaveformShowCps = WaveformShowCps;
         Se.Settings.Waveform.FocusOnMouseOver = WaveformFocusOnMouseOver;
         Se.Settings.Waveform.CenterVideoPosition = WaveformCenterVideoPosition;
         Se.Settings.Waveform.CenterVideoPositionAlsoWhenPaused = WaveformCenterVideoPositionAlsoWhenPaused;


### PR DESCRIPTION
Fixes #14707.

The waveform draws a small footer under each paragraph — `#43  01:10`, with a chars/sec line above it. SE 4 let you switch those off under **Waveform/spectrogram** ("Show chars/sec" / "Show words/min"); SE 5 kept the two settings behind the footer (`WaveformShowNumberAndDuration`, `WaveformShowCps` — both default on, both already honoured by `DrawParagraphFooter`) but never exposed them, so there was no way to hide the labels.

## What changed

- Two checkboxes in the **Waveform/spectrogram** settings section, right after "Draw grid lines" (where SE 4 has them), bound to the existing settings.
- **No new language string**: the labels are composed from strings that already exist — `Show` + `NumberSymbol` + `Duration` → "Show # + Duration", and `Show` + `CharsPerSec` → "Show Chars/sec". So every translation gets them for free.
- `MainViewModel` now calls `AudioVisualizer.InvalidateVisual()` after applying settings. The footer toggles (like the waveform font/colour settings) are read from `Se.Settings` at draw time and none of them is an `AffectsRender` property, so without this the change only showed up on the next selection change.

SE 5's waveform never draws words/min, so there is nothing to toggle for that half of the SE 4 pair.

## Verification

- `dotnet build src/ui/UI.csproj` clean.
- Rendered the settings window headlessly and confirmed both rows appear in the Waveform/spectrogram section with the composed labels and the correct (checked) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)