### PR TITLE
Paddle OCR: read results from json for both engines, keep batch convert cues in order

### DIFF
--- a/src/ui/Features/Ocr/Engines/PaddleOcr.cs
+++ b/src/ui/Features/Ocr/Engines/PaddleOcr.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,15 +29,12 @@ public partial class PaddleOcr
     public int MinConfidencePercent { get; set; }
 
     private bool _batchRightToLeft;
-    private List<PaddleOcrResultParser.TextDetectionResult> _textDetectionResults = new();
     private IProgress<PaddleOcrBatchProgress>? _batchProgress;
-    private string _batchFileName = string.Empty;
     private List<PaddleOcrBatchInput> _batchFileNames = new List<PaddleOcrBatchInput>();
     private string _paddingOcrPath;
     private string _clsPath;
     private string _detPath;
     private string _recPath;
-    private CancellationToken _cancellationToken;
     private readonly Stopwatch _batchStopwatch = new();
     private readonly StringBuilder _errorOutput = new();
     private readonly Lock _errorLock = new();
@@ -105,8 +101,6 @@ public partial class PaddleOcr
         _clsPath = Path.Combine(_paddingOcrPath, "cls");
         _detPath = Path.Combine(_paddingOcrPath, "det");
         _recPath = Path.Combine(_paddingOcrPath, "rec");
-
-        _cancellationToken = new CancellationToken();
     }
 
     internal static string GetRecName(string language, string mode) => PaddleOcrModels.GetRecName(language, mode);
@@ -297,17 +291,23 @@ public partial class PaddleOcr
                          $"--textline_orientation_model_dir \"{_clsPath + Path.DirectorySeparatorChar + TextlineOrientationModelName}\" " +
                          $"--textline_orientation_model_name \"{TextlineOrientationModelName}\"";
 
