### PR TITLE
Add litagin/anime-whisper as a Japanese speech-to-text model (#14656)

### DIFF
--- a/src/libuilogic/AudioToText/WhisperCppModel.cs
+++ b/src/libuilogic/AudioToText/WhisperCppModel.cs
@@ -288,6 +288,19 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
                 Size = "3.1 GB Swedish",
                 Urls = new []{ "https://huggingface.co/KBLab/kb-whisper-large/resolve/main/ggml-model.bin" },
             },
+
+            // litagin/anime-whisper (MIT) - a kotoba-whisper-v2.0 fine-tune for Japanese anime/visual
+            // novel dialogue (#14656). It has the stock large-v3 vocab (51866), so whisper.cpp loads it
+            // on the normal multilingual path, and its "is_distil" check is
+            // "n_text_layer == 2 && n_vocab != 51866" - false here - so timestamps are not disabled
+            // even though the model has only 2 decoder layers.
+            new WhisperModel
+            {
+                Name = "anime.ja",
+                Rename = true,
+                Size = "538 MB Japanese",
+                Urls = new []{ "https://huggingface.co/Aratako/anime-whisper-ggml/resolve/main/ggml-anime-whisper-q5_0.bin" },
+            },
         };
     }
 }

--- a/src/libuilogic/AudioToText/WhisperPurfviewFasterWhisperModel.cs
+++ b/src/libuilogic/AudioToText/WhisperPurfviewFasterWhisperModel.cs
@@ -262,6 +262,18 @@ namespace Nikse.SubtitleEdit.UiLogic.AudioToText
                 Urls = MakeUrls("https://huggingface.co/NbAiLab/nb-whisper-large/resolve/main"),
                 Folder = "faster-whisper-large.nb",
             },
+
+            // litagin/anime-whisper (MIT) - a kotoba-whisper-v2.0 fine-tune for Japanese anime/visual
+            // novel dialogue (#14656), here as the int8 CTranslate2 conversion. The repo ships
+            // "vocabulary.json" but no "vocabulary.txt"; that 404 is expected and handled by
+            // DownloadSpeechToTextModelsViewModel.OptionalFileNames.
+            new WhisperModel
+            {
+                Name = "anime.ja",
+                Size = "768 MB Japanese",
+                Urls = MakeUrls("https://huggingface.co/quantumcookie/anime-whisper-ct2-int8/resolve/main"),
+                Folder = "faster-whisper-anime.ja",
+            },
         };
 
         private string[] MakeUrls(string baseUrl)


### PR DESCRIPTION
Closes #14656.

[litagin/anime-whisper](https://huggingface.co/litagin/anime-whisper) is a `kotoba-whisper-v2.0` fine-tune trained on ~5,300 hours of Japanese anime / visual-novel dialogue. It transcribes the sound effects and non-verbal vocalisations that `large-v3` tends to drop or hallucinate over, which is what the reporter asked for.

## This is a model-list entry, not engine work

The issue thread assumed anime-whisper "isn't like the other whisper models". It is — `config.json` says:

| field | value |
|---|---|
| `architectures` | `WhisperForConditionalGeneration` |
| `vocab_size` | 51866 (stock large-v3 vocab) |
| `num_mel_bins` | 128 |
| enc / dec layers | 32 / 2 (distil-shaped, same as `distil-large-v3`) |

The only reason it didn't work before is that litagin publishes just `model.safetensors` — no ggml or CTranslate2 build in that repo. Third-party conversions exist, both MIT like the source model.

## What was added

- **Purfview Faster Whisper XXL** — `quantumcookie/anime-whisper-ct2-int8` (768 MB). `Folder` is set explicitly to `faster-whisper-anime.ja` so the exe resolves it locally instead of silently re-downloading (#12133). The repo ships `vocabulary.json` but no `vocabulary.txt`; that 404 is already expected and handled by `DownloadSpeechToTextModelsViewModel.OptionalFileNames`.
- **whisper.cpp** — `Aratako/anime-whisper-ggml` q5_0 (538 MB), following the `large-v3-turbo.he` / `medium.sv` pattern.

Timestamps are fine on the whisper.cpp side despite the 2-layer decoder — its guard is `is_distil = n_text_layer == 2 && n_vocab != 51866`, which is false here, so `no_timestamps` is not forced.

## Engine coverage

`WhisperEngineCTranslate2.Models` returns `new WhisperPurfviewFasterWhisperModel().Models`, and its `GetAndCreateWhisperModelFolder` / `IsModelInstalled` / `ImportCustomModel` all delegate to the Purfview engine - so the Purfview entry above covers **Whisper CTranslate2** as well. It downloads into the same `_models/faster-whisper-anime.ja` folder and `GetModelForCmdLine` turns it into `--model_directory _models/faster-whisper-anime.ja`.

That matters for one detail: faster-whisper reads `feature_size` (128 for this model) from `preprocessor_config.json`, because the CTranslate2 `config.json` carries only `alignment_heads` / `lang_ids` / `suppress_ids` and no mel count. Purfview's `_fileNames` already requests that file and the conversion repo ships it, so both engines get it.

Nothing was added to `WhisperCTranslate2Model.cs`. Despite the name, that class is reachable only from `WhisperHelper.GetWhisperModel`, and only its `ModelFolder` property is ever read - no engine uses its `Models` list, so an entry there would be dead code.

## Note on `efwkjn/whisper-ja-anime-v0.3`

Worth recording, since it comes up as the obvious alternative: it can't be added the same way. It uses a custom Japanese tokenizer with `vocab_size` 20480, and its own README says faster-whisper gets `is_multilingual` and `suppress_tokens` wrong and needs code changes — which isn't possible against a bundled `faster-whisper-xxl.exe`. whisper.cpp is worse: it derives multilinguality as `n_vocab >= 51865` and `num_languages() = n_vocab - 51765`, so at 20480 the model loads as English-only with broken special-token offsets. It would need upstream support in both runtimes first.

It also isn't the better model for this use case — on the author's own `BENCH.md`, anime-whisper has lower CER than v0.3 on all five held-out anime/VN test sets. v0.3's advantage is long-form general Japanese, where plain `large-v3` beats it anyway.

## Testing

Builds clean. I haven't run a transcription with either conversion — worth a smoke test on a Japanese clip with both engines before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

