### PR TITLE
Fire Find/Replace mnemonics on the bare letter when focus is on a button

### DIFF
--- a/src/ui/Features/Edit/Find/FindViewModel.cs
+++ b/src/ui/Features/Edit/Find/FindViewModel.cs
@@ -143,6 +143,10 @@ public partial class FindViewModel : ObservableObject
             e.Handled = true;
             UiUtil.ShowHelp("features/edit", "find");
         }
+        else
+        {
+            UiUtil.TryInvokeBareAccessKey(Window, e);
+        }
     }
 
     internal async void FindTextBoxKeyDown(object? sender, KeyEventArgs e)

--- a/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
+++ b/src/ui/Features/Edit/Replace/ReplaceViewModel.cs
@@ -188,6 +188,10 @@ public partial class ReplaceViewModel : ObservableObject
             e.Handled = true;
             UiUtil.ShowHelp("features/edit", "replace");
         }
+        else
+        {
+            UiUtil.TryInvokeBareAccessKey(Window, e);
+        }
     }
 
     internal void RefreshSubtitles(List<string> subs, List<string>? originalSubs = null, bool canEditOriginal = false)

--- a/src/ui/Logic/UiUtil.cs
+++ b/src/ui/Logic/UiUtil.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -473,6 +474,53 @@ public static class UiUtil
         var accessChar = text[idx + 1];
         var display = text.Remove(idx, 1);
         return TryGetAccessKey(accessChar, out var key) ? (display, key) : (display, null);
+    }
+
+    /// <summary>
+    /// WinForms fired a button mnemonic on the bare letter whenever the focused control did not
+    /// consume text, so SE4 users clicked "Find" once and then tapped F / R / A with the focus
+    /// resting on the buttons (discussion #14716). Mirror that: with no modifier held and focus
+    /// outside any text input, a key matching a button's Alt access key runs that button.
+    /// Returns true when a button was invoked.
+    /// </summary>
+    internal static bool TryInvokeBareAccessKey(Window? window, KeyEventArgs e)
+    {
+        if (window == null || e.Handled || e.KeyModifiers != KeyModifiers.None)
+        {
+            return false;
+        }
+
+        var focused = TopLevel.GetTopLevel(window)?.FocusManager?.GetFocusedElement();
+        if (focused is TextBox || focused is AutoCompleteBox || focused is ComboBox { IsEditable: true })
+        {
+            return false;
+        }
+
+        foreach (var button in window.GetLogicalDescendants().OfType<Button>())
+        {
+            if (button.HotKey is not { KeyModifiers: KeyModifiers.Alt } gesture || gesture.Key != e.Key)
+            {
+                continue;
+            }
+
+            if (!button.IsEffectivelyEnabled || !button.IsEffectivelyVisible)
+            {
+                return false;
+            }
+
+            var parameter = button.CommandParameter;
+            if (button.Command?.CanExecute(parameter) != true)
+            {
+                return false;
+            }
+
+            e.Handled = true;
+            button.Focus();
+            button.Command.Execute(parameter);
+            return true;
+        }
+
+        return false;
     }
 
     private static bool TryGetAccessKey(char c, out Key key)

--- a/tests/UI/Features/Edit/ReplaceWindowAccessKeyTests.cs
+++ b/tests/UI/Features/Edit/ReplaceWindowAccessKeyTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Edit.Replace;
 using Nikse.SubtitleEdit.Logic;
