### PR TITLE
Clarify shortcut label: "Open Subtitle Edit data folder"

### DIFF
--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3149,7 +3149,7 @@
       "fileExportEbuStl": "Export EBU STL",
       "fileExportPac": "Export PAC",
       "fileExit": "Exit",
-      "openSeDataFolder": "Open Subtitle Edit folder",
+      "openSeDataFolder": "Open Subtitle Edit data folder",
       "editFindPrevious": "Find previous",
       "fillSelectedLinesWithClipboard": "Fill selected lines with clipboard text",
       "listInverseSelection": "Inverse selection",

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -322,7 +322,7 @@ public class LanguageSettingsShortcuts
         FileExportEbuStl = "Export EBU STL";
         FileExportPac = "Export PAC";
         FileExit = "Exit";
-        OpenSeDataFolder = "Open Subtitle Edit folder";
+        OpenSeDataFolder = "Open Subtitle Edit data folder";
 
         EditFindPrevious = "Find previous";
         FillSelectedLinesWithClipboard = "Fill selected lines with clipboard text";


### PR DESCRIPTION
The shortcut bound to `OpenDataFolderCommand` opens `Se.DataFolder` — the settings/data folder — but was labelled just "Open Subtitle Edit folder", which reads like the program install folder.

Renamed to **"Open Subtitle Edit data folder"** in `LanguageSettingsShortcuts.cs` (source of truth) and the matching key in `English.json`.

Translated language files keep their existing wording; translators can follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)