### PR TITLE
Unify PaddleOCR Standalone/Python JSON readout and use async polling to avoid result-order races

### DIFF
--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -77,6 +77,9 @@ public partial class PaddleOcr
         };
     }
 
+    // Maximum time to wait for a single PaddleOCR result file.
+    private const int PaddleOcrResultTimeoutSeconds = 20;
+
     // The engine archives all wrap their content in a folder named after the archive itself,
     // so the root folder is derived rather than repeated; the models archive is the one that
     // does not follow that rule (".VideOCR" is in the file name only) and passes it in.
@@ -302,7 +305,7 @@ public partial class PaddleOcr
         // that OutputHandlerBatch parses. So for the Python engine we let it write one
         // "<index>_res.json" per image with --save_path and read those instead.
         string? saveFolder = null;
-        if (engineType == OcrEngineType.PaddleOcrPython)
+        if (engineType == OcrEngineType.PaddleOcrStandalone || engineType == OcrEngineType.PaddleOcrPython)
         {
             saveFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(saveFolder);
@@ -312,7 +315,10 @@ public partial class PaddleOcr
             // PP-OCRv5 models (NotImplementedError: ConvertPirAttribute2RuntimeAttribute ...).
             // The bundled standalone build is known-good and faster with MKL-DNN, so only
             // disable it for the Python engine.
-            parameters += " --enable_mkldnn False";
+            if (engineType == OcrEngineType.PaddleOcrPython)
+            {
+                parameters += " --enable_mkldnn False";
+            }
         }
 
         var process = new Process
@@ -341,7 +347,10 @@ public partial class PaddleOcr
         // We always pass explicit local model dirs, so skip PaddleX's online model-source
         // connectivity check - otherwise it can hang the OCR run at "Initializing...".
         process.StartInfo.EnvironmentVariables["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True";
-        process.OutputDataReceived += OutputHandlerBatch;
+        if (saveFolder == null)
+        {
+            process.OutputDataReceived += OutputHandlerBatch;
+        }
         process.ErrorDataReceived += ErrorHandler;
         _textDetectionResults.Clear();
         lock (_errorLock)
@@ -373,35 +382,87 @@ public partial class PaddleOcr
         var reportedStems = new HashSet<string>();
         if (saveFolder != null)
         {
-            var roundsSinceProgress = 0;
-            while (reportedStems.Count < _batchFileNames.Count && !cancellationToken.IsCancellationRequested)
+            var orderedInputs = _batchFileNames
+                .OrderBy(p => p.Index)
+                .ToList();
+
+            for (var nextIndex = 0;
+                 nextIndex < orderedInputs.Count && !cancellationToken.IsCancellationRequested;
+                 nextIndex++)
             {
-                try
+                var input = orderedInputs[nextIndex];
+                var stem = Path.GetFileNameWithoutExtension(input.FileName);
+                var jsonPath = Path.Combine(saveFolder, stem + "_res.json");
+
+                string json = string.Empty;
+
+                var waitStopwatch = Stopwatch.StartNew();
+
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    await Task.Delay(400, cancellationToken);
+                    if (File.Exists(jsonPath))
+                    {
+                        try
+                        {
+                            json = File.ReadAllText(jsonPath);
+                            var trimmed = json.TrimEnd();
+
+                            if (trimmed.Length > 0 && trimmed[^1] == '}')
+                            {
+                                break;
+                            }
+                        }
+                        catch
+                        {
+                            // file is probably still written to
+                        }
+                    }
+                    if (waitStopwatch.Elapsed >= TimeSpan.FromSeconds(PaddleOcrResultTimeoutSeconds))
+                    {
+                        json = string.Empty;
+                        break;
+                    }
+                    await Task.Delay(5, cancellationToken);
                 }
-                catch (TaskCanceledException)
+
+                if (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }
 
-                var before = reportedStems.Count;
-                ReportNewPaddleOcrPythonResults(saveFolder, reportedStems);
-
-                if (reportedStems.Count > before)
+                if (string.IsNullOrEmpty(json))
                 {
-                    roundsSinceProgress = 0;
+                    reportedStems.Add(stem);
+
+                    _batchProgress?.Report(new PaddleOcrBatchProgress
+                    {
+                        Index = input.Index,
+                        Item = input.Item,
+                        Text = "[OCR TIMEOUT]",
+                        Confidence = 0,
+                    });
+
                     continue;
                 }
 
-                // No new results this round - stop once they have clearly stopped arriving:
-                // a short grace once the launcher exited, a long safety-net otherwise.
-                roundsSinceProgress++;
-                var maxIdleRounds = process.HasExited ? 150 : 750; // ~60s after exit, ~5 min otherwise
-                if (roundsSinceProgress >= maxIdleRounds)
+                reportedStems.Add(stem);
+
+                var results = ParsePaddleOcrJsonContent(json, jsonPath);
+                Se.WriteToolsLog(
+                    $"Paddle OCR result {reportedStems.Count} (line index {input.Index}) ready at {_batchStopwatch.Elapsed.TotalSeconds:F1}s");
+
+                var resultConfidence = 0.0;
+                var text = results.Count > 0
+                    ? MakeResult(results, out resultConfidence)
+                    : string.Empty;
+
+                _batchProgress?.Report(new PaddleOcrBatchProgress
                 {
-                    break;
-                }
+                    Index = input.Index,
+                    Item = input.Item,
+                    Text = text,
+                    Confidence = resultConfidence,
+                });
             }
         }
 
