### PR TITLE
Fix #14741: keep the video position when settings are applied

### DIFF
--- a/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
+++ b/src/ui/Controls/VideoPlayer/VideoPlayerControl.cs
@@ -1034,6 +1034,75 @@ namespace Nikse.SubtitleEdit.Controls.VideoPlayer
             });
         }
 
+        /// <summary>
+        /// Seeks a freshly opened player back to <paramref name="seconds"/> and keeps at it until
+        /// it reports it is actually there, then ends the restore announced by
+        /// <see cref="BeginPositionRestore"/>.
+        /// <para>
+        /// Every rebuild path (layout rebuild, dock/undock, fullscreen) used to do this by hand,
+        /// by assigning <see cref="Position"/> ten times over 100 ms. Both halves of that were
+        /// wrong. The property reaches the player only through the bound position slider, whose
+        /// Maximum is this control's <see cref="Duration"/> - published from the position tick,
+        /// not by <see cref="WaitForPlayersReadyAsync"/>, which waits on the core's duration - so
+        /// a write landing in that gap is clamped and seeks the video to the start instead. And
+        /// once the duration is published the repeats stop happening at all: the property already
+        /// holds the value, so the styled-property layer drops the rest and they never reach the
+        /// slider - a 100 ms budget that is really one seek. mpv swallows seeks while it is still
+        /// loading, which a 43 minute file does for far longer than that, and nothing re-seeked
+        /// afterwards: the video stayed at 0:00 after Options/OK, and the waveform, which follows
+        /// the play-head, sat on the first line of the file (issue #14741).
+        /// </para>
+        /// <para>
+        /// Uses <see cref="SeekTo"/>, which writes the player directly and so is immune to both,
+        /// and gives up only after <paramref name="timeoutMs"/> - keeping the pending target when
+        /// it does, so a rebuild is still handed where the video should be rather than the 0 of a
+        /// player that never got there (issue #14218).
+        /// </para>
+        /// </summary>
+        internal async Task RestorePositionAsync(double seconds, int timeoutMs = 5000)
+        {
+            if (seconds <= 0)
+            {
+                EndPositionRestore();
+                return;
+            }
+
+            var end = Environment.TickCount64 + timeoutMs;
+            var delayMs = 10;
+            while (true)
+            {
+                if (IsDisposed)
+                {
+                    return;
+                }
+
+                SeekTo(seconds);
+                await Task.Delay(delayMs);
+
+                // A control torn down while this was awaiting has nothing left to seek, and its
+                // player throws rather than reporting a position (issue #13083).
+                if (IsDisposed)
+                {
+                    return;
+                }
+
+                if (Math.Abs(_videoPlayerInstance.Position - seconds) < PositionRestoreArrivedToleranceSeconds)
+                {
+                    EndPositionRestore();
+                    return;
+                }
+
+                if (Environment.TickCount64 >= end)
+                {
+                    return;
+                }
+
+                // Back off: the first few tries cover a player that is merely settling, the
+                // slower ones a file still loading, without polling it flat out for seconds.
+                delayMs = Math.Min(delayMs * 2, 200);
+            }
+        }
+
         internal async Task WaitForPlayersReadyAsync(int timeoutMs = 2500)
         {
             var end = DateTime.UtcNow.AddMilliseconds(timeoutMs);

--- a/src/ui/Features/Main/Layout/InitVideoPlayer.cs
+++ b/src/ui/Features/Main/Layout/InitVideoPlayer.cs
@@ -76,23 +76,12 @@ public static class InitVideoPlayer
                 await control.Open(mediaFile);
                 await control.WaitForPlayersReadyAsync();
 
-                // A second rebuild within the ready wait (Options/OK, dock/undock) disposes
-                // this control's player via the block above - stop restoring into it (#13083).
-                for (var i = 0; i < 10; i++)
-                {
-                    await System.Threading.Tasks.Task.Delay(10);
-                    if (control.IsDisposed)
-                    {
-                        return;
-                    }
-
-                    control.Position = position;
-                }
-
-                // Only if the player really got there - the loop above is a fixed 100 ms of
-                // seeks, so a player still loading when it runs out would otherwise be handed
-                // back as the truth while it still reports 0 (issue #14218).
-                control.EndPositionRestoreIfArrived();
+                // Seeks until the player reports it arrived, and bails out when a second rebuild
+                // within the ready wait (Options/OK, dock/undock) disposes this control's player
+                // via the block above (#13083). Doing this by hand here - ten assignments to
+                // Position - is what left the video, and with it the waveform, at 0:00 after a
+                // settings change on a long file (issue #14741).
+                await control.RestorePositionAsync(position);
             });
         }
 