-        // The PaddleOCR 3.x Python CLI prints results as a (truncated) Python dict to
-        // stderr instead of the old "ppocr INFO: [[...],('text',score)]" stdout format
-        // that OutputHandlerBatch parses. So for the Python engine we let it write one
-        // "<index>_res.json" per image with --save_path and read those instead.
-        string? saveFolder = null;
+        // Both engines report through result files rather than stdout. --save_path makes the
+        // CLI write one "<index>_res.json" per image (plus a box-annotated
+        // "<index>_ocr_res_img.png" we ignore - save_all writes every registered output and
+        // there is no json-only flag), which we poll for below.
+        //
+        // The two builds print very differently, which is why parsing stdout is not an option
+        // for one shared path: upstream PaddleOCR 3.x logs a *truncated* Python dict to stderr
+        // under the logger name "paddleocr", while the bundled standalone build restores the
+        // 2.x format - full "[[...],('text',score)]" records on stdout under "ppocr". Reading
+        // the json keeps both engines on one protocol, and gives structured polys/confidences
+        // instead of a regex over a log line.
+        var saveFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(saveFolder);
+        parameters += $" --save_path \"{saveFolder}\"";
+
         if (engineType == OcrEngineType.PaddleOcrPython)
         {
-            saveFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(saveFolder);
-            parameters += $" --save_path \"{saveFolder}\"";
-
             // A stock pip "paddlepaddle" build can crash inside the oneDNN/PIR executor on
             // PP-OCRv5 models (NotImplementedError: ConvertPirAttribute2RuntimeAttribute ...).
             // The bundled standalone build is known-good and faster with MKL-DNN, so only
@@ -341,9 +341,7 @@ public partial class PaddleOcr
         // We always pass explicit local model dirs, so skip PaddleX's online model-source
         // connectivity check - otherwise it can hang the OCR run at "Initializing...".
         process.StartInfo.EnvironmentVariables["PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK"] = "True";
-        process.OutputDataReceived += OutputHandlerBatch;
         process.ErrorDataReceived += ErrorHandler;
-        _textDetectionResults.Clear();
         lock (_errorLock)
         {
             _errorOutput.Clear();
@@ -357,51 +355,49 @@ public partial class PaddleOcr
         process.Start();
 #pragma warning restore CA1416 // Validate platform compatibility;
 
+        // Both streams have to be drained continuously even though we parse neither: PaddleOCR
+        // is very chatty on stderr (and the standalone build logs every result to stdout), so
+        // letting an OS pipe fill up blocks the process mid-run.
         process.BeginOutputReadLine();
-        // Drain stderr continuously: PaddleOCR is very chatty on stderr and if we let the
-        // OS pipe fill up the process blocks mid-run. (We read it once at the end before.)
         process.BeginErrorReadLine();
 
-        // For the Python engine PaddleOCR writes one "<index>_res.json" per image as it
-        // goes, so poll the folder and report each result as soon as it appears - that
-        // gives progress for every line instead of a single update at the very end.
+        // PaddleOCR writes one "<index>_res.json" per image as it goes, so poll the folder and
+        // report each result as soon as it appears - that gives progress for every line instead
+        // of a single update at the very end.
         //
-        // Important: the "paddleocr" launcher spawns a separate worker process to do the
+        // Important: the pip "paddleocr" launcher spawns a separate worker process to do the
         // actual OCR and can exit (or block) long before that worker finishes. So we poll
         // until results stop arriving, NOT until the launcher exits - otherwise only the
         // first couple of lines get reported while the worker keeps running in the background.
         var reportedStems = new HashSet<string>();
-        if (saveFolder != null)
+        var roundsSinceProgress = 0;
+        while (reportedStems.Count < _batchFileNames.Count && !cancellationToken.IsCancellationRequested)
         {
-            var roundsSinceProgress = 0;
-            while (reportedStems.Count < _batchFileNames.Count && !cancellationToken.IsCancellationRequested)
+            try
             {
-                try
-                {
-                    await Task.Delay(400, cancellationToken);
-                }
-                catch (TaskCanceledException)
-                {
-                    break;
-                }
+                await Task.Delay(400, cancellationToken);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
 
-                var before = reportedStems.Count;
-                ReportNewPaddleOcrPythonResults(saveFolder, reportedStems);
+            var before = reportedStems.Count;
+            ReportNewPaddleOcrResults(saveFolder, reportedStems);
 
-                if (reportedStems.Count > before)
-                {
-                    roundsSinceProgress = 0;
-                    continue;
-                }
+            if (reportedStems.Count > before)
+            {
+                roundsSinceProgress = 0;
+                continue;
+            }
 
-                // No new results this round - stop once they have clearly stopped arriving:
-                // a short grace once the launcher exited, a long safety-net otherwise.
-                roundsSinceProgress++;
-                var maxIdleRounds = process.HasExited ? 150 : 750; // ~60s after exit, ~5 min otherwise
-                if (roundsSinceProgress >= maxIdleRounds)
-                {
-                    break;
-                }
+            // No new results this round - stop once they have clearly stopped arriving:
+            // a short grace once the launcher exited, a long safety-net otherwise.
+            roundsSinceProgress++;
+            var maxIdleRounds = process.HasExited ? 150 : 750; // ~60s after exit, ~5 min otherwise
+            if (roundsSinceProgress >= maxIdleRounds)
+            {
+                break;
             }
         }
 
@@ -426,36 +422,9 @@ public partial class PaddleOcr
             // ignore
         }
 
-        if (process.ExitCode != 0 && reportedStems.Count == 0)
-        {
-            lock (_errorLock)
-            {
-                Error = _errorOutput.ToString();
-            }
-
-            Se.LogError($"PaddleOCR failed with exit code {process.ExitCode} and error: {Error}");
-            Se.WriteToolsLog($"Paddle OCR ({engineType}) failed with exit code {process.ExitCode}: {Error}");
-            return;
-        }
-
-        if (saveFolder != null)
-        {
-            // Final sweep - report any files written after the last poll.
-            ReportNewPaddleOcrPythonResults(saveFolder, reportedStems);
-        }
-        else if (_textDetectionResults.Count > 0)
-        {
-            var input = _batchFileNames.First(p => p.FileName == _batchFileName);
-            var p = new PaddleOcrBatchProgress
-            {
-                Index = input.Index,
-                Text = MakeResult(_textDetectionResults, out var resultConfidence),
-                Confidence = resultConfidence,
-                Item = input.Item,
-            };
-            _batchProgress?.Report(p);
-            _textDetectionResults.Clear();
-        }
+        // Final sweep - report any files written after the last poll. Done before the failure
+        // check below so a run that produced results but exited non-zero still delivers them.
+        ReportNewPaddleOcrResults(saveFolder, reportedStems);
 
         try
         {
@@ -466,44 +435,82 @@ public partial class PaddleOcr
             // ignore
         }
 
-        if (saveFolder != null)
+        try
         {
-            try
+            Directory.Delete(saveFolder, true);
+        }
+        catch
+        {
+            // ignore
+        }
+
+        // Not a single result file. Either the run failed outright (non-zero exit, stderr
+        // carries the reason) or it "succeeded" without writing anything - a rejected
+        // --save_path, a worker killed mid-run. Both have to surface as an error: the callers
+        // only show one when Error is set, so staying quiet here hands the user an empty
+        // subtitle that looks like a successful OCR.
+        if (reportedStems.Count == 0 && _batchFileNames.Count > 0)
+        {
+            lock (_errorLock)
             {
-                Directory.Delete(saveFolder, true);
+                Error = _errorOutput.Length > 0
+                    ? _errorOutput.ToString()
+                    : $"PaddleOCR wrote no results and exited with code {process.ExitCode}.";
             }
-            catch
-            {
-                // ignore
-            }
+
+            Se.LogError($"PaddleOCR failed with exit code {process.ExitCode} and error: {Error}");
+            Se.WriteToolsLog($"Paddle OCR ({engineType}) failed with exit code {process.ExitCode}: {Error}");
         }
     }
 
     // Test seam: wires up the batch inputs and progress sink used by
-    // ReportNewPaddleOcrPythonResults so the polling/reporting logic can be tested.
+    // ReportNewPaddleOcrResults so the polling/reporting logic can be tested.
     internal void InitializeForTest(List<PaddleOcrBatchInput> inputs, IProgress<PaddleOcrBatchProgress> progress)
     {
         _batchFileNames = inputs;
         _batchProgress = progress;
     }
 
-    // Reports any "<index>_res.json" files (written by the PaddleOCR 3.x Python CLI via
-    // --save_path) that haven't been reported yet. Skips files still being written.
-    internal void ReportNewPaddleOcrPythonResults(string saveFolder, HashSet<string> reportedStems)
+    private const string ResultFileSuffix = "_res.json";
+
+    // Reports any "<index>_res.json" files (written by the PaddleOCR CLI via --save_path) that
+    // haven't been reported yet, in line order. Skips files still being written.
+    internal void ReportNewPaddleOcrResults(string saveFolder, HashSet<string> reportedStems)
     {
+        // One directory listing per poll instead of a File.Exists per outstanding image: at a
+        // 400 ms poll over a feature-length subtitle the per-image form is thousands of stat
+        // calls a second, nearly all of them for files that are not there yet.
+        string[] resultFiles;
+        try
+        {
+            resultFiles = Directory.GetFiles(saveFolder, "*" + ResultFileSuffix);
+        }
+        catch
+        {
+            return; // folder gone or not created yet - try again on the next poll
+        }
+
+        if (resultFiles.Length <= reportedStems.Count)
+        {
+            return; // nothing new on disk since the last poll
+        }
+
+        var writtenStems = new HashSet<string>(resultFiles.Length);
+        foreach (var resultFile in resultFiles)
+        {
+            var name = Path.GetFileName(resultFile);
+            writtenStems.Add(name.Substring(0, name.Length - ResultFileSuffix.Length));
+        }
+
         foreach (var input in _batchFileNames.OrderBy(p => p.Index))
         {
             var stem = Path.GetFileNameWithoutExtension(input.FileName);
-            if (reportedStems.Contains(stem))
+            if (reportedStems.Contains(stem) || !writtenStems.Contains(stem))
             {
                 continue;
             }
 
-            var jsonPath = Path.Combine(saveFolder, stem + "_res.json");
-            if (!File.Exists(jsonPath))
-            {
-                continue;
-            }
+            var jsonPath = Path.Combine(saveFolder, stem + ResultFileSuffix);
 
             string json;
             try
@@ -889,11 +896,6 @@ public partial class PaddleOcr
         return borderedBitmap;
     }
 
-    private string MakeResult(List<PaddleOcrResultParser.TextDetectionResult> textDetectionResults)
-    {
-        return MakeResult(textDetectionResults, out _);
-    }
-
     internal string MakeResult(List<PaddleOcrResultParser.TextDetectionResult> textDetectionResults, out double confidence)
     {
         var kept = textDetectionResults;
@@ -1002,101 +1004,6 @@ public partial class PaddleOcr
         var bMid = (bMin + bMax) / 2.0;
         return (aMin < bMid && bMid < aMax) || (bMin < aMid && aMid < bMax);
     }
-
-    private void OutputHandler(object sendingProcess, DataReceivedEventArgs outLine)
-    {
-        if (string.IsNullOrWhiteSpace(outLine.Data) || _cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        if (!outLine.Data.Contains("ppocr INFO:"))
-        {
-            return;
-        }
-
-        var arr = outLine.Data.Split("ppocr INFO: ");
-        if (arr.Length < 2)
-        {
-            return;
-        }
-
-        var data = arr[1];
-
-        string pattern =
-            @"\[\[\[\d+\.\d+,\s*\d+\.\d+],\s*\[\d+\.\d+,\s*\d+\.\d+],\s*\[\d+\.\d+,\s*\d+\.\d+],\s*\[\d+\.\d+,\s*\d+\.\d+]],\s*\(['""].*['""],\s*\d+\.\d+\)\]";
-        var match = Regex.Match(data, pattern);
-        if (match.Success)
-        {
-            var parser = new PaddleOcrResultParser();
-            var x = parser.Parse(data);
-            _textDetectionResults.Add(x);
-        }
-
-        // Example: [[[92.0, 56.0], [735.0, 60.0], [734.0, 118.0], [91.0, 113.0]], ('My mommy always said', 0.9907816052436829)]
-    }
-
-    private Lock _lock = new Lock();
-
-    private void OutputHandlerBatch(object sendingProcess, DataReceivedEventArgs outLine)
-    {
-        if (string.IsNullOrWhiteSpace(outLine.Data) || _cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        if (!outLine.Data.Contains("ppocr INFO:"))
-        {
-            return;
-        }
-
-        lock (_lock)
-        {
-            foreach (var fileName in _batchFileNames)
-            {
-                if (outLine.Data.Contains(fileName.FileName))
-                {
-                    if (_textDetectionResults.Count > 0)
-                    {
-                        var old = _batchFileNames.First(p => p.FileName == _batchFileName);
-                        var progress = new PaddleOcrBatchProgress
-                        {
-                            Index = old.Index,
-                            Item = old.Item,
-                            Text = MakeResult(_textDetectionResults, out var resultConfidence),
-                            Confidence = resultConfidence,
-                        };
-                        _textDetectionResults.Clear();
-                        _batchProgress?.Report(progress);
-                    }
-
-                    _batchFileName = fileName.FileName;
-                    return;
-                }
-            }
-
-            var arr = outLine.Data.Split("ppocr INFO: ");
-            if (arr.Length < 2)
-            {
-                return;
-            }
-
-            var data = arr[1];
-
-            string pattern =
-                @"\[\[\[\d+\.\d+,\s*\d+\.\d+],\s*\[\d+\.\d+,\s*\d+\.\d+],\s*\[\d+\.\d+,\s*\d+\.\d+],\s*\[\d+\.\d+,\s*\d+\.\d+]],\s*\(['""].*['""],\s*\d+\.\d+\)\]";
-            var match = Regex.Match(data, pattern);
-            if (match.Success)
-            {
-                var parser = new PaddleOcrResultParser();
-                var x = parser.Parse(data);
-                _textDetectionResults.Add(x);
-            }
-        }
-
-        // Example: [[[92.0, 56.0], [735.0, 60.0], [734.0, 118.0], [91.0, 113.0]], ('My mommy always said', 0.9907816052436829)]
-    }
-
 
     // Every language PaddleOCR 3.7 supports with a recognition model that ships in the
     // bundled support files. Adding a code here is enough to offer it - as long as the

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -380,7 +380,10 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
             }
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("PaddleOCR", StringComparison.OrdinalIgnoreCase))
             {
-                await RunPaddleOcr(imageSubtitle, item, cancellationToken);
+                if (!await RunPaddleOcr(imageSubtitle, item, cancellationToken))
+                {
+                    return;
+                }
             }
             else if (Se.Settings.Tools.BatchConvert.OcrEngine.Equals("Ollama", StringComparison.OrdinalIgnoreCase))
             {
@@ -1342,7 +1345,8 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
     private readonly Lock _paddleLock = new Lock();
 
-    private async Task RunPaddleOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
+    /// <inheritdoc cref="RunOllamaOcr"/>
+    private async Task<bool> RunPaddleOcr(IOcrSubtitle imageSubtitles, BatchConvertItem item, CancellationToken cancellationToken)
     {
         var numberOfImages = imageSubtitles.Count;
         var ocrEngine = new PaddleOcr();
@@ -1364,8 +1368,22 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return;
+                return false;
             }
+        }
+
+        // Paddle OCR hands results back as they finish, and the engine's worker pool does not
+        // finish them in order. Appending on arrival scrambled the subtitle (#14723), so the
+        // cues are created up front and each result fills its own slot; whatever never comes
+        // back is dropped below rather than left behind as a blank cue.
+        var filled = new bool[numberOfImages];
+        var trimmed = false;
+        for (var i = 0; i < numberOfImages; i++)
+        {
+            item.Subtitle.Paragraphs.Add(new Paragraph(
+                string.Empty,
+                imageSubtitles.GetStartTime(i).TotalMilliseconds,
+                imageSubtitles.GetEndTime(i).TotalMilliseconds));
         }
 
         var ocrProgress = new Progress<PaddleOcrBatchProgress>(p =>
@@ -1377,24 +1395,79 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
             lock (_paddleLock)
             {
+                // Progress is posted, so a straggler can still be delivered after the unfilled
+                // cues have been dropped - by then the indexes no longer line up.
+                if (trimmed)
+                {
+                    return;
+                }
+
                 ocrCount++;
                 var number = p.Index;
                 var percentage = numberOfImages > 0 ? ocrCount * 100 / numberOfImages : 0;
                 item.Status = string.Format(Se.Language.General.OcrPercentX, percentage);
 
-                var paragraph = new Paragraph(p.Text, imageSubtitles.GetStartTime(number).TotalMilliseconds, imageSubtitles.GetEndTime(number).TotalMilliseconds);
-                item.Subtitle.Paragraphs.Add(paragraph);
+                if (number >= 0 && number < numberOfImages)
+                {
+                    item.Subtitle.Paragraphs[number].Text = p.Text;
+                    filled[number] = true;
+                }
             }
         });
 
         item.Status = Se.Language.General.OcrDotDotDot;
-        await ocrEngine.OcrBatch(OcrEngineType.PaddleOcrStandalone, batchImages, language, mode, ocrProgress, cancellationToken);
-        var checkCount = 0;
-        while (ocrCount < numberOfImages && checkCount < 100)
+        var cancelled = false;
+        try
         {
-            await Task.Delay(100);
-            checkCount++;
+            await ocrEngine.OcrBatch(OcrEngineType.PaddleOcrStandalone, batchImages, language, mode, ocrProgress, cancellationToken);
+
+            var checkCount = 0;
+            while (ocrCount < numberOfImages && checkCount < 100)
+            {
+                await Task.Delay(100);
+                checkCount++;
+            }
         }
+        catch (OperationCanceledException)
+        {
+            // Still trim below, so a cancelled run leaves the lines it did OCR rather than a
+            // subtitle padded out with empty cues.
+            cancelled = true;
+        }
+
+        lock (_paddleLock)
+        {
+            trimmed = true;
+            for (var i = numberOfImages - 1; i >= 0; i--)
+            {
+                if (!filled[i])
+                {
+                    item.Subtitle.Paragraphs.RemoveAt(i);
+                }
+            }
+        }
+
+        if (cancelled || cancellationToken.IsCancellationRequested)
+        {
+            item.Status = Se.Language.General.Cancelled;
+            return false;
+        }
+
+        // Nothing came back at all - the engine failed to start, crashed, or produced no
+        // result files. Saving now would write a file with zero cues and report "Converted",
+        // so stop here and leave the reason on the row instead (#14723).
+        if (item.Subtitle.Paragraphs.Count == 0 && numberOfImages > 0)
+        {
+            // Error is the captured stderr, which can be tens of kilobytes of Paddle chatter.
+            // The last line is the one that carries the reason, and a status cell fits nothing more.
+            var reason = ocrEngine.Error
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .LastOrDefault() ?? "PaddleOCR returned no results";
+            item.Status = string.Format(Se.Language.General.ErrorX, reason);
+            return false;
+        }
+
+        return true;
     }
     
     /// <returns>

