### PR TITLE
paddle standalone to json; ensure serial order

### DIFF
--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -302,7 +302,7 @@ public partial class PaddleOcr
         // that OutputHandlerBatch parses. So for the Python engine we let it write one
         // "<index>_res.json" per image with --save_path and read those instead.
         string? saveFolder = null;
-        if (engineType == OcrEngineType.PaddleOcrPython)
+        if (engineType == OcrEngineType.PaddleOcrStandalone || engineType == OcrEngineType.PaddleOcrPython)
         {
             saveFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(saveFolder);
@@ -312,7 +312,10 @@ public partial class PaddleOcr
             // PP-OCRv5 models (NotImplementedError: ConvertPirAttribute2RuntimeAttribute ...).
             // The bundled standalone build is known-good and faster with MKL-DNN, so only
             // disable it for the Python engine.
-            parameters += " --enable_mkldnn False";
+            if (engineType == OcrEngineType.PaddleOcrPython)
+            {
+                parameters += " --enable_mkldnn False";
+            }
         }
 
         var process = new Process
@@ -341,7 +344,10 @@ public partial class PaddleOcr
         // We always pass explicit local model dirs, so skip PaddleX's online model-source
         // connectivity check - otherwise it can hang the OCR run at "Initializing...".
         process.StartInfo.EnvironmentVariables["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True";
-        process.OutputDataReceived += OutputHandlerBatch;
+        if (saveFolder == null)
+        {
+            process.OutputDataReceived += OutputHandlerBatch;
+        }
         process.ErrorDataReceived += ErrorHandler;
         _textDetectionResults.Clear();
         lock (_errorLock)

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1368,6 +1368,14 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
         }
 
+        for (var i = 0; i < numberOfImages; i++)
+        {
+            item.Subtitle.Paragraphs.Add(new Paragraph(
+                string.Empty,
+                imageSubtitles.GetStartTime(i).TotalMilliseconds,
+                imageSubtitles.GetEndTime(i).TotalMilliseconds));
+        }
+
         var ocrProgress = new Progress<PaddleOcrBatchProgress>(p =>
         {
             if (cancellationToken.IsCancellationRequested)
@@ -1382,8 +1390,7 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 var percentage = numberOfImages > 0 ? ocrCount * 100 / numberOfImages : 0;
                 item.Status = string.Format(Se.Language.General.OcrPercentX, percentage);
 
-                var paragraph = new Paragraph(p.Text, imageSubtitles.GetStartTime(number).TotalMilliseconds, imageSubtitles.GetEndTime(number).TotalMilliseconds);
-                item.Subtitle.Paragraphs.Add(paragraph);
+                item.Subtitle.Paragraphs[number].Text = p.Text;
             }
         });
 


### PR DESCRIPTION
1st commit: switch paddle standalone from stdout to json polling
2nd commit: ensure subtitles are recorded in order (avoid race conditions from worker threads pool)