@@ -103,5 +104,117 @@ public class ReplaceWindowAccessKeyTests
     {
         var button = UiUtil.MakeButton("Count", new RelayCommand(() => { }));
         Assert.Equal("Count", button.Content);
+    }
+}
+
+/// <summary>
+/// SE4 fired the mnemonics on the bare letter once focus rested on a button (WinForms processed
+/// mnemonics for any control that did not consume text). Discussion #14716 asked for that back:
+/// click Find once, then tap F / R / A with two fingers. Typing in the find box must stay typing.
+/// </summary>
+public class ReplaceWindowBareAccessKeyTests
+{
+    private static (ReplaceViewModel Vm, ReplaceWindow Window) Open()
+    {
+        var vm = new ReplaceViewModel();
+        vm.RefreshSubtitles(["Hello world"]);
+        var window = new ReplaceWindow(vm);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (vm, window);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(PhysicalKey.F, nameof(ReplaceViewModel.FindNextPressed))]
+    [InlineData(PhysicalKey.R, nameof(ReplaceViewModel.ReplacePressed))]
+    [InlineData(PhysicalKey.A, nameof(ReplaceViewModel.ReplaceAllPressed))]
+    public void BareLetter_FiresCommand_WhenFocusIsOnAButton(PhysicalKey key, string flag)
+    {
+        var (vm, window) = Open();
+        try
+        {
+            var findButton = window.GetLogicalDescendants().OfType<Button>()
+                .First(b => b.HotKey?.Key == Key.F);
+            findButton.Focus();
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(findButton.IsFocused);
+
+            window.KeyPressQwerty(key, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True((bool)typeof(ReplaceViewModel).GetProperty(flag)!.GetValue(vm)!);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void BareLetter_MovesFocusToTheInvokedButton()
+    {
+        var (_, window) = Open();
+        try
+        {
+            var buttons = window.GetLogicalDescendants().OfType<Button>().ToList();
+            buttons.First(b => b.HotKey?.Key == Key.F).Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPressQwerty(PhysicalKey.R, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(buttons.First(b => b.HotKey?.Key == Key.R).IsFocused);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTheory]
+    [InlineData(0)] // find box
+    [InlineData(1)] // replace box
+    public void BareLetter_StaysTyping_WhileATextBoxHasFocus(int textBoxIndex)
+    {
+        var (vm, window) = Open();
+        try
+        {
+            // The find box is an AutoCompleteBox whose TextBox lives in the visual tree only.
+            var textBox = window.GetVisualDescendants().OfType<TextBox>().ElementAt(textBoxIndex);
+            textBox.Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPressQwerty(PhysicalKey.R, RawInputModifiers.None);
+            window.KeyTextInput("r");
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(vm.ReplacePressed);
+            Assert.Equal("r", textBox.Text);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void BareLetter_IsIgnored_WhenFocusIsOnARadioButton_ButtonStillRuns()
+    {
+        // Any non-text control counts as "not typing" - a radio button, like in WinForms.
+        var (vm, window) = Open();
+        try
+        {
+            window.GetLogicalDescendants().OfType<RadioButton>().First().Focus();
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPressQwerty(PhysicalKey.F, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(vm.FindNextPressed);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #14718 for discussion #14716. DexKen clarified that SE4 needed just **F** and **R**, no Alt, so two fingers could rest on the keys.

**Why SE4 worked that way.** WinForms processes button mnemonics on the bare letter whenever the focused control doesn't consume text, and the SE4 Replace dialog called `buttonFind.Focus()` / `buttonReplace.Focus()` after every action. So the flow was: click Find once, then tap F / R / A.

**Fix.** `UiUtil.TryInvokeBareAccessKey`: with no modifier held and focus outside a `TextBox`, `AutoCompleteBox` or editable `ComboBox`, a key matching a button's Alt access key (the `_` marker in the label) runs that button's command and focuses it, so the next tap keeps working. Wired into the Find and Replace windows via their existing tunnel key handlers. Typing in the find/replace boxes is untouched; Alt chords keep working.

**Tests** (`ReplaceWindowBareAccessKeyTests`, headless): bare F / R / A fire from a focused button, focus moves to the invoked button, bare R in either text box stays typing (text becomes "r", no command), and a focused radio button also counts as "not typing". Full UI suite: 5046 passed.

**Not reproduced.** DexKen also reports Alt+R doing nothing on RC7 (Windows). Alt+F and Alt+A work for them. I can't find a code path that treats R differently, and headless Alt+R fires the Replace command. Asked for details in the discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)