### PR TITLE
Underline button access keys so Alt+F / Alt+R in Replace are discoverable

### DIFF
--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -399,9 +399,17 @@ public static class UiUtil
     {
         var (displayText, accessKey) = ParseAccessKey(text);
 
+        // Keep the `_` marker in the rendered label so the access letter is underlined while Alt is
+        // held (#14716): the HotKey below fires the command, but with plain-string content nothing
+        // ever told the user that Alt+F / Alt+R existed. AccessText owns the underline; it is not
+        // handed the access key itself, so the chord keeps firing exactly once through the HotKey.
+        object content = accessKey.HasValue
+            ? new AccessText { Text = text, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center }
+            : displayText;
+
         var button = new Button
         {
-            Content = displayText,
+            Content = content,
             Margin = new Thickness(4, 0),
             Padding = new Thickness(12, 6),
             MinWidth = 80,

--- a/tests/UI/Features/Edit/ReplaceWindowAccessKeyTests.cs
+++ b/tests/UI/Features/Edit/ReplaceWindowAccessKeyTests.cs
@@ -1,0 +1,107 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Edit.Replace;
+using Nikse.SubtitleEdit.Logic;
+using System.Linq;
+
+namespace UITests.Features.Edit;
+
+/// <summary>
+/// The Replace dialog keeps SE4's Alt+F / Alt+R / Alt+A mnemonics (#14716). The chord must fire the
+/// command once even while typing in the find box, and the letter must be underlined while Alt is
+/// held, or nobody ever learns the shortcut exists.
+/// </summary>
+public class ReplaceWindowAccessKeyTests
+{
+    [AvaloniaTheory]
+    [InlineData(PhysicalKey.F, nameof(ReplaceViewModel.FindNextPressed))]
+    [InlineData(PhysicalKey.R, nameof(ReplaceViewModel.ReplacePressed))]
+    [InlineData(PhysicalKey.A, nameof(ReplaceViewModel.ReplaceAllPressed))]
+    public void AltAccessKey_FiresCommand_WhileFindBoxHasFocus(PhysicalKey key, string flag)
+    {
+        var vm = new ReplaceViewModel();
+        vm.RefreshSubtitles(["Hello world"]);
+        var window = new ReplaceWindow(vm);
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            var textBox = window.GetLogicalDescendants().OfType<TextBox>().First();
+            textBox.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPressQwerty(key, RawInputModifiers.Alt);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True((bool)typeof(ReplaceViewModel).GetProperty(flag)!.GetValue(vm)!);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void AltAccessKey_FiresCommandExactlyOnce()
+    {
+        var count = 0;
+        var button = UiUtil.MakeButton("_Find next", new RelayCommand(() => count++));
+        var window = new Window { Content = new StackPanel { Children = { new TextBox(), button } } };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.GetLogicalDescendants().OfType<TextBox>().First().Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPressQwerty(PhysicalKey.F, RawInputModifiers.Alt);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(1, count);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void AccessLetter_IsUnderlined_WhileAltIsShown()
+    {
+        var button = UiUtil.MakeButton("_Find next", new RelayCommand(() => { }));
+        var window = new Window { Content = button };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var accessText = Assert.IsType<AccessText>(button.Content);
+            Assert.Equal("_Find next", accessText.Text);
+            Assert.Equal("F", accessText.AccessKey.ToString()?.ToUpperInvariant());
+            Assert.False(accessText.GetValue(AccessText.ShowAccessKeyProperty));
+
+            // Avalonia's AccessKeyHandler flips this inherited property on the window while Alt is
+            // held; AccessText draws the underline from it.
+            window.SetValue(AccessText.ShowAccessKeyProperty, true);
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(accessText.GetValue(AccessText.ShowAccessKeyProperty));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void LabelWithoutMarker_StaysPlainText()
+    {
+        var button = UiUtil.MakeButton("Count", new RelayCommand(() => { }));
+        Assert.Equal("Count", button.Content);
+    }
+}

--- a/tests/UI/Features/Shared/SetVideoOffset/SetVideoOffsetWindowTests.cs
+++ b/tests/UI/Features/Shared/SetVideoOffset/SetVideoOffsetWindowTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.LogicalTree;
 using Nikse.SubtitleEdit.Features.Shared.SetVideoOffset;
@@ -64,10 +65,11 @@ public class SetVideoOffsetWindowTests : IDisposable
         var window = Open(NewViewModel());
 
         var buttonTexts = window.GetLogicalDescendants().OfType<Button>()
-            .Select(b => b.Content as string ?? string.Empty)
+            .Select(b => b.Content is AccessText accessText ? accessText.Text ?? string.Empty : b.Content as string ?? string.Empty)
+            .Select(t => t.Replace("_", string.Empty))
             .ToList();
 
-        // The OK/Cancel texts carry an access-key underscore that never reaches the button.
+        // The OK/Cancel texts carry an access-key underscore; it is rendered as an underline.
         Assert.Contains(Se.Language.General.Ok.Replace("_", string.Empty), buttonTexts);
         Assert.Contains(Se.Language.General.Apply, buttonTexts);
         Assert.Contains(Se.Language.General.Reset, buttonTexts);


### PR DESCRIPTION
Fixes the discoverability gap behind discussion #14716 ("Restore F and R keyboard shortcuts in the replace dialogue box").

**What was wrong.** The Replace dialog already had SE4's Alt+F (Find next), Alt+R (Replace & find next) and Alt+A (Replace all) since the `_` marker in the language strings started driving button hotkeys. But `UiUtil.MakeButton` stripped the marker and set a plain string as content, so the access letter was never underlined, even while Alt was held. The shortcuts worked and nobody could see them.

**Fix.** When a label carries a marker, render it through an `AccessText`. Avalonia underlines the letter while Alt is down, matching WinForms. The existing `HotKey` keeps firing the command; the `AccessText` is not registered as an access key on its own, so the chord fires exactly once. Labels without a marker stay plain strings, so anything matching button content by string is unaffected.

This applies to every dialog button that uses the marker (OK, Cancel, Done, Join, Merge, the Find/Replace buttons, ...).

**Tests** (`ReplaceWindowAccessKeyTests`, headless):
- Alt+F / Alt+R / Alt+A fire the Replace window commands while the find box has focus.
- The command fires exactly once per chord.
- The label keeps its marker as an `AccessText` with access key `F`, and the inherited show-access-key flag reaches it.
- A label without a marker stays a plain string.

`SetVideoOffsetWindowTests` read OK/Cancel content as a string and was updated to read the `AccessText` too. Full UI suite: 5039 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)