--- a/tests/UI/Features/Ocr/Engines/PaddleOcrResultParserTests.cs
+++ b/tests/UI/Features/Ocr/Engines/PaddleOcrResultParserTests.cs
@@ -39,21 +39,95 @@ public class PaddleOcrResultParserTests
             File.WriteAllText(Path.Combine(dir, "0000_res.json"), SingleLineJson("Alpha"));
             File.WriteAllText(Path.Combine(dir, "0001_res.json"), "{ \"rec_texts\": [\"Beta\"");
 
-            ocr.ReportNewPaddleOcrPythonResults(dir, seen);
+            ocr.ReportNewPaddleOcrResults(dir, seen);
             Assert.Single(reported);
             Assert.Equal(5, reported[0].Index);
             Assert.Equal("Alpha", reported[0].Text);
 
             // Second image finishes writing -> reported on the next poll.
             File.WriteAllText(Path.Combine(dir, "0001_res.json"), SingleLineJson("Beta"));
-            ocr.ReportNewPaddleOcrPythonResults(dir, seen);
+            ocr.ReportNewPaddleOcrResults(dir, seen);
             Assert.Equal(2, reported.Count);
             Assert.Equal(6, reported[1].Index);
             Assert.Equal("Beta", reported[1].Text);
 
             // Nothing new on a further poll - each image reported exactly once.