@@ -438,12 +499,7 @@ public partial class PaddleOcr
             return;
         }
 
-        if (saveFolder != null)
-        {
-            // Final sweep - report any files written after the last poll.
-            ReportNewPaddleOcrPythonResults(saveFolder, reportedStems);
-        }
-        else if (_textDetectionResults.Count > 0)
+        if ((saveFolder == null) && (_textDetectionResults.Count > 0))
         {
             var input = _batchFileNames.First(p => p.FileName == _batchFileName);
             var p = new PaddleOcrBatchProgress
@@ -485,59 +541,6 @@ public partial class PaddleOcr
     {
         _batchFileNames = inputs;
         _batchProgress = progress;
-    }
-
-    // Reports any "<index>_res.json" files (written by the PaddleOCR 3.x Python CLI via
-    // --save_path) that haven't been reported yet. Skips files still being written.
-    internal void ReportNewPaddleOcrPythonResults(string saveFolder, HashSet<string> reportedStems)
-    {
-        foreach (var input in _batchFileNames.OrderBy(p => p.Index))
-        {
-            var stem = Path.GetFileNameWithoutExtension(input.FileName);
-            if (reportedStems.Contains(stem))
-            {
-                continue;
-            }
-
-            var jsonPath = Path.Combine(saveFolder, stem + "_res.json");
-            if (!File.Exists(jsonPath))
-            {
-                continue;
-            }
-
-            string json;
-            try
-            {
-                json = File.ReadAllText(jsonPath);
-            }
-            catch
-            {
-                continue; // locked / mid-write - try again on the next poll
-            }
-
-            // A complete result file ends with the closing brace; if not, it is still
-            // being written, so skip it for now and pick it up on the next poll.
-            var trimmed = json.TrimEnd();
-            if (trimmed.Length == 0 || trimmed[^1] != '}')
-            {
-                continue;
-            }
-
-            reportedStems.Add(stem);
-
-            var results = ParsePaddleOcrJsonContent(json, jsonPath);
-            Se.WriteToolsLog(
-                $"Paddle OCR result {reportedStems.Count} (line index {input.Index}) ready at {_batchStopwatch.Elapsed.TotalSeconds:F1}s");
-            var resultConfidence = 0.0;
-            var text = results.Count > 0 ? MakeResult(results, out resultConfidence) : string.Empty;
-            _batchProgress?.Report(new PaddleOcrBatchProgress
-            {
-                Index = input.Index,
-                Item = input.Item,
-                Text = text,
-                Confidence = resultConfidence,
-            });
-        }
     }
 
     private void ErrorHandler(object sendingProcess, DataReceivedEventArgs outLine)

--- a/tests/UI/Features/Ocr/Engines/PaddleOcrResultParserTests.cs
+++ b/tests/UI/Features/Ocr/Engines/PaddleOcrResultParserTests.cs
@@ -7,60 +7,6 @@ namespace UITests.Features.Ocr.Engines;
 
 public class PaddleOcrResultParserTests
 {
-    private sealed class SyncProgress<T> : IProgress<T>
-    {
-        private readonly Action<T> _onReport;
-        public SyncProgress(Action<T> onReport) => _onReport = onReport;
-        public void Report(T value) => _onReport(value);
-    }
-
-    private static string SingleLineJson(string text) =>
-        $$"""{ "rec_texts": ["{{text}}"], "rec_scores": [0.99], "rec_polys": [[[10, 10], [200, 10], [200, 40], [10, 40]]] }""";
-
-    [Fact]
-    public void ReportNewResults_ReportsEachImageOnce_SkipsPartialFiles()
-    {
-        var dir = Path.Combine(Path.GetTempPath(), "paddle_report_" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        try
-        {
-            var inputs = new List<PaddleOcrBatchInput>
-            {
-                new() { Index = 5, FileName = Path.Combine(dir, "0000.png") },
-                new() { Index = 6, FileName = Path.Combine(dir, "0001.png") },
-            };
-
-            var reported = new List<PaddleOcrBatchProgress>();
-            var ocr = new PaddleOcr();
-            ocr.InitializeForTest(inputs, new SyncProgress<PaddleOcrBatchProgress>(reported.Add));
-            var seen = new HashSet<string>();
-
-            // First image complete, second still being written (no closing brace).
-            File.WriteAllText(Path.Combine(dir, "0000_res.json"), SingleLineJson("Alpha"));
-            File.WriteAllText(Path.Combine(dir, "0001_res.json"), "{ \"rec_texts\": [\"Beta\"");
-
-            ocr.ReportNewPaddleOcrPythonResults(dir, seen);
-            Assert.Single(reported);
-            Assert.Equal(5, reported[0].Index);
-            Assert.Equal("Alpha", reported[0].Text);
-
-            // Second image finishes writing -> reported on the next poll.
-            File.WriteAllText(Path.Combine(dir, "0001_res.json"), SingleLineJson("Beta"));
-            ocr.ReportNewPaddleOcrPythonResults(dir, seen);
-            Assert.Equal(2, reported.Count);
-            Assert.Equal(6, reported[1].Index);
-            Assert.Equal("Beta", reported[1].Text);
-
-            // Nothing new on a further poll - each image reported exactly once.
-            ocr.ReportNewPaddleOcrPythonResults(dir, seen);
-            Assert.Equal(2, reported.Count);
-        }
-        finally
-        {
-            Directory.Delete(dir, true);
-        }
-    }
-
     private readonly PaddleOcrResultParser _parser = new();
 
     private static string MakeLine(string pythonText, double confidence = 0.99) =>


### PR DESCRIPTION

### Unify PaddleOCR Standalone/Python JSON readout and use async polling to avoid result-order races

**Background**
PaddleOCR 3.x supports writing one **<index>_res.json** result file per input image via **--save_path**.
PaddleOCR Standalone previously used its stdout output for batch results. This worked, but using the JSON output provides a more modern result interface and allows the Standalone and Python implementations to use the same result handling path.
This change therefore switches PaddleOCR Standalone to JSON readout and unifies it with the existing Python JSON result handling.

**Observed result-order issue**
During testing of the JSON-based Standalone path, an intermittent ordering problem was observed:
- Input images had the correct sequential indices.
- The generated <index>_res.json files appeared in the expected order.
- The polling/logging showed the expected sequential indices and result processing.
- Nevertheless, two adjacent subtitles were occasionally swapped in the resulting subtitle output.
- The problem was non-deterministic and could disappear or reappear between otherwise identical runs.
- Different polling intervals changed the frequency with which the problem was observed.
No sorting of the resulting subtitles was introduced as a workaround. OCR processing must preserve the original input order; sorting by timestamp, end time, or paragraph number remains an independent, user-selectable Batch Converter operation.

**Changes**
- Switch PaddleOCR Standalone from stdout result parsing to PaddleOCR's <index>_res.json output.
- Use the same JSON-based result handling for PaddleOCR Standalone and Python, simplifying and unifying the two paths.
- Continue draining PaddleOCR's stdout even though OCR results are no longer parsed from it. This prevents the stdout pipe from filling up and potentially blocking the PaddleOCR process.
- Replace the previous repeated full-batch JSON polling with per-result polling.
- Wait asynchronously for the JSON belonging to the current batch index.
- Use a 5 ms delay only while the expected JSON is not yet available or complete.
- Process already-existing subsequent JSON files immediately, without an additional polling delay.
- Add a 20-second timeout for an individual result. On timeout, report [OCR TIMEOUT] and continue with the next index.
- Keep the existing IProgress<PaddleOcrBatchProgress> mechanism unchanged.

**Async result polling**
The new implementation waits for results in the existing batch-index order without serializing PaddleOCR's actual OCR processing.
PaddleOCR can continue processing and writing multiple images independently while Subtitle Edit waits for the currently expected result. Once that result is available, it is reported immediately. If subsequent result files are already available, they are consumed immediately afterwards.
This avoids the intermittent result-order races observed with the previous polling approach.

**Timeout handling**
A single missing or incomplete result should not block the batch indefinitely.
Each expected JSON therefore has a 20-second timeout. If the file does not become available and readable within that time, the affected subtitle receives:
**[OCR TIMEOUT]**
and processing continues with the next batch index.
The explicit marker is intentional: an empty subtitle would make an OCR failure indistinguishable from a legitimately empty result and make failures difficult to locate in a large batch.

**Performance**
The async polling does not introduce a performance penalty in testing. In fact, the complete OCR run was slightly faster than before, although the measured improvement was below 5%.
With approximately 1500 difficult VobSub subtitles, a complete batch took about 72 seconds on a RTX5060.
The 5 ms delay is only used while the currently expected JSON is not yet available or complete. If the file already exists, it is processed immediately.

**Result**
The JSON output path is now shared by PaddleOCR Standalone and Python, simplifying and unifying the two implementations.
The intermittent subtitle swaps observed during testing of the JSON-based Standalone implementation were no longer reproduced with the asynchronous per-result polling approach, while preserving the original input order and the user's independent control over subtitle sorting.