### PR TITLE
Stop an Alt shortcut from activating the menu bar (#14743)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -603,6 +603,9 @@ public partial class MainViewModel :
     Control? _focusBeforeMainMenu;
     Control? _focusBeforeWindowDeactivated;
     bool _altClosesMainMenuOnKeyUp;
+    bool _altChordCancelsMainMenuActivation;
+    bool _mainMenuActiveBeforeAltRelease;
+    Control? _focusBeforeAltChord;
     readonly AltMenuActivationGuard _altMenuActivationGuard = new();
     bool _findClosingProgrammatically;
     ReplaceViewModel? _replaceViewModel;
@@ -28435,6 +28438,8 @@ public partial class MainViewModel :
         _shortcutManager.ClearKeys();
         _altMenuActivationGuard.Reset();
         _altClosesMainMenuOnKeyUp = false; // the matching Alt release will never arrive
+        _altChordCancelsMainMenuActivation = false;
+        _focusBeforeAltChord = null;
 
         // A task switch (Alt+Tab) must also drop any active menu-bar state. Otherwise Avalonia leaves
         // the access-key underlines / selection armed and they reappear when the window is re-activated,
@@ -28927,6 +28932,21 @@ public partial class MainViewModel :
                 // Alt+<key> is a shortcut or access key, not a toggle - releasing Alt afterwards
                 // must leave the menu alone (mirrors the built-in "ignore Alt up" bookkeeping).
                 _altClosesMainMenuOnKeyUp = false;
+
+                // Avalonia's AccessKeyHandler does the same bookkeeping ("Alt was part of a chord,
+                // so its release must not open the menu bar") in its own tunnelling key-down
+                // handler - but it registers that handler in the TopLevel constructor with
+                // handledEventsToo:false, and tunnel handlers on one element run in *reverse*
+                // registration order. Our window handler therefore runs first, and the moment it
+                // marks an Alt shortcut handled (Alt+Down = "go to next line" out of the box) the
+                // built-in handler never sees the chord key: releasing Alt then opens the menu bar,
+                // which swallows every following shortcut - Ctrl+Left/Right walked the menu items
+                // instead of moving the start time (#14743). Arm the cancellation here and undo the
+                // activation on the Alt release (see OnKeyUpHandler).
+                if (keyEventArgs.KeyModifiers.HasFlag(KeyModifiers.Alt))
+                {
+                    _altChordCancelsMainMenuActivation = true;
+                }
             }
 
             if (UiUtil.TryHandleWindowSystemMenu(keyEventArgs, Window))
@@ -29342,11 +29362,49 @@ public partial class MainViewModel :
             _setEndAtKeyUpLineGoToNext = false;
         }
 
+        // This handler is registered for both routing strategies, so every key-up runs it twice.
+        // Avalonia's AccessKeyHandler opens the menu bar from its own tunnelling key-up handler,
+        // which - tunnel handlers on one element running in reverse registration order - comes
+        // after ours: in the tunnel pass the bar is still closed, in the bubble pass it is open.
+        // Both undo paths below must therefore act in the bubble pass only. Remember here whether
+        // the bar was already active before the release, so an Alt+<access key> that opened it on
+        // the key *down* (Alt+F) is left alone and only a release-triggered activation is undone -
+        // and which control held focus, since that is the last moment before Avalonia takes it.
+        if (e.Key is Key.LeftAlt or Key.RightAlt && e.Route == RoutingStrategies.Tunnel)
+        {
+            _mainMenuActiveBeforeAltRelease = Menu is { IsOpen: true } || IsMainMenuFocused();
+            _focusBeforeAltChord = Window?.FocusManager?.GetFocusedElement() as Control;
+        }
+
+        // Undo the menu-bar activation Avalonia performs when Alt is released after an Alt+<key>
+        // shortcut it never saw (see the arming site in OnKeyDownHandler for why it misses it).
+        if (e.Key is Key.LeftAlt or Key.RightAlt &&
+            e.Route == RoutingStrategies.Bubble &&
+            _altChordCancelsMainMenuActivation)
+        {
+            _altChordCancelsMainMenuActivation = false;
+            var focusAfterChord = _focusBeforeAltChord;
+            _focusBeforeAltChord = null;
+
+            if (!_mainMenuActiveBeforeAltRelease && (Menu is { IsOpen: true } || IsMainMenuFocused()))
+            {
+                if (focusAfterChord is { IsEffectivelyVisible: true })
+                {
+                    _focusBeforeMainMenu = focusAfterChord;
+                }
+
+                DeactivateMainMenu();
+            }
+        }
+
         // Undo the menu-bar activation Avalonia performs when Alt is released after an Alt+click/drag.
         // Its AccessKeyHandler runs in the window's tunnel phase, so the menu is already open and
         // focused by the time we get here - without this, IsMainMenuFocused() in OnKeyDownHandler