--- a/src/ui/Features/Shared/FullScreenVideoPlayer.cs
+++ b/src/ui/Features/Shared/FullScreenVideoPlayer.cs
@@ -239,29 +239,26 @@ public class FullScreenVideoWindow : Window
             }
 
             videoPlayer.VideoPlayer.Pause();
-            videoPlayer.VideoPlayer.Position = position;
-            videoPlayer.Position = position;
+            videoPlayer.SeekTo(position);
             videoPlayer.Volume = volume;
 
             // Position and volume are not the only state the fresh player starts over with -
             // let the caller re-apply whatever else it tracks (the selected audio track, #12844).
             onPlayerReady?.Invoke(videoPlayer);
 
-            Dispatcher.UIThread.Post(() =>
+            Dispatcher.UIThread.Post(async () =>
             {
                 if (videoPlayer.IsDisposed)
                 {
                     return;
                 }
 
-                videoPlayer.VideoPlayer.Position = position;
-                videoPlayer.Position = position;
-
-                // Restore done - a rebuild reading from this control gets the live position
-                // again (issue #14218). Only once the player has actually arrived, though: mpv
-                // can still be loading here, and handing a rebuild the 0 of a player that never
-                // reached the target is the rewind this guard exists to prevent.
-                videoPlayer.EndPositionRestoreIfArrived();
+                // Re-seeks until the player reports it arrived, and only then lets a rebuild
+                // reading from this control get the live position again (issue #14218). mpv can
+                // still be loading here, and handing a rebuild the 0 of a player that never
+                // reached the target is the rewind that guard exists to prevent - which a single
+                // extra re-apply, as this did, cannot promise (issue #14741).
+                await videoPlayer.RestorePositionAsync(position);
             });
         };
     }

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -203,13 +203,14 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
                 }
 
                 videoPlayerControl.Volume = _originalVolume;
-                videoPlayerControl.Position = _originalPosition;
 
-                // The player is where it belongs - a rebuild from here on can read the live
-                // position again (issue #14218). If it is not there yet (mpv still loading), the
-                // target stays until the position tick sees the player arrive; handing a rebuild
-                // the 0 of a player that never got there is the rewind this guards against.
-                videoPlayerControl.EndPositionRestoreIfArrived();
+                // Seeks until the player is where it belongs, and only then lets a rebuild read
+                // the live position again (issue #14218). If it never gets there (mpv still
+                // loading), the target stays - handing a rebuild the 0 of a player that never
+                // arrived is the rewind this guards against. Assigning Position instead, as this
+                // did, reaches the player through the position slider, which clamps the write to
+                // a duration that may not be published yet (issue #14741).
+                await videoPlayerControl.RestorePositionAsync(_originalPosition);
 
                 // Undocking opens the video in a new player, which starts on mpv's default audio
                 // track - re-apply the track the user picked in the main window (issue #12844).

