### PR TITLE
Merge roll-up (scrolling) captions in merge lines with same text

### DIFF
--- a/docs/features/merge-same-text.md
+++ b/docs/features/merge-same-text.md
@@ -11,5 +11,6 @@ Merge consecutive subtitle lines that have identical text content into one entry
 
 - **Max ms between lines** — Only merge lines that are at most this many milliseconds apart
 - **Include incrementing lines** — Also merge sequences where the text increments (e.g. countdowns or revealing text)
+- **Include roll-up (scrolling) captions** — Also merge old-style roll-up captions, where each caption shows the tail of the previous one plus a new line (e.g. `FOUR SCORE` → `FOUR SCORE / AND SEVEN YEARS AGO,` → `AND SEVEN YEARS AGO, / OUR FATHERS`). Every line is kept once, timed from when it first scrolled in, and regrouped into subtitles of the configured maximum number of lines
 
 The preview updates live; uncheck any group in the list to exclude it before clicking **OK**.

--- a/src/libse/Common/MergeLinesSameTextUtils.cs
+++ b/src/libse/Common/MergeLinesSameTextUtils.cs
@@ -8,6 +8,16 @@ namespace Nikse.SubtitleEdit.Core.Common
     {
         public static Subtitle MergeLinesWithSameTextInSubtitle(Subtitle subtitle, bool fixIncrementing, int maxMsBetween)
         {
+            return MergeLinesWithSameTextInSubtitle(subtitle, fixIncrementing, maxMsBetween, false);
+        }
+
+        public static Subtitle MergeLinesWithSameTextInSubtitle(Subtitle subtitle, bool fixIncrementing, int maxMsBetween, bool includeRollUp)
+        {
+            if (includeRollUp)
+            {
+                subtitle = MergeRollUpCaptions(subtitle, maxMsBetween);
+            }
+
             var mergedIndexes = new HashSet<int>();
             var removed = new HashSet<int>();
             var mergedSubtitle = new Subtitle();
@@ -71,6 +81,176 @@ namespace Nikse.SubtitleEdit.Core.Common
             return mergedSubtitle;
         }
 
+
+        /// <summary>
+        /// Rewrites roll-up (scrolling) caption chains - where each caption shows the tail of the
+        /// previous one plus new lines, e.g. "A", "A/B", "A/B/C", "B/C/D", "C/D/E" - so every line
+        /// appears once, timed from when it first scrolled in and re-chunked into paragraphs of
+        /// <see cref="GeneralSettings.MaxNumberOfLines"/> lines. Non-roll-up paragraphs are copied as is.
+        /// </summary>
+        public static Subtitle MergeRollUpCaptions(Subtitle subtitle, int maxMsBetween)
+        {
+            var maxLines = Math.Max(1, Configuration.Settings.General.MaxNumberOfLines);
+            var result = new Subtitle(subtitle);
+            result.Paragraphs.Clear();
+            var i = 0;
+            while (i < subtitle.Paragraphs.Count)
+            {
+                if (TryGetRollUpChain(subtitle.Paragraphs, i, maxMsBetween, maxLines, out var endIndex, out var merged))
+                {
+                    result.Paragraphs.AddRange(merged);
+                    i = endIndex + 1;
+                }
+                else
+                {
+                    result.Paragraphs.Add(new Paragraph(subtitle.Paragraphs[i]));
+                    i++;
+                }
+            }
+
+            result.Renumber();
+            return result;
+        }
+
+        /// <summary>
+        /// Detects a roll-up chain starting at <paramref name="startIndex"/>. A chain step is a
+        /// paragraph whose lines begin with a non-empty suffix of the previous paragraph's lines,
+        /// optionally followed by new lines. The chain must contain at least one real scroll (a
+        /// top line dropping off), otherwise it is a plain incrementing sequence handled by
+        /// <see cref="QualifiesForMergeIncrement"/>.
+        /// </summary>
+        public static bool TryGetRollUpChain(List<Paragraph> paragraphs, int startIndex, int maxMsBetween, int maxLines, out int endIndex, out List<Paragraph> merged)
+        {
+            endIndex = startIndex;
+            merged = new List<Paragraph>();
+            if (paragraphs == null || startIndex < 0 || startIndex >= paragraphs.Count)
+            {
+                return false;
+            }
+
+            var first = paragraphs[startIndex];
+            var prevLines = GetComparableLines(first);
+            if (prevLines.Count == 0)
+            {
+                return false;
+            }
+
+            // Every distinct line, with its raw (tagged) text and the time it first scrolled in.
+            var lineTexts = new List<string>(first.Text.SplitToLines());
+            var lineStarts = new List<double>();
+            for (var k = 0; k < lineTexts.Count; k++)
+            {
+                lineStarts.Add(first.StartTime.TotalMilliseconds);
+            }
+
+            var chainEndMs = first.EndTime.TotalMilliseconds;
+            var sawScroll = false;
+            var lastIndex = startIndex;
+            for (var j = startIndex + 1; j < paragraphs.Count; j++)
+            {
+                var next = paragraphs[j];
+                if (next.StartTime.TotalMilliseconds - chainEndMs > maxMsBetween)
+                {
+                    break;
+                }
+
+                var nextLines = GetComparableLines(next);
+                var overlap = GetRollUpOverlap(prevLines, nextLines);
+                if (overlap <= 0)
+                {
+                    break;
+                }
+
+                if (overlap < prevLines.Count)
+                {
+                    sawScroll = true;
+                }
+
+                var nextRawLines = next.Text.SplitToLines();
+                for (var k = overlap; k < nextLines.Count; k++)
+                {
+                    lineTexts.Add(k < nextRawLines.Count ? nextRawLines[k] : nextLines[k]);
+                    lineStarts.Add(next.StartTime.TotalMilliseconds);
+                }
+
+                chainEndMs = Math.Max(chainEndMs, next.EndTime.TotalMilliseconds);
+                prevLines = nextLines;
+                lastIndex = j;
+            }
+
+            if (!sawScroll || lastIndex == startIndex)
+            {
+                return false;
+            }
+
+            for (var k = 0; k < lineTexts.Count; k += maxLines)
+            {
+                var count = Math.Min(maxLines, lineTexts.Count - k);
+                var text = string.Join(Environment.NewLine, lineTexts.GetRange(k, count));
+                var start = lineStarts[k];
+                var end = k + maxLines < lineTexts.Count ? lineStarts[k + maxLines] : chainEndMs;
+                if (end < start)
+                {
+                    end = start;
+                }
+
+                var p = new Paragraph(first) { Text = text };
+                p.StartTime.TotalMilliseconds = start;
+                p.EndTime.TotalMilliseconds = end;
+                merged.Add(p);
+            }
+
+            endIndex = lastIndex;
+            return true;
+        }
+
+        private static List<string> GetComparableLines(Paragraph p)
+        {
+            var lines = new List<string>();
+            if (p?.Text == null)
+            {
+                return lines;
+            }
+
+            foreach (var line in HtmlUtil.RemoveHtmlTags(p.Text, true).SplitToLines())
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length > 0)
+                {
+                    lines.Add(trimmed);
+                }
+            }
+
+            return lines;
+        }
+
+        /// <summary>
+        /// Returns the number of leading lines in <paramref name="next"/> that equal a suffix of
+        /// <paramref name="prev"/> (the longest such suffix), or 0 when the captions do not chain.
+        /// </summary>
+        private static int GetRollUpOverlap(List<string> prev, List<string> next)
+        {
+            if (prev.Count == 0 || next.Count == 0)
+            {
+                return 0;
+            }
+
+            for (var overlap = Math.Min(prev.Count, next.Count); overlap > 0; overlap--)
+            {
+                var matches = true;
+                for (var k = 0; k < overlap && matches; k++)
+                {
+                    matches = string.Equals(prev[prev.Count - overlap + k], next[k], StringComparison.OrdinalIgnoreCase);
+                }
+
+                if (matches)
+                {
+                    return overlap;
+                }
+            }
+
+            return 0;
+        }
 
         public static bool QualifiesForMerge(Paragraph p, Paragraph next, int maxMsBetween)
         {

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertConfig.cs
@@ -249,6 +249,7 @@ public class BatchConvertConfig
         public bool IsActive { get; set; }
         public int MaxMillisecondsBetweenLines { get; set; }
         public bool IncludeIncrementingLines { get; set; }
+        public bool IncludeRollUpCaptions { get; set; }
 
         public MergeLinesWithSameTextsSettings()
         {

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -192,6 +192,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     // Merge lines with same text
     [ObservableProperty] private int _mergeSameTextMaxMillisecondsBetweenLines;
     [ObservableProperty] private bool _mergeSameTextIncludeIncrementingLines;
+    [ObservableProperty] private bool _mergeSameTextIncludeRollUpCaptions;
 
     // Merge lines with same time codes
     [ObservableProperty] private int _mergeSameTimeMaxMillisecondsDifference;
@@ -719,6 +720,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         // Merge lines with same text / same time codes (shared with the standalone dialogs)
         Se.Settings.Tools.MergeSameText.MaxMillisecondsBetweenLines = MergeSameTextMaxMillisecondsBetweenLines;
         Se.Settings.Tools.MergeSameText.IncludeIncrementingLines = MergeSameTextIncludeIncrementingLines;
+        Se.Settings.Tools.MergeSameText.IncludeRollUpCaptions = MergeSameTextIncludeRollUpCaptions;
         Se.Settings.Tools.MergeSameTimeCode.MaxMillisecondsDifference = MergeSameTimeMaxMillisecondsDifference;
         Se.Settings.Tools.MergeSameTimeCode.MergeDialog = MergeSameTimeMergeDialog;
         Se.Settings.Tools.MergeSameTimeCode.AutoBreak = MergeSameTimeAutoBreak;
@@ -918,6 +920,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
         MergeSameTextMaxMillisecondsBetweenLines = Se.Settings.Tools.MergeSameText.MaxMillisecondsBetweenLines;
         MergeSameTextIncludeIncrementingLines = Se.Settings.Tools.MergeSameText.IncludeIncrementingLines;
+        MergeSameTextIncludeRollUpCaptions = Se.Settings.Tools.MergeSameText.IncludeRollUpCaptions;
 
         MergeSameTimeMaxMillisecondsDifference = Se.Settings.Tools.MergeSameTimeCode.MaxMillisecondsDifference;
         MergeSameTimeMergeDialog = Se.Settings.Tools.MergeSameTimeCode.MergeDialog;
@@ -2748,6 +2751,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             {
                 IsActive = activeFunctions.Contains(BatchConvertFunctionType.MergeLinesWithSameText),
                 IncludeIncrementingLines = MergeSameTextIncludeIncrementingLines,
+                IncludeRollUpCaptions = MergeSameTextIncludeRollUpCaptions,
                 MaxMillisecondsBetweenLines = MergeSameTextMaxMillisecondsBetweenLines,
             },
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -3392,6 +3392,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
         var removed = new HashSet<int>();
         var maxMsBetween = _config.MergeLinesWithSameTexts.MaxMillisecondsBetweenLines;
         var fixIncrementing = _config.MergeLinesWithSameTexts.IncludeIncrementingLines;
+        if (_config.MergeLinesWithSameTexts.IncludeRollUpCaptions)
+        {
+            subtitle = MergeLinesSameTextUtils.MergeRollUpCaptions(subtitle, maxMsBetween);
+        }
 
         for (var i = 0; i < subtitle.Paragraphs.Count - 1; i++)
         {

--- a/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewMergeLinesWithSameText.cs
+++ b/src/ui/Features/Tools/BatchConvert/FunctionViews/ViewMergeLinesWithSameText.cs
@@ -18,6 +18,7 @@ public static class ViewMergeLinesWithSameText
         var labelGap = UiUtil.MakeLabel(Se.Language.Tools.MergeLinesWithSameText.MaxMsBetweenLines);
         var numericUpDownGap = UiUtil.MakeNumericUpDownInt(0, 10000, Se.Settings.Tools.MergeSameText.MaxMillisecondsBetweenLines, 130, vm, nameof(vm.MergeSameTextMaxMillisecondsBetweenLines));
         var checkBoxIncludeIncrementText = UiUtil.MakeCheckBox(Se.Language.Tools.MergeLinesWithSameText.IncludeIncrementingLines, vm, nameof(vm.MergeSameTextIncludeIncrementingLines));
+        var checkBoxIncludeRollUp = UiUtil.MakeCheckBox(Se.Language.Tools.MergeLinesWithSameText.IncludeRollUpCaptions, vm, nameof(vm.MergeSameTextIncludeRollUpCaptions));
         var panelGap = UiUtil.MakeHorizontalPanel(labelGap, numericUpDownGap);
 
 
@@ -29,6 +30,7 @@ public static class ViewMergeLinesWithSameText
                 labelHeader,
                 panelGap,
                 checkBoxIncludeIncrementText,
+                checkBoxIncludeRollUp,
             }
         };
 

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeDisplayItem.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeDisplayItem.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +14,12 @@ public partial class MergeDisplayItem : ObservableObject
     [ObservableProperty] private string _mergedGroup;
 
     public List<SubtitleLineViewModel> LinesToMerge { get; set; } = new List<SubtitleLineViewModel>();
+
+    /// <summary>
+    /// Set for roll-up (scrolling) caption chains, which merge into several re-chunked
+    /// paragraphs rather than one paragraph with <see cref="MergedText"/>.
+    /// </summary>
+    public List<Paragraph>? ResultParagraphs { get; set; }
 
     public MergeDisplayItem(bool apply, List<SubtitleLineViewModel> linesToMerge, string mergedText, string mergeGroup)
     {

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextViewModel.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -19,6 +20,7 @@ public partial class MergeSameTextViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private MergeDisplayItem? _selectedMergeItem;
     [ObservableProperty] private int _maxMillisecondsBetweenLines;
     [ObservableProperty] private bool _includeIncrementingLines;
+    [ObservableProperty] private bool _includeRollUpCaptions;
     [ObservableProperty] private ObservableCollection<SubtitleLineViewModel> _mergeSubtitles;
     [ObservableProperty] private MergeDisplayItem? _selectedMergeSubtitle;
     [ObservableProperty] private bool _isOkEnabled;
@@ -102,6 +104,12 @@ public partial class MergeSameTextViewModel : ObservableObject, IClosingCleanup
         var fixIncrementing = IncludeIncrementingLines;
         var numberOfMerges = 0;
         Paragraph? p = null;
+
+        if (IncludeRollUpCaptions)
+        {
+            AddRollUpMerges(maxMsBetween, removed);
+        }
+
         for (var i = 1; i < _subtitles.Count; i++)
         {
             if (removed.Contains(i - 1))
@@ -178,6 +186,40 @@ public partial class MergeSameTextViewModel : ObservableObject, IClosingCleanup
         IsOkEnabled = MergeItems.Count > 0;
     }
 
+    /// <summary>
+    /// Roll-up (scrolling) caption chains are claimed first, so the plain same-text /
+    /// incrementing loop never sees their members (they are added to <paramref name="removed"/>).
+    /// </summary>
+    private void AddRollUpMerges(int maxMsBetween, HashSet<int> removed)
+    {
+        var paragraphs = _subtitles
+            .Select(s => new Paragraph(s.Text, s.StartTime.TotalMilliseconds, s.EndTime.TotalMilliseconds) { Number = s.Number })
+            .ToList();
+        var maxLines = Math.Max(1, Configuration.Settings.General.MaxNumberOfLines);
+        var i = 0;
+        while (i < paragraphs.Count)
+        {
+            if (!MergeLinesSameTextUtils.TryGetRollUpChain(paragraphs, i, maxMsBetween, maxLines, out var endIndex, out var merged))
+            {
+                i++;
+                continue;
+            }
+
+            var group = (MergeItems.Count + 1).ToString();
+            var linesToMerge = new List<SubtitleLineViewModel>();
+            for (var idx = i; idx <= endIndex; idx++)
+            {
+                linesToMerge.Add(_subtitles[idx]);
+                MergeSubtitles.Add(new SubtitleLineViewModel(_subtitles[idx]) { Extra = group });
+                removed.Add(idx);
+            }
+
+            var mergedText = string.Join(" | ", merged.Select(m => m.Text.Replace(Environment.NewLine, " / ")));
+            MergeItems.Add(new MergeDisplayItem(true, linesToMerge, mergedText, group) { ResultParagraphs = merged });
+            i = endIndex + 1;
+        }
+    }
+
     private bool IsFixAllowed(Paragraph p)
     {
         foreach (var mi in MergeItems.Where(p => !p.Apply))
@@ -198,12 +240,14 @@ public partial class MergeSameTextViewModel : ObservableObject, IClosingCleanup
     {
         MaxMillisecondsBetweenLines = Se.Settings.Tools.MergeSameText.MaxMillisecondsBetweenLines;
         IncludeIncrementingLines = Se.Settings.Tools.MergeSameText.IncludeIncrementingLines;
+        IncludeRollUpCaptions = Se.Settings.Tools.MergeSameText.IncludeRollUpCaptions;
     }
 
     private void SaveSettings()
     {
         Se.Settings.Tools.MergeSameText.MaxMillisecondsBetweenLines = MaxMillisecondsBetweenLines;
         Se.Settings.Tools.MergeSameText.IncludeIncrementingLines = IncludeIncrementingLines;
+        Se.Settings.Tools.MergeSameText.IncludeRollUpCaptions = IncludeRollUpCaptions;
 
         Se.SaveSettings();
     }
@@ -222,6 +266,22 @@ public partial class MergeSameTextViewModel : ObservableObject, IClosingCleanup
             }
 
             var match = MergeItems.FirstOrDefault(p => p.Apply && p.LinesToMerge.Contains(s));
+            if (match != null && match.ResultParagraphs != null)
+            {
+                for (var k = 0; k < match.ResultParagraphs.Count; k++)
+                {
+                    var rp = match.ResultParagraphs[k];
+                    var merged = new SubtitleLineViewModel(s, generateNewId: k > 0);
+                    merged.Text = rp.Text;
+                    merged.StartTime = TimeSpan.FromMilliseconds(rp.StartTime.TotalMilliseconds);
+                    merged.EndTime = TimeSpan.FromMilliseconds(rp.EndTime.TotalMilliseconds);
+                    result.Add(merged);
+                }
+
+                skipCount += match.LinesToMerge.Count - 1;
+                continue;
+            }
+
             if (match != null)
             {
                 var merged = new SubtitleLineViewModel(s);

--- a/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
+++ b/src/ui/Features/Tools/MergeSubtitlesWithSameText/MergeSameTextWindow.cs
@@ -74,7 +74,9 @@ public class MergeSameTextWindow : Window
         numericUpDownGap.ValueChanged += (s, e) => { vm.SetDirty(); };
         var checkBoxIncludeIncrementText = UiUtil.MakeCheckBox(Se.Language.Tools.MergeLinesWithSameText.IncludeIncrementingLines, vm, nameof(vm.IncludeIncrementingLines));
         checkBoxIncludeIncrementText.IsCheckedChanged += (s, e) => { vm.SetDirty(); };
-        var panelGap = UiUtil.MakeHorizontalPanel(labelGap, numericUpDownGap, checkBoxIncludeIncrementText);
+        var checkBoxIncludeRollUp = UiUtil.MakeCheckBox(Se.Language.Tools.MergeLinesWithSameText.IncludeRollUpCaptions, vm, nameof(vm.IncludeRollUpCaptions));
+        checkBoxIncludeRollUp.IsCheckedChanged += (s, e) => { vm.SetDirty(); };
+        var panelGap = UiUtil.MakeHorizontalPanel(labelGap, numericUpDownGap, checkBoxIncludeIncrementText, checkBoxIncludeRollUp);
 
         return panelGap;
     }

--- a/src/ui/Logic/Config/Language/Tools/LanguageMergeLineswithSameText.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageMergeLineswithSameText.cs
@@ -4,10 +4,12 @@ public class LanguageMergeLineswithSameText
 {
     public string MaxMsBetweenLines { get; set; }
     public string IncludeIncrementingLines { get; set; }
+    public string IncludeRollUpCaptions { get; set; }
 
     public LanguageMergeLineswithSameText()
     {
         MaxMsBetweenLines = "Max milliseconds between lines";
         IncludeIncrementingLines = "Include lines with incrementing text";
+        IncludeRollUpCaptions = "Include roll-up (scrolling) captions";
     }
 }

--- a/src/ui/Logic/Config/SeMergeSameText.cs
+++ b/src/ui/Logic/Config/SeMergeSameText.cs
@@ -4,10 +4,12 @@ public class SeMergeSameText
 {
     public int MaxMillisecondsBetweenLines { get; set; }
     public bool IncludeIncrementingLines { get; set; }
+    public bool IncludeRollUpCaptions { get; set; }
 
     public SeMergeSameText()
     {
         MaxMillisecondsBetweenLines = 250;
         IncludeIncrementingLines = true;
+        IncludeRollUpCaptions = true;
     }
 }

--- a/tests/libse/Common/MergeLinesSameTextUtilsRollUpTest.cs
+++ b/tests/libse/Common/MergeLinesSameTextUtilsRollUpTest.cs
@@ -1,0 +1,88 @@
+using Xunit;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Common
+{
+    public class MergeLinesSameTextUtilsRollUpTest
+    {
+        private static Subtitle MakeRollUp()
+        {
+            var nl = System.Environment.NewLine;
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("FOUR SCORE", 1000, 1900));
+            s.Paragraphs.Add(new Paragraph("FOUR SCORE" + nl + "AND SEVEN YEARS AGO,", 2000, 2900));
+            s.Paragraphs.Add(new Paragraph("FOUR SCORE" + nl + "AND SEVEN YEARS AGO," + nl + "OUR FATHERS", 3000, 3900));
+            s.Paragraphs.Add(new Paragraph("AND SEVEN YEARS AGO," + nl + "OUR FATHERS" + nl + "BROUGHT FORTH", 4000, 4900));
+            s.Paragraphs.Add(new Paragraph("OUR FATHERS" + nl + "BROUGHT FORTH" + nl + "UPON THIS CONTINENT", 5000, 5900));
+            s.Paragraphs.Add(new Paragraph("BROUGHT FORTH" + nl + "UPON THIS CONTINENT" + nl + "A NEW NATION:", 6000, 6900));
+            return s;
+        }
+
+        [Fact]
+        public void RollUpChainIsRechunkedIntoTwoLineParagraphs()
+        {
+            var nl = System.Environment.NewLine;
+            var result = MergeLinesSameTextUtils.MergeRollUpCaptions(MakeRollUp(), 250);
+
+            Assert.Equal(3, result.Paragraphs.Count);
+            Assert.Equal("FOUR SCORE" + nl + "AND SEVEN YEARS AGO,", result.Paragraphs[0].Text);
+            Assert.Equal(1000, result.Paragraphs[0].StartTime.TotalMilliseconds);
+            Assert.Equal(3000, result.Paragraphs[0].EndTime.TotalMilliseconds);
+            Assert.Equal("OUR FATHERS" + nl + "BROUGHT FORTH", result.Paragraphs[1].Text);
+            Assert.Equal(3000, result.Paragraphs[1].StartTime.TotalMilliseconds);
+            Assert.Equal(5000, result.Paragraphs[1].EndTime.TotalMilliseconds);
+            Assert.Equal("UPON THIS CONTINENT" + nl + "A NEW NATION:", result.Paragraphs[2].Text);
+            Assert.Equal(5000, result.Paragraphs[2].StartTime.TotalMilliseconds);
+            Assert.Equal(6900, result.Paragraphs[2].EndTime.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void TopLineDropsWhileNewSecondLineArrives()
+        {
+            var nl = System.Environment.NewLine;
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("A" + nl + "B", 1000, 1900));
+            s.Paragraphs.Add(new Paragraph("B" + nl + "C", 2000, 2900));
+            s.Paragraphs.Add(new Paragraph("C" + nl + "D", 3000, 3900));
+            s.Paragraphs.Add(new Paragraph("Unrelated", 4000, 4900));
+
+            var result = MergeLinesSameTextUtils.MergeRollUpCaptions(s, 250);
+
+            Assert.Equal(3, result.Paragraphs.Count);
+            Assert.Equal("A" + nl + "B", result.Paragraphs[0].Text);
+            Assert.Equal(2000, result.Paragraphs[0].EndTime.TotalMilliseconds);
+            Assert.Equal("C" + nl + "D", result.Paragraphs[1].Text);
+            Assert.Equal(2000, result.Paragraphs[1].StartTime.TotalMilliseconds);
+            Assert.Equal(3900, result.Paragraphs[1].EndTime.TotalMilliseconds);
+            Assert.Equal("Unrelated", result.Paragraphs[2].Text);
+        }
+
+        [Fact]
+        public void PureIncrementingSequenceIsLeftToIncrementMerge()
+        {
+            var nl = System.Environment.NewLine;
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("A", 1000, 1900));
+            s.Paragraphs.Add(new Paragraph("A" + nl + "B", 2000, 2900));
+
+            var result = MergeLinesSameTextUtils.MergeRollUpCaptions(s, 250);
+            Assert.Equal(2, result.Paragraphs.Count);
+
+            var merged = MergeLinesSameTextUtils.MergeLinesWithSameTextInSubtitle(s, true, 250, true);
+            Assert.Equal(1, merged.Paragraphs.Count);
+            Assert.Equal("A" + nl + "B", merged.Paragraphs[0].Text);
+        }
+
+        [Fact]
+        public void GapLargerThanMaxBreaksChain()
+        {
+            var nl = System.Environment.NewLine;
+            var s = new Subtitle();
+            s.Paragraphs.Add(new Paragraph("A" + nl + "B", 1000, 1900));
+            s.Paragraphs.Add(new Paragraph("B" + nl + "C", 5000, 5900));
+
+            var result = MergeLinesSameTextUtils.MergeRollUpCaptions(s, 250);
+            Assert.Equal(2, result.Paragraphs.Count);
+        }
+    }
+}


### PR DESCRIPTION
Old-style roll-up captions repeat the tail of the previous caption and add a new line, sometimes dropping the top line in the same step:

```
FOUR SCORE
FOUR SCORE / AND SEVEN YEARS AGO,
FOUR SCORE / AND SEVEN YEARS AGO, / OUR FATHERS
AND SEVEN YEARS AGO, / OUR FATHERS / BROUGHT FORTH
OUR FATHERS / BROUGHT FORTH / UPON THIS CONTINENT
BROUGHT FORTH / UPON THIS CONTINENT / A NEW NATION:
```

The existing "incrementing text" merge only extends a paragraph, so these chains stayed fragmented. This adds a roll-up pass:

- `MergeLinesSameTextUtils.TryGetRollUpChain` follows a chain where each caption's lines start with a non-empty suffix of the previous caption's lines (so a top line dropping while a new bottom line arrives is one step). Every distinct line is kept once, timed from when it first scrolled in, and re-chunked into paragraphs of `MaxNumberOfLines`. The result for the sample above is three two-line subtitles at the times the first line of each chunk appeared.
- A chain must contain at least one real scroll, so pure incrementing sequences keep the current behaviour.
- New "Include roll-up (scrolling) captions" checkbox (default on) in the tool and in batch convert; the tool preview shows a roll-up group whose result is several paragraphs.
- Docs and four libse tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)