-        // swallows every shortcut until the user clicks something (discussion #11744).
-        if (_altMenuActivationGuard.TryConsumeAltRelease(e.Key, out var focusToRestore) &&
+        // swallows every shortcut until the user clicks something (discussion #11744). The guard is
+        // consumed in the bubble pass only: consuming it in the tunnel pass disarmed it while the
+        // bar was still closed, so the undo never ran at all.
+        if (e.Route != RoutingStrategies.Tunnel &&
+            _altMenuActivationGuard.TryConsumeAltRelease(e.Key, out var focusToRestore) &&
             (Menu is { IsOpen: true } || IsMainMenuFocused()))
         {
             if (focusToRestore is { IsEffectivelyVisible: true })

--- a/tests/UI/Features/Main/AltChordMenuActivationTests.cs
+++ b/tests/UI/Features/Main/AltChordMenuActivationTests.cs
@@ -1,0 +1,187 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// An Alt+&lt;key&gt; shortcut must not leave the menu bar activated (#14743, discussion #11744).
+///
+/// Avalonia's AccessKeyHandler notes "Alt was part of a chord" in its own tunnelling key-down
+/// handler, registered in the TopLevel constructor with handledEventsToo:false. Tunnel handlers on
+/// one element run in reverse registration order, so the window key handler added by MainView runs
+/// first: as soon as it marks an Alt shortcut handled - Alt+Down is the shipped "go to next line"
+/// binding - the built-in handler never sees the chord key and the Alt release runs MainMenu.Open().
+/// The bar then owns the keyboard and OnKeyDownHandler bails on IsMainMenuFocused, so the next
+/// Ctrl+Left/Right walked the menu items instead of moving the start time.
+///
+/// The boundary case - Alt+&lt;access key&gt;, which opens the bar on the key *down* and must keep
+/// working - is covered by MainMenuKeyboardActivationTests.AltLetter_OpensTheMenuBarItself.
+/// </summary>
+public class AltChordMenuActivationTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+
+    public void Dispose()
+    {
+        foreach (var window in _windows)
+        {
+            window.Close();
+        }
+
+        _windows.Clear();
+    }
+
+    [AvaloniaFact]
+    public void AltShortcutChord_DoesNotActivateTheMenuBar()
+    {
+        var (window, vm) = ShowMainWindowWithLines();
+        vm.EditTextBox.Focus();
+        Settle(window);
+        Assert.True(vm.EditTextBox.IsFocused, "the text box should hold focus before the Alt chord");
+
+        PressAltChord(window, PhysicalKey.ArrowDown);
+
+        Assert.False(vm.Menu.IsOpen, "an Alt shortcut must not open the menu bar on the Alt release");
+        Assert.False(window.FocusManager?.GetFocusedElement() is MenuItem, "focus must not land on a menu item");
+        Assert.True(vm.EditTextBox.IsFocused, "the text box should keep focus across the Alt shortcut");
+    }
+
+    [AvaloniaFact]
+    public void AltShortcutChord_LeavesTheFollowingShortcutWorking()
+    {
+        var allowTextNavigation = Se.Settings.Tools.AllowTextNavigationShortcutsInTextbox;
+        Se.Settings.Tools.AllowTextNavigationShortcutsInTextbox = true;
+        try
+        {
+            // The reported cycle: Alt+Down to step to the next line, then Ctrl+Left to nudge its
+            // start time - both from the text box, without touching the grid or the waveform.
+            WithShortcut(nameof(MainViewModel.MoveStartOneFrameBackCommand), ["Control", nameof(Key.Left)], () =>
+            {
+                var (window, vm) = ShowMainWindowWithLines();
+                vm.EditTextBox.Focus();
+                Settle(window);
+
+                PressAltChord(window, PhysicalKey.ArrowDown);
+                Assert.Equal(1, vm.SelectedSubtitleIndex);
+
+                var startBefore = vm.Subtitles[1].StartTime;
+                window.KeyPressQwerty(PhysicalKey.ArrowLeft, RawInputModifiers.Control);
+                Settle(window);
+                window.KeyReleaseQwerty(PhysicalKey.ArrowLeft, RawInputModifiers.Control);
+                Settle(window);
+
+                Assert.True(vm.Subtitles[1].StartTime < startBefore,
+                    "Ctrl+Left should move the start time back a frame instead of walking the menu bar");
+            });
+        }
+        finally
+        {
+            Se.Settings.Tools.AllowTextNavigationShortcutsInTextbox = allowTextNavigation;
+        }
+    }
+
+    [AvaloniaFact]
+    public void AltPointerGesture_DoesNotLeaveTheMenuBarActivated()
+    {
+        // The same reverse-order trap disabled the Alt+drag guard (#11744): its key-up handler
+        // consumed the armed state in the tunnel pass, where Avalonia has not opened the bar yet.
+        var (window, vm) = ShowMainWindowWithLines();
+        vm.EditTextBox.Focus();
+        Settle(window);
+
+        window.KeyPressQwerty(PhysicalKey.AltLeft, RawInputModifiers.Alt);
+        Settle(window);
+        window.MouseDown(new Avalonia.Point(400, 500), MouseButton.Left, RawInputModifiers.Alt);
+        Settle(window);
+        window.MouseUp(new Avalonia.Point(400, 500), MouseButton.Left, RawInputModifiers.Alt);
+        Settle(window);
+        window.KeyReleaseQwerty(PhysicalKey.AltLeft, RawInputModifiers.None);
+        Settle(window);
+
+        Assert.False(vm.Menu.IsOpen, "an Alt+click gesture must not leave the menu bar open");
+    }
+
+    /// <summary>
+    /// Alt held down, a second key pressed and released, then Alt released - the order in which
+    /// Avalonia's AccessKeyHandler arms and settles its menu-bar activation.
+    /// </summary>
+    private static void PressAltChord(Window window, PhysicalKey key)
+    {
+        window.KeyPressQwerty(PhysicalKey.AltLeft, RawInputModifiers.Alt);
+        Settle(window);
+        window.KeyPressQwerty(key, RawInputModifiers.Alt);
+        Settle(window);
+        window.KeyReleaseQwerty(key, RawInputModifiers.Alt);
+        Settle(window);
+        window.KeyReleaseQwerty(PhysicalKey.AltLeft, RawInputModifiers.None);
+        Settle(window);
+    }
+
+    private static void WithShortcut(string actionName, string[] keys, Action test)
+    {
+        var original = Se.Settings.Shortcuts.Where(s => s.ActionName == actionName).ToList();
+        Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == actionName);
+        Se.Settings.Shortcuts.Add(new SeShortCut(actionName, [.. keys]));
+        try
+        {
+            test();
+        }
+        finally
+        {
+            Se.Settings.Shortcuts.RemoveAll(s => s.ActionName == actionName);
+            Se.Settings.Shortcuts.AddRange(original);
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ShowMainWindowWithLines()
+    {
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+        for (var i = 0; i < 5; i++)
+        {
+            vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Line " + i, i * 3000, i * 3000 + 2000), null!) { Number = i + 1 });
+        }
+
+        Settle(window);
+
+        // On macOS the in-window menu is hidden in favor of the native menu bar; these tests
+        // exercise the in-window menu (the Windows/Linux path), so show it regardless of host.
+        vm.Menu.IsVisible = true;
+        vm.SelectedSubtitleIndex = 0;
+        vm.SubtitleGrid.SelectedItem = vm.Subtitles[0];
+        Settle(window);
+
+        return (window, vm);
+    }
+
+    private static void Settle(Window window)
+    {
+        for (var pump = 0; pump < 5; pump++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14743.

## What the user sees

`Alt+Down` ("go to next line", a shipped default binding) to step to the next line, then `Ctrl+Left/Right` to nudge the start time — and the arrow keys walk the menu bar instead. From the reporter's video, frame by frame:

| t | keys | menu bar |
|---|---|---|
| 64.2 s | `Alt` down | access-key underlines appear |
| 64.6 s | `Alt`+`Down` | still just underlines |
| 65.0 s | `Alt` released | **"File" highlighted — the bar is activated** |
| 65.4 s+ | `Ctrl`+`Left` ×N | highlight walks left: Translate → Spell check → Edit |

Once the bar owns the keyboard, `OnKeyDownHandler` bails at `IsMainMenuFocused()` and the Menu navigates its own items — which reads as "Ctrl+Left/Right acts like Tab". The `AllowTextNavigationShortcutsInTextbox` opt-in added for #14654 is set correctly in the reporter's Settings.json; it just never gets a chance to run.

## Cause

Avalonia's `AccessKeyHandler` does the "Alt was part of a chord, so its release must not open the menu bar" bookkeeping in its own tunnelling key-down handler. That handler is registered in the `TopLevel` constructor with `handledEventsToo: false`, and **tunnel handlers on one element run in reverse registration order** — so the window key handler `MainView.AttachKeyHandlers` adds runs *first*. The moment it marks an Alt shortcut handled, the built-in handler never sees the chord key, its `_ignoreAltUp` stays false, and `OnPreviewKeyUp` (which has no such guard) calls `MainMenu.Open()`.

Reproduced in plain Avalonia with no SE code: a second-registered tunnel handler that marks `Alt+Down` handled makes the menu open on the Alt release; without it, it does not. Not new in Avalonia 12 — 11.2.2 has the same shape. It came in when the key handlers moved from `MainView` to the `window` (they were on the child control in e92fd63f1, where `AccessKeyHandler` ran first by element order).

**Second defect, same cause:** the Alt+drag guard from discussion #11744 was dead too. `OnKeyUpHandler` is registered for `Tunnel | Bubble`, so it runs twice per key-up, and `AltMenuActivationGuard.TryConsumeAltRelease` was consumed in the **tunnel** pass — where the bar is still closed, because Avalonia opens it from its own tunnel handler that runs after ours. An end-to-end Alt+click test fails on current `main`.

## Fix

- Arm a cancellation when a handled key chord carries Alt; undo the activation on the Alt release, restoring the focus the window held just before Avalonia took it (captured in the key-up tunnel pass — the last moment before the steal).
- Only act in the **bubble** pass, for both undo paths. That also restores the #11744 pointer guard.
- An `Alt+<access key>` such as `Alt+F` opens the bar on the key *down*, not the release, so it is recognised by the pre-release snapshot and left alone.

`BinaryEditWindow` registers its key handlers on the default (bubble) strategy, so `AccessKeyHandler` always runs first there — no equivalent change needed.

## Tests

New `tests/UI/Features/Main/AltChordMenuActivationTests.cs`:

- `AltShortcutChord_DoesNotActivateTheMenuBar` — the bar stays closed and the text box keeps focus.
- `AltShortcutChord_LeavesTheFollowingShortcutWorking` — the reported cycle end to end: `Alt+Down`, then `Ctrl+Left` moves the start time back a frame.
- `AltPointerGesture_DoesNotLeaveTheMenuBarActivated` — the #11744 regression.

All three fail on `main` and pass with the fix. Full UI suite green (5049 passed), including `MainMenuKeyboardActivationTests.AltLetter_OpensTheMenuBarItself`, which caught a first, too-broad attempt that also cancelled access-key activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)