--- a/tests/UI/Controls/VideoPlayerControlRestorePositionSeekTests.cs
+++ b/tests/UI/Controls/VideoPlayerControlRestorePositionSeekTests.cs
@@ -1,0 +1,120 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic.VideoPlayers;
+using Nikse.SubtitleEdit.Logic.VideoPlayers.LibMpvDynamic;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UITests.Controls;
+
+/// <summary>
+/// Covers issue #14741: any settings change rebuilds the video player, and the rebuild has to
+/// seek the fresh player back to where the user was. That restore used to be a fixed 100 ms of
+/// assignments to <c>VideoPlayerControl.Position</c>, which a long file loses routinely - mpv
+/// swallows seeks while it is still loading, and the property reaches the player only through
+/// the position slider, which clamps the write to a duration that is not published yet. The
+/// video then sat at 0:00 after Options/OK, and the waveform, which follows the play-head, sat
+/// at the first line of the file while the subtitle grid kept the user's row.
+/// </summary>
+public class VideoPlayerControlRestorePositionSeekTests
+{
+    /// <summary>A player that swallows seeks for a while after the file is loaded, the way mpv
+    /// does while its core is still coming up on a big file.</summary>
+    private sealed class SlowToSeekVideoPlayer : IVideoPlayer
+    {
+        private double _position;
+        private long _acceptSeeksFromTicks;
+
+        /// <summary>How long after the load this player ignores seeks. Longer than the old
+        /// restore's whole budget, shorter than the new one's.</summary>
+        public int LoadingMs { get; set; } = 700;
+
+        public bool SwallowEverySeek { get; set; }
+
+        public string Name => "slow-to-seek";
+        public string FileName { get; private set; } = string.Empty;
+
+        public bool CanLoad() => true;
+
+        public Task LoadFile(string fileName, double startPositionSeconds = 0)
+        {
+            FileName = fileName;
+            _position = 0;
+            _acceptSeeksFromTicks = Environment.TickCount64 + LoadingMs;
+            return Task.CompletedTask;
+        }
+
+        public void CloseFile() => FileName = string.Empty;
+
+        public void Play()
+        {
+        }
+
+        public void PlayOrPause()
+        {
+        }
+
+        public void Pause()
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public AudioTrackInfo? ToggleAudioTrack() => null;
+
+        public bool IsPlaying => false;
+        public bool IsPaused => true;
+
+        public double Position
+        {
+            get => _position;
+            set
+            {
+                if (!SwallowEverySeek && Environment.TickCount64 >= _acceptSeeksFromTicks)
+                {
+                    _position = value;
+                }
+            }
+        }
+
+        public double Duration => 2595; // a 43 minute file, like the one in the issue
+        public int VolumeMaximum => 100;
+        public double Volume { get; set; } = 50;
+        public double Speed { get; set; } = 1.0;
+    }
+
+    [AvaloniaFact]
+    public async Task ARestoreKeepsSeekingUntilTheLoadingPlayerTakesIt()
+    {
+        var player = new SlowToSeekVideoPlayer();
+        var control = new VideoPlayerControl(player);
+        control.BeginPositionRestore(54);
+        await control.Open("fake.mkv");
+
+        await control.RestorePositionAsync(54);
+
+        Assert.Equal(54, player.Position, 3);
+
+        // The player is there, so a later rebuild reads the live position rather than a target
+        // left pinned for the rest of this control's life (issue #14218).
+        Assert.Equal(control.Position, control.PositionForRestore);
+    }
+
+    [AvaloniaFact]
+    public async Task ARestoreThatNeverLandsGivesUpButKeepsItsTarget()
+    {
+        var player = new SlowToSeekVideoPlayer { SwallowEverySeek = true };
+        var control = new VideoPlayerControl(player);
+        control.BeginPositionRestore(54);
+        await control.Open("fake.mkv");
+
+        await control.RestorePositionAsync(54, 300);
+
+        // Nothing to hand a rebuild but the target: the live position is the 0 of a player that
+        // never got where it was told to go (issue #14218).
+        Assert.Equal(54, control.PositionForRestore);
+    }
+}


### PR DESCRIPTION
Fixes #14741.

## What the user sees

Changing almost any setting (font face, a checkbox like "Allow single letter in textbox", ...) makes the waveform/spectrogram jump to the first line of the file, while the subtitle grid stays on the current row.

The waveform is innocent — it just follows the play-head. In the reporter's video the position box reads `00:00:00:02 / 00:43:15:22` right after Apply (it was ~`00:00:54` before) and the video surface goes black: **applying settings rewinds the video player to 0**. The grid keeps its row because `ApplySettings` saves and restores the selected index (#14421).

## Root cause

A settings change rebuilds the layout, and `InitVideoPlayer.MakeLayoutVideoPlayer` destroys the video player control and builds a new one, re-opening the file and seeking back to the saved position. That restore was ten assignments to `VideoPlayerControl.Position` over 100 ms, and both halves of it were wrong:

- **The write is clamped.** `Position` reaches the player only through the bound position slider, whose `Maximum` is the control's `Duration` — published from the 50 ms position tick, *not* by `WaitForPlayersReadyAsync`, which waits on the native core's duration. A write landing in that gap is clamped and seeks to the start of the file.
- **The retries don't happen.** Once the duration is published the property already holds the value, so the styled-property layer drops the remaining assignments and they never reach the slider. The 100 ms budget was really one seek — and mpv swallows seeks while it is still loading, which a 43 minute file does for far longer than that. Nothing re-seeked afterwards.

`SeekTo` exists precisely for this ("the styled property drops an assignment equal to the value it already holds"), but the restore paths never used it.

## The fix

New `VideoPlayerControl.RestorePositionAsync(seconds, timeoutMs)`: seeks with `SeekTo` (a direct write to the player, immune to both problems) and keeps at it with a backing-off delay until the player reports it arrived, or the timeout runs out — keeping the pending restore target when it does, so a rebuild is still handed where the video should be rather than the 0 of a player that never got there (#14218). Bails out on `IsDisposed` like the code it replaces (#13083).

The layout rebuild, the dock/undock restore and the fullscreen restore all went through the same broken path and now share the helper.

## Tests

`tests/UI/Controls/VideoPlayerControlRestorePositionSeekTests.cs`, against a fake player that swallows seeks for 700 ms after the load the way mpv does:

- `ARestoreKeepsSeekingUntilTheLoadingPlayerTakesIt` — fails on the old 100 ms loop (player stays at 0), passes now.
- `ARestoreThatNeverLandsGivesUpButKeepsItsTarget` — the #14218 guard still holds.

Full UI suite: 5017 passed, 25 failed — the same 25 focus/menu/grid/scroll tests that already fail on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)