-            ocr.ReportNewPaddleOcrPythonResults(dir, seen);
+            ocr.ReportNewPaddleOcrResults(dir, seen);
             Assert.Equal(2, reported.Count);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ReportNewResults_OutOfOrderCompletion_ReportsInLineOrder()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "paddle_order_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var inputs = new List<PaddleOcrBatchInput>();
+            for (var i = 0; i < 4; i++)
+            {
+                inputs.Add(new PaddleOcrBatchInput { Index = i, FileName = Path.Combine(dir, i.ToString("0000") + ".png") });
+            }
+
+            var reported = new List<PaddleOcrBatchProgress>();
+            var ocr = new PaddleOcr();
+            ocr.InitializeForTest(inputs, new SyncProgress<PaddleOcrBatchProgress>(reported.Add));
+
+            // Paddle's worker pool does not finish images in order; three land before the first
+            // poll, so a single poll has to hand them back sorted by line, not by arrival.
+            foreach (var i in new[] { 2, 0, 3 })
+            {
+                File.WriteAllText(Path.Combine(dir, i.ToString("0000") + "_res.json"), SingleLineJson("Line " + i));
+            }
+
+            var seen = new HashSet<string>();
+            ocr.ReportNewPaddleOcrResults(dir, seen);
+            Assert.Equal(new[] { 0, 2, 3 }, reported.Select(r => r.Index).ToArray());
+
+            // The straggler is reported on its own, and nothing is reported twice.
+            File.WriteAllText(Path.Combine(dir, "0001_res.json"), SingleLineJson("Line 1"));
+            ocr.ReportNewPaddleOcrResults(dir, seen);
+            Assert.Equal(new[] { 0, 2, 3, 1 }, reported.Select(r => r.Index).ToArray());
+            Assert.Equal(new[] { "Line 0", "Line 2", "Line 3", "Line 1" }, reported.Select(r => r.Text).ToArray());
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void ReportNewResults_IgnoresTheAnnotatedImagesSavedAlongsideTheJson()
+    {
+        // --save_path runs save_all, so every image also gets a "<stem>_ocr_res_img.png" next to
+        // its json. The poll must not mistake one for a result.
+        var dir = Path.Combine(Path.GetTempPath(), "paddle_img_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var inputs = new List<PaddleOcrBatchInput>
+            {
+                new() { Index = 0, FileName = Path.Combine(dir, "0000.png") },
+            };
+
+            var reported = new List<PaddleOcrBatchProgress>();
+            var ocr = new PaddleOcr();
+            ocr.InitializeForTest(inputs, new SyncProgress<PaddleOcrBatchProgress>(reported.Add));
+            var seen = new HashSet<string>();
+
+            File.WriteAllText(Path.Combine(dir, "0000_ocr_res_img.png"), "not json");
+            ocr.ReportNewPaddleOcrResults(dir, seen);
+            Assert.Empty(reported);
+
+            File.WriteAllText(Path.Combine(dir, "0000_res.json"), SingleLineJson("Alpha"));
+            ocr.ReportNewPaddleOcrResults(dir, seen);
+            Assert.Single(reported);
+            Assert.Equal("Alpha", reported[0].Text);
         }
         finally
         {

--- a/tests/UI/Features/Ocr/Engines/PaddleOcrStandaloneIntegrationTests.cs
+++ b/tests/UI/Features/Ocr/Engines/PaddleOcrStandaloneIntegrationTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Nikse.SubtitleEdit.Core.BluRaySup;
+using Nikse.SubtitleEdit.Features.Ocr;
+using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Logic.Config;
+using SkiaSharp;
+
+namespace UITests.Features.Ocr.Engines;
+
+/// <summary>
+/// End-to-end run against the real bundled PaddleOCR standalone binary: renders subtitle-like
+/// bitmaps, OCRs them through <see cref="PaddleOcr.OcrBatch"/>, and checks every line comes
+/// back against its own index.
+/// <para>
+/// Skipped unless the engine and models are actually installed - they are a ~450 MB download,
+/// so CI and a fresh clone just skip. Install them from Subtitle Edit (OCR window > download
+/// Paddle OCR) or unpack the release archives into <c>Se.PaddleOcrFolder</c>.
+/// </para>
+/// </summary>
+public class PaddleOcrStandaloneIntegrationTests
+{
+    private static readonly string[] Lines =
+    {
+        "My mommy always said",
+        "there were no monsters",
+        "No real ones",
+        "but there are.",
+    };
+
+    [Fact]
+    public async Task OcrBatch_Standalone_ReportsEveryLineAgainstItsOwnIndex()
+    {
+        SkipIfEngineMissing();
+
+        // A blank image among the real ones: PaddleOCR still writes a result file for it, which
+        // is what keeps the poll loop from idling out waiting on a line that has no text.
+        var inputs = new List<PaddleOcrBatchInput>();
+        for (var i = 0; i < Lines.Length; i++)
+        {
+            inputs.Add(new PaddleOcrBatchInput { Index = i, Bitmap = RenderLine(Lines[i]) });
+        }
+
+        inputs.Add(new PaddleOcrBatchInput { Index = Lines.Length, Bitmap = RenderLine(string.Empty) });
+
+        var reported = new List<PaddleOcrBatchProgress>();
+        var progress = new SyncProgress<PaddleOcrBatchProgress>(p =>
+        {
+            lock (reported)
+            {
+                reported.Add(p);
+            }
+        });
+
+        var ocr = new PaddleOcr();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+        await ocr.OcrBatch(OcrEngineType.PaddleOcrStandalone, inputs, "en",
+            Se.Settings.Ocr.PaddleOcrMode, progress, cts.Token);
+
+        Assert.Equal(string.Empty, ocr.Error);
+
+        // Every image reported exactly once, and the text landed on the index it belongs to -
+        // the engine's worker pool does not finish images in order, so this is the property
+        // that matters, not the order the reports arrived in.
+        Assert.Equal(inputs.Count, reported.Count);
+        Assert.Equal(inputs.Select(i => i.Index).OrderBy(i => i), reported.Select(r => r.Index).OrderBy(i => i));
+
+        foreach (var (expected, index) in Lines.Select((text, i) => (text, i)))
+        {
+            var result = reported.Single(r => r.Index == index);
+            Assert.Equal(expected, result.Text.Trim());
+            Assert.True(result.Confidence > 0.5, $"line {index} confidence was {result.Confidence}");
+        }
+
+        Assert.Equal(string.Empty, reported.Single(r => r.Index == Lines.Length).Text.Trim());
+    }
+
+    [Fact]
+    public async Task OcrBatch_Standalone_TextFreeImageStillReportsAndDoesNotError()
+    {
+        SkipIfEngineMissing();
+
+        // A 1x1 transparent image gives the detector nothing to find. PaddleOCR still writes a
+        // result file for it, so the run comes back reported-and-clean rather than idling out in
+        // the poll loop and then failing as "no results".
+        var inputs = new List<PaddleOcrBatchInput>
+        {
+            new() { Index = 0, Bitmap = new SKBitmap(1, 1, true) },
+        };
+
+        var reported = new List<PaddleOcrBatchProgress>();
+        var ocr = new PaddleOcr();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        await ocr.OcrBatch(OcrEngineType.PaddleOcrStandalone, inputs, "en",
+            Se.Settings.Ocr.PaddleOcrMode, new SyncProgress<PaddleOcrBatchProgress>(reported.Add), cts.Token);
+
+        Assert.Single(reported);
+        Assert.Equal(string.Empty, reported[0].Text);
+        Assert.Equal(string.Empty, ocr.Error);
+    }
+
+    /// <summary>
+    /// The contract batch convert's RunPaddleOcr is built on, over a real Blu-ray SUP: every
+    /// input index comes back exactly once, so pre-creating a cue per image and filling it by
+    /// index cannot leave a gap or land text on the wrong line.
+    /// </summary>
+    [Fact]
+    public async Task OcrBatch_Standalone_RealBluRaySup_ReportsEveryIndexExactlyOnce()
+    {
+        SkipIfEngineMissing();
+
+        var supFile = Path.Combine(AppContext.BaseDirectory, "Files", "sample_BDSUP_multi_image.sup");
+        if (!File.Exists(supFile))
+        {
+            Assert.Skip($"Sample Blu-ray SUP not found at {supFile}");
+        }
+
+        var pcsData = BluRaySupParser.ParseBluRaySup(supFile, new StringBuilder());
+        var imageSubtitle = new OcrSubtitleBluRay(pcsData);
+        Assert.True(imageSubtitle.Count > 1, "sample should hold more than one image");
+
+        // Exactly how BatchConverter.RunPaddleOcr builds its batch.
+        var batchImages = new List<PaddleOcrBatchInput>(imageSubtitle.Count);
+        for (var i = 0; i < imageSubtitle.Count; i++)
+        {
+            batchImages.Add(new PaddleOcrBatchInput { Index = i, Bitmap = imageSubtitle.GetBitmap(i) });
+        }
+
+        var reported = new List<PaddleOcrBatchProgress>();
+        var ocr = new PaddleOcr();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+        await ocr.OcrBatch(OcrEngineType.PaddleOcrStandalone, batchImages, "en",
+            Se.Settings.Ocr.PaddleOcrMode,
+            new SyncProgress<PaddleOcrBatchProgress>(p =>
+            {
+                lock (reported)
+                {
+                    reported.Add(p);
+                }
+            }),
+            cts.Token);
+
+        Assert.Equal(string.Empty, ocr.Error);
+        Assert.Equal(imageSubtitle.Count, reported.Count);
+        Assert.Equal(Enumerable.Range(0, imageSubtitle.Count), reported.Select(r => r.Index).OrderBy(i => i));
+
+        // Reported in line order, and a real Blu-ray subtitle is not blank.
+        Assert.Equal(reported.Select(r => r.Index), reported.Select(r => r.Index).OrderBy(i => i));
+        Assert.Contains(reported, r => !string.IsNullOrWhiteSpace(r.Text));
+    }
+
+    private static void SkipIfEngineMissing()
+    {
+        var exe = Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe");
+        var bin = Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin");
+        if (!File.Exists(exe) && !File.Exists(bin))
+        {
+            Assert.Skip($"PaddleOCR standalone engine not installed in {Se.PaddleOcrFolder}");
+        }
+
+        if (!Directory.Exists(Se.PaddleOcrModelsFolder))
+        {
+            Assert.Skip($"PaddleOCR models not installed in {Se.PaddleOcrModelsFolder}");
+        }
+    }
+
+    /// <summary>
+    /// White text on black, the way a decoded VobSub/Blu-ray subtitle bitmap looks. Rendered
+    /// generously: OcrBatch pads every image with a 40 px border before handing it to Paddle,
+    /// and the small detection model starts missing lines when the text is small next to that.
+    /// </summary>
+    private static SKBitmap RenderLine(string text)
+    {
+        var bitmap = new SKBitmap(1280, 140);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.Black);
+
+        if (!string.IsNullOrEmpty(text))
+        {
+            using var typeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold)
+                                 ?? SKTypeface.Default;
+            using var font = new SKFont(typeface, 52);
+            using var paint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+            canvas.DrawText(text, 40, 95, font, paint);
+        }
+
+        canvas.Flush();
+        return bitmap;
+    }
+
+    private sealed class SyncProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _onReport;
+
+        public SyncProgress(Action<T> onReport) => _onReport = onReport;
+
+        public void Report(T value) => _onReport(value);
+    }
+}

--- a/tests/UI/UITests.csproj
+++ b/tests/UI/UITests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -39,6 +39,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Files\SeTrimTestCff.otf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\libse\Files\sample_BDSUP_multi_image.sup" Link="Files\sample_BDSUP_multi_image.sup">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\xunit.runner.json" Link="xunit.runner.json">


### PR DESCRIPTION
Follow-up to #14723, taking that PR's direction (standalone → json) and finishing it: removing the stdout half that becomes unreachable, and closing the gaps the json switch opens up.

## Confirmed against the real binary first

The open question on #14723 was whether the bundled standalone actually supports `--save_path`. It does — verified by running the real PaddleOCR-Standalone v3.7.0 CPU build:

```
paddleocr ocr -h  →  usage: paddleocr ocr [-h] -i INPUT [--save_path SAVE_PATH]
```

A real run writes one `<index>_res.json` per image, plus a box-annotated `<index>_ocr_res_img.png` we ignore (`--save_path` runs `save_all`, which calls every registered save func; there is no json-only flag).

**That extra image costs nothing measurable.** 80 subtitle bitmaps, same models, same machine:

| | wall time | output |
|---|---|---|
| without `--save_path` | 33.8 s | — |
| with `--save_path` | 32.1 s | 80 json + 80 png, 780 KB total |

Worth noting for the record: the standalone's stdout path was **not** broken. `timminator/PaddleOCR-Standalone` is a Nuitka build of PaddleOCR that deliberately restores 2.x output — `LOGGER_NAME = "ppocr"` and `StreamHandler(stream=sys.stdout)`, where upstream 3.x uses `"paddleocr"` on stderr. So this is a protocol unification, not a bug fix: one code path for both engines, and structured polys/confidences instead of a regex over a log line.

## What changed

**One protocol.** Both engines now use `--save_path`. `--enable_mkldnn False` stays Python-only.

**Dead code removed.** Only `PaddleOcrStandalone` and `PaddleOcrPython` ever reach `OcrBatch`, so once both use `--save_path` the stdout half has no caller: `OutputHandlerBatch`, the already-dead `OutputHandler`, `_textDetectionResults`, `_batchFileName`, `_lock`, `_cancellationToken`, an unused `MakeResult` overload and the post-exit fallback branch are all gone (−185 lines).

**Silent failures now surface.** `OcrBatch` set `Error` only when the exit code was non-zero. A run that "succeeded" without writing anything left `Error` empty, so no caller showed a thing and the user got an empty OCR that looked like success. It now errors whenever zero result files came back. The final sweep also moved ahead of that check, so a run that produced results but exited non-zero still delivers them — and both temp folders are cleaned up on the failure path, which the old early `return` skipped.

**Cheaper polling.** The poll listed the folder with a `File.Exists` per outstanding image. At 400 ms over a feature-length subtitle that is thousands of stat calls a second, nearly all for files not yet written. Now one directory listing per round.

**Batch convert cue order** (the #14723 fix, with the blank-cue hole closed). Cues are created up front and filled by index, so out-of-order results no longer scramble the subtitle. But cues that never get a result are now dropped rather than written out blank, and `RunPaddleOcr` returns `bool` like the other OCR runners — a run that produced nothing leaves the reason on the row instead of saving a file of empty cues and reporting "Converted". Cancellation goes through the same trim, so a cancelled run keeps the lines it did OCR.

## Testing

Unit: out-of-order arrival reports in line order; the annotated `_ocr_res_img.png` files are not mistaken for results.

Integration (`PaddleOcrStandaloneIntegrationTests`) — real runs against the installed engine, skipped when the ~450 MB engine/models are not present:
- rendered subtitle bitmaps + a blank one → every index reported exactly once, each text on its own index, blank stays blank
- a text-free image still gets a result file, so the poll does not idle out
- the sample Blu-ray SUP (`sample_BDSUP_multi_image.sup`) end to end — real images, real OCR, correct index mapping at ~0.99 confidence

Full `tests/UI` suite: 5018 passed, 25 failed — all 25 pre-existing on `origin/main` (verified by running the same tests from a clean `origin/main` worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
