### PR TITLE
Fix #14751: recover from a corrupt waveform cache instead of hanging on it

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -6389,12 +6389,7 @@ public partial class MainViewModel :
         var spectrogramFileName = WavePeakGenerator2.SpectrogramDrawer.GetSpectrogramFileName(_videoFileName, _audioTrack?.FfIndex ?? -1);
         if (File.Exists(spectrogramFileName))
         {
-            var spectrogram = SpectrogramData2.FromDisk(spectrogramFileName);
-            if (spectrogram != null)
-            {
-                spectrogram.Load();
-                AudioVisualizer.SetSpectrogram(spectrogram);
-            }
+            AudioVisualizer.SetSpectrogram(TryLoadCachedSpectrogram(spectrogramFileName));
 
             AudioVisualizer.ResetCache();
             _updateAudioVisualizer = true;
@@ -10520,7 +10515,12 @@ public partial class MainViewModel :
             return;
         }
 
-        var wavePeaks = WavePeakData2.FromDisk(peakWaveFileName);
+        var wavePeaks = TryLoadCachedPeaks(peakWaveFileName);
+        if (wavePeaks == null)
+        {
+            return;
+        }
+
         if (AudioVisualizer != null)
         {
             AudioVisualizer.WavePeaks = wavePeaks;
@@ -10533,12 +10533,7 @@ public partial class MainViewModel :
             var spectrogramFileName = WavePeakGenerator2.SpectrogramDrawer.GetSpectrogramFileName(_videoFileName, _audioTrack?.FfIndex ?? -1);
             if (File.Exists(spectrogramFileName))
             {
-                var spectrogram = SpectrogramData2.FromDisk(spectrogramFileName);
-                if (spectrogram != null)
-                {
-                    spectrogram.Load();
-                    AudioVisualizer.SetSpectrogram(spectrogram);
-                }
+                AudioVisualizer.SetSpectrogram(TryLoadCachedSpectrogram(spectrogramFileName));
             }
 
             InitializeWaveformDisplayMode();
@@ -25802,7 +25797,24 @@ public partial class MainViewModel :
         else if (File.Exists(peakWaveFileName))
         {
             ShowStatus(Se.Language.Main.LoadingWaveInfoFromCache);
-            var wavePeaks = WavePeakData2.FromDisk(peakWaveFileName);
+            var wavePeaks = TryLoadCachedPeaks(peakWaveFileName);
+            if (wavePeaks == null)
+            {
+                // The cache file was corrupt and has now been thrown away, so extraction can
+                // produce a good one - which is the whole point of deleting it. With
+                // auto-generate off, the hint lets the user start that extraction.
+                if (Se.Settings.Waveform.WaveformAutoGenerate)
+                {
+                    StartWaveformExtraction(videoFileName, trackNumber, peakWaveFileName, spectrogramFileName);
+                }
+                else
+                {
+                    ShowClickToGenerateWaveformHint();
+                }
+
+                return;
+            }
+
             if (AudioVisualizer != null)
             {
                 Dispatcher.UIThread.Post(() =>
@@ -25815,12 +25827,9 @@ public partial class MainViewModel :
                         AudioVisualizer.UseSmpteDropFrameTime();
                     }
 
-                    var spectrogram = SpectrogramData2.FromDisk(spectrogramFileName);
-                    if (spectrogram != null)
-                    {
-                        spectrogram.Load();
-                        AudioVisualizer.SetSpectrogram(spectrogram);
-                    }
+                    // Always set it, null included: that is what clears the previously opened
+                    // video's spectrogram when this one has none.
+                    AudioVisualizer.SetSpectrogram(TryLoadCachedSpectrogram(spectrogramFileName));
 
                     InitializeWaveformDisplayMode();
 
@@ -25841,14 +25850,85 @@ public partial class MainViewModel :
                 });
             }
         }
-        else if (AudioVisualizer != null)
+        else
         {
             // No cached waveform and auto-generate is off: show the click-to-generate hint.
-            Dispatcher.UIThread.Post(() =>
-            {
-                AudioVisualizer.ShowClickToGenerateHint = true;
-                AudioVisualizer.InvalidateVisual();
-            });
+            ShowClickToGenerateWaveformHint();
+        }
+    }
+
+    private void ShowClickToGenerateWaveformHint()
+    {
+        var audioVisualizer = AudioVisualizer;
+        if (audioVisualizer == null)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            audioVisualizer.ShowClickToGenerateHint = true;
+            audioVisualizer.InvalidateVisual();
+        });
+    }
+
+    /// <summary>
+    /// Reads cached wave peaks, discarding the cache file when it cannot be read.
+    /// </summary>
+    /// <remarks>
+    /// A cache file left half-written by a crash (#14751) is not a one-off annoyance: nothing on
+    /// this path looks past File.Exists, so the same ruined file is re-read on every open of that
+    /// video and the failure repeats forever. Deleting it lets the next extraction replace it.
+    /// </remarks>
+    private static WavePeakData2? TryLoadCachedPeaks(string peakWaveFileName)
+    {
+        try
+        {
+            return WavePeakData2.FromDisk(peakWaveFileName);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, $"Discarding unreadable waveform cache file: {peakWaveFileName}");
+            DeleteCorruptCacheFile(peakWaveFileName);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads a cached spectrogram, discarding the cache file when it cannot be read. Returns null
+    /// when there is no spectrogram to show - which is also the normal case for a video whose
+    /// peaks were extracted with the spectrogram setting off.
+    /// </summary>
+    private static SpectrogramData2? TryLoadCachedSpectrogram(string spectrogramFileName)
+    {
+        if (!File.Exists(spectrogramFileName))
+        {
+            return null;
+        }
+
+        var spectrogram = SpectrogramData2.FromDisk(spectrogramFileName);
+        if (spectrogram.Load())
+        {
+            return spectrogram;
+        }
+
+        // The file was there a moment ago but would not load. Drop it, so the missing
+        // spectrogram makes the next open of this video extract a fresh one.
+        Se.LogError($"Discarding unreadable spectrogram cache file: {spectrogramFileName}");
+        spectrogram.Dispose();
+        DeleteCorruptCacheFile(spectrogramFileName);
+        return null;
+    }
+
+    private static void DeleteCorruptCacheFile(string fileName)
+    {
+        try
+        {
+            File.Delete(fileName);
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, $"Unable to delete corrupt cache file: {fileName}");
         }
     }
 

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -2517,6 +2517,21 @@ public partial class SettingsViewModel : ObservableObject
     {
         if (Directory.Exists(Se.WaveformsFolder))
         {
+            // Cache files are written through a "<name>.tmp" file next to the destination, so a
+            // crashed extraction can leave one behind; sweep those too, or "Delete" would leave
+            // the folder holding files the size info below still counts.
+            foreach (var file in Directory.GetFiles(Se.WaveformsFolder, "*.wav" + WaveCacheFile.TempSuffix).ToList())
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
             foreach (var file in Directory.GetFiles(Se.WaveformsFolder, "*.wav").ToList())
             {
                 try
@@ -2532,6 +2547,18 @@ public partial class SettingsViewModel : ObservableObject
 
         if (Directory.Exists(Se.SpectrogramsFolder))
         {
+            foreach (var file in Directory.GetFiles(Se.SpectrogramsFolder, "*.spectrogram" + WaveCacheFile.TempSuffix).ToList())
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
             foreach (var file in Directory.GetFiles(Se.SpectrogramsFolder, "*.spectrogram").ToList())
             {
                 try
@@ -2552,10 +2579,12 @@ public partial class SettingsViewModel : ObservableObject
         if (Directory.Exists(Se.WaveformsFolder))
         {
             files.AddRange(Directory.GetFiles(Se.WaveformsFolder, "*.wav"));
+            files.AddRange(Directory.GetFiles(Se.WaveformsFolder, "*.wav" + WaveCacheFile.TempSuffix));
         }
         if (Directory.Exists(Se.SpectrogramsFolder))
         {
             files.AddRange(Directory.GetFiles(Se.SpectrogramsFolder, "*.spectrogram", SearchOption.AllDirectories));
+            files.AddRange(Directory.GetFiles(Se.SpectrogramsFolder, "*.spectrogram" + WaveCacheFile.TempSuffix, SearchOption.AllDirectories));
         }
         return files;
     }

--- a/src/ui/Logic/Media/WaveToVisualizer2.cs
+++ b/src/ui/Logic/Media/WaveToVisualizer2.cs
@@ -88,7 +88,7 @@ public class WaveHeader2
         int bytesRead = stream.Read(buffer);
         if (bytesRead < buffer.Length)
         {
-            throw new ArgumentException("Stream is too small");
+            throw new InvalidDataException("Stream is too small");
         }
 
         // Parse constant header - use Span slicing to avoid array indexing
@@ -97,6 +97,17 @@ public class WaveHeader2
         Format = Encoding.UTF8.GetString(buffer.Slice(8, 4));
         FmtId = Encoding.UTF8.GetString(buffer.Slice(12, 4));
         FmtChunkSize = BitConverter.ToInt32(buffer.Slice(16));
+
+        // Every size in this header comes straight off disk, and a waveform cache file left
+        // half-written by a crash (#14751) has garbage in it. Sizing an allocation from an
+        // unchecked field is how a corrupt cache turns into a multi-hundred-megabyte array and
+        // a frozen UI, so each one is bounded by the bytes the file actually has before it is
+        // used. 16 is the smallest legal fmt chunk and the last field read below sits at 14..15.
+        if (FmtChunkSize < 16 || ConstantHeaderSize + (long)FmtChunkSize + 8 > stream.Length)
+        {
+            throw new InvalidDataException(
+                $"Invalid wave header: fmt chunk size {FmtChunkSize} does not fit in a {stream.Length} byte stream.");
+        }
 
         // Read fmt chunk - allocate only if needed (usually 16-18 bytes, max ~40)
         Span<byte> fmtBuffer = FmtChunkSize <= 128
@@ -146,6 +157,25 @@ public class WaveHeader2
             DataId = Encoding.UTF8.GetString(dataHeader.Slice(0, 4));
             DataChunkSize = BitConverter.ToUInt32(dataHeader.Slice(4));
             DataStartPosition = (int)currentPos + 8;
+        }
+
+        // A truncated file still declares the full data size - the peak writer emits the header
+        // with the final sample count up front and streams the samples after it, so a crash
+        // mid-write leaves a header promising bytes that never landed. Cap the promise at what
+        // is really there: the peaks that survived still load, and nothing sizes an array from
+        // a number the file cannot back.
+        var availableDataBytes = Math.Max(0, stream.Length - DataStartPosition);
+        if (DataChunkSize > availableDataBytes)
+        {
+            DataChunkSize = (uint)availableDataBytes;
+        }
+
+        // BlockAlign below divides LengthInSamples, and LengthInSeconds divides by BytesPerSecond;
+        // a zeroed-out fmt chunk would make both a divide-by-zero deep inside a peak load.
+        if (NumberOfChannels <= 0 || BitsPerSample <= 0)
+        {
+            throw new InvalidDataException(
+                $"Invalid wave header: {NumberOfChannels} channel(s), {BitsPerSample} bits per sample.");
         }
 
         // Recalculate BlockAlign (older versions wrote incorrect values)
@@ -243,6 +273,62 @@ public struct WavePeak2
     public int Abs
     {
         get { return Math.Max(Math.Abs((int)Max), Math.Abs((int)Min)); }
+    }
+}
+
+/// <summary>
+/// Writes a waveform/spectrogram cache file through a temp file in the same folder, so the
+/// destination only ever exists complete.
+/// </summary>
+/// <remarks>
+/// Both cache formats put their length up front and stream the payload after it, so writing
+/// straight to the destination means a crash (or a full disk, or a killed process) leaves a
+/// file whose header promises far more than it holds - and since the load path only checks
+/// that the file *exists*, that ruin is then re-read on every single open of the same video,
+/// forever (#14751). Renaming a finished temp file over the destination is atomic on both
+/// NTFS and POSIX, so an interrupted write leaves the old cache - or no cache - but never a
+/// half-written one.
+/// </remarks>
+internal static class WaveCacheFile
+{
+    /// <summary>Suffix of the in-progress file; the cleanup in settings globs it away too.</summary>
+    internal const string TempSuffix = ".tmp";
+
+    internal static void Write(string filePath, Action<Stream> writeContent)
+    {
+        var dir = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        // Deliberately deterministic rather than unique: a crash can only ever strand one temp
+        // file per cached video, and the next extraction of that video reuses the same name.
+        // It also keeps the temp file beside the destination, which is what lets the move be a
+        // rename instead of a cross-volume copy.
+        var tempFilePath = filePath + TempSuffix;
+        try
+        {
+            using (var stream = File.Create(tempFilePath))
+            {
+                writeContent(stream);
+            }
+
+            File.Move(tempFilePath, filePath, true);
+        }
+        catch
+        {
+            try
+            {
+                File.Delete(tempFilePath);
+            }
+            catch
+            {
+                // ignore - a stranded temp file is overwritten by the next run
+            }
+
+            throw;
+        }
     }
 }
 
@@ -366,6 +452,10 @@ public class WavePeakData2
 
 public class SpectrogramData2 : IDisposable
 {
+    // Sanity bounds for the metadata read back from a cache file - see LoadFromBinaryFile.
+    private const int MaxFftSize = 65536;
+    private const int MaxImageWidth = 65536;
+
     private string? _loadFromFilePath;
     private float[]? _rawSamples;
 
@@ -410,14 +500,20 @@ public class SpectrogramData2 : IDisposable
         get { return _loadFromFilePath == null && _rawSamples == null; }
     }
 
-    public void Load()
+    /// <summary>
+    /// Materializes the spectrogram images. Returns false when there was nothing usable to load -
+    /// the file is missing, or it is there but unreadable. Callers that know the file existed can
+    /// treat false as "this cache file is corrupt" and discard it (#14751); before, the failure
+    /// was logged and swallowed here, so a ruined file was silently re-read on every open.
+    /// </summary>
+    public bool Load()
     {
         // Load from raw data if available
         if (_rawSamples != null)
         {
             GenerateImagesFromRawData();
             _rawSamples = null;
-            return;
+            return true;
         }
 
         // Load from binary file if path is set
@@ -430,7 +526,7 @@ public class SpectrogramData2 : IDisposable
             {
                 if (!File.Exists(filePath))
                 {
-                    return;
+                    return false;
                 }
 
                 LoadFromBinaryFile(filePath);
@@ -438,8 +534,11 @@ public class SpectrogramData2 : IDisposable
             catch (Exception exception)
             {
                 Se.LogError(exception, $"Unable to load spectrogram from {filePath}");
+                return false;
             }
         }
+
+        return true;
     }
 
     private void LoadFromBinaryFile(string filePath)
@@ -447,13 +546,32 @@ public class SpectrogramData2 : IDisposable
         using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         using var br = new BinaryReader(fs);
 
+        const int metadataSize = 16; // 2 ints (8 bytes) + 1 double (8 bytes), matching SaveToBinaryFile
+        if (fs.Length < metadataSize)
+        {
+            throw new InvalidDataException($"Spectrogram file is too small ({fs.Length} bytes).");
+        }
+
         // Read metadata
         FftSize = br.ReadInt32();
         ImageWidth = br.ReadInt32();
         SampleDuration = br.ReadDouble();
 
+        // GenerateImagesFromRawData divides the sample count by FftSize * ImageWidth to get the
+        // number of images to build, so corrupt metadata is not merely wrong output: a stored
+        // 1 x 1 turns one file into millions of SKBitmap allocations and the app never comes
+        // back (#14751). The writer only ever stores 256 x 1024; the bounds here stay wide
+        // enough that changing those constants needs no change to this check.
+        if (FftSize < 2 || FftSize > MaxFftSize || FftSize % 2 != 0 ||
+            ImageWidth < 1 || ImageWidth > MaxImageWidth ||
+            !double.IsFinite(SampleDuration) || SampleDuration <= 0)
+        {
+            throw new InvalidDataException(
+                $"Invalid spectrogram metadata: fft size {FftSize}, image width {ImageWidth}, sample duration {SampleDuration}.");
+        }
+
         // Read raw samples
-        var sampleCount = (int)((fs.Length - 16) / sizeof(float)); // 16 bytes = 2 ints (8 bytes) + 1 double (8 bytes), matching SaveToBinaryFile
+        var sampleCount = (int)((fs.Length - metadataSize) / sizeof(float));
         _rawSamples = new float[sampleCount];
 
         var byteSpan = MemoryMarshal.AsBytes(_rawSamples.AsSpan());
@@ -544,23 +662,20 @@ public class SpectrogramData2 : IDisposable
 
     public static void SaveToBinaryFile(string filePath, int fftSize, int imageWidth, double sampleDuration, float[] samples)
     {
-        var dir = Path.GetDirectoryName(filePath);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        WaveCacheFile.Write(filePath, fs =>
         {
-            Directory.CreateDirectory(dir);
-        }
+            var bw = new BinaryWriter(fs);
 
-        using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write);
-        using var bw = new BinaryWriter(fs);
+            // Write metadata
+            bw.Write(fftSize);
+            bw.Write(imageWidth);
+            bw.Write(sampleDuration);
 
-        // Write metadata
-        bw.Write(fftSize);
-        bw.Write(imageWidth);
-        bw.Write(sampleDuration);
-
-        // Write raw samples
-        ReadOnlySpan<byte> byteSpan = MemoryMarshal.AsBytes(samples.AsSpan());
-        fs.Write(byteSpan);
+            // Write raw samples
+            ReadOnlySpan<byte> byteSpan = MemoryMarshal.AsBytes(samples.AsSpan());
+            fs.Write(byteSpan);
+            bw.Flush();
+        });
     }
 }
 
@@ -771,10 +886,7 @@ public class WavePeakGenerator2 : IDisposable
         // save results to file
         if (!string.IsNullOrWhiteSpace(peakFileName))
         {
-            using (var stream = File.Create(peakFileName))
-            {
-                WriteWaveformData(stream, peaksPerSecond, peaks);
-            }
+            WaveCacheFile.Write(peakFileName, stream => WriteWaveformData(stream, peaksPerSecond, peaks));
         }
 
         return new WavePeakData2(peaksPerSecond, peaks);
@@ -800,20 +912,10 @@ public class WavePeakGenerator2 : IDisposable
         }
         peaks.Add(new WavePeak2(1000, -1000));
 
-        // save results to file
-        var dir = Path.GetDirectoryName(peakFileName);
-        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-        {
-            Directory.CreateDirectory(dir);
-        }
-
-        // One bulk write of the (Max, Min) short pairs - byte-identical to the old 4-bytes-per-
-        // peak loop (a WavePeak2 is exactly the two little-endian shorts the loop wrote), ~16x
-        // faster on a multi-hour file.
-        using (var stream = File.Create(peakFileName))
-        {
-            WriteWaveformData(stream, peaksPerSecond, peaks);
-        }
+        // Save results to file. One bulk write of the (Max, Min) short pairs - byte-identical to
+        // the old 4-bytes-per-peak loop (a WavePeak2 is exactly the two little-endian shorts the
+        // loop wrote), ~16x faster on a multi-hour file.
+        WaveCacheFile.Write(peakFileName, stream => WriteWaveformData(stream, peaksPerSecond, peaks));
 
         return new WavePeakData2(peaksPerSecond, peaks);
     }
@@ -982,6 +1084,13 @@ public class WavePeakGenerator2 : IDisposable
         if (Header.NumberOfChannels != 1 && Header.NumberOfChannels != 2)
         {
             throw new Exception("Peaks file must have 1 or 2 channels.");
+        }
+
+        // The sample rate is the peaks-per-second the whole waveform time base is built on;
+        // a corrupt 0 would silently yield an infinite length rather than an error.
+        if (Header.SampleRate <= 0)
+        {
+            throw new InvalidDataException($"Peaks file has an invalid sample rate ({Header.SampleRate}).");
         }
 
         // load data

--- a/tests/UI/Logic/WaveformCacheCorruptionTests.cs
+++ b/tests/UI/Logic/WaveformCacheCorruptionTests.cs
@@ -1,0 +1,406 @@
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace UITests.Logic;
+
+/// <summary>
+/// A waveform/spectrogram cache file left half-written by a crash used to wedge the app: the
+/// loader sized its arrays straight from the header, so garbage there meant a huge allocation on
+/// the UI thread, and since the load path only checked that the file existed, the same ruined
+/// file was re-read on every open of that video (#14751). These tests pin the two halves of the
+/// fix - every size is bounded by the bytes the file really holds, and a finished write is moved
+/// into place rather than streamed into the destination.
+/// </summary>
+public class WaveformCacheCorruptionTests
+{
+    private const int PeaksPerSecond = 100;
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "se-wave-cache-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static List<WavePeak2> BuildPeaks(int count)
+    {
+        var peaks = new List<WavePeak2>(count);
+        for (var i = 0; i < count; i++)
+        {
+            peaks.Add(new WavePeak2((short)(i % 1000), (short)-(i % 1000)));
+        }
+
+        return peaks;
+    }
+
+    private static byte[] BuildPeakFileBytes(int peakCount)
+    {
+        var stream = new MemoryStream();
+        WavePeakGenerator2.WriteWaveformData(stream, PeaksPerSecond, BuildPeaks(peakCount));
+        return stream.ToArray();
+    }
+
+    [Fact]
+    public void FromDisk_ValidPeakFile_RoundTrips()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            File.WriteAllBytes(path, BuildPeakFileBytes(500));
+
+            var peaks = WavePeakData2.FromDisk(path);
+
+            Assert.Equal(PeaksPerSecond, peaks.SampleRate);
+            Assert.Equal(500, peaks.Peaks.Count - 5); // LoadPeaks pads the array by 5
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void FromDisk_EmptyFile_Throws()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            File.WriteAllBytes(path, Array.Empty<byte>());
+
+            Assert.Throws<InvalidDataException>(() => WavePeakData2.FromDisk(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// What a journalling filesystem hands back after a crash: the file has its size but the
+    /// data never landed. A zero fmt chunk size used to read past an empty buffer.
+    /// </summary>
+    [Fact]
+    public void FromDisk_ZeroFilledFile_Throws()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            File.WriteAllBytes(path, new byte[4096]);
+
+            Assert.Throws<InvalidDataException>(() => WavePeakData2.FromDisk(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The allocation that froze the app: a garbage fmt chunk size is rejected against the file
+    /// length instead of being handed to <c>new byte[FmtChunkSize]</c>.
+    /// </summary>
+    [Fact]
+    public void FromDisk_FmtChunkSizeLargerThanFile_ThrowsWithoutAllocating()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var bytes = BuildPeakFileBytes(100);
+            BitConverter.GetBytes(int.MaxValue - 8).CopyTo(bytes, 16);
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Throws<InvalidDataException>(() => WavePeakData2.FromDisk(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void FromDisk_NegativeFmtChunkSize_Throws()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var bytes = BuildPeakFileBytes(100);
+            BitConverter.GetBytes(-1).CopyTo(bytes, 16);
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Throws<InvalidDataException>(() => WavePeakData2.FromDisk(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The other allocation that froze the app. 0xFFFFFFFF in the data chunk size asked for a 4 GB
+    /// byte array plus a 4 GB peak array; now it is capped at the bytes the file actually has, so
+    /// the load stays bounded and returns the peaks that survived.
+    /// </summary>
+    [Fact]
+    public void FromDisk_DataChunkSizeLargerThanFile_ClampsToWhatIsThere()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var bytes = BuildPeakFileBytes(250);
+            BitConverter.GetBytes(uint.MaxValue).CopyTo(bytes, 40);
+            File.WriteAllBytes(path, bytes);
+
+            var peaks = WavePeakData2.FromDisk(path);
+
+            // 250 peaks survived the "corruption"; the array is padded by 5 either way.
+            Assert.Equal(255, peaks.Peaks.Count);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The crash case the atomic write now prevents, read through the loader: a header promising
+    /// the full peak count over a body that stops early loads the part that made it to disk.
+    /// </summary>
+    [Fact]
+    public void FromDisk_TruncatedBody_LoadsTheSurvivingPeaks()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var bytes = BuildPeakFileBytes(1000);
+            // Keep the 44 byte header and 400 of the 4000 payload bytes = 100 peaks.
+            var truncated = new byte[44 + 400];
+            Array.Copy(bytes, truncated, truncated.Length);
+            File.WriteAllBytes(path, truncated);
+
+            var peaks = WavePeakData2.FromDisk(path);
+
+            Assert.Equal(105, peaks.Peaks.Count);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void FromDisk_ZeroSampleRate_Throws()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var bytes = BuildPeakFileBytes(100);
+            BitConverter.GetBytes(0).CopyTo(bytes, 24);
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Throws<InvalidDataException>(() => WavePeakData2.FromDisk(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void FromDisk_ZeroChannels_Throws()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var bytes = BuildPeakFileBytes(100);
+            BitConverter.GetBytes((short)0).CopyTo(bytes, 22);
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Throws<InvalidDataException>(() => WavePeakData2.FromDisk(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    private static byte[] BuildSpectrogramBytes(int fftSize, int imageWidth, double sampleDuration, int sampleCount)
+    {
+        var stream = new MemoryStream();
+        var writer = new BinaryWriter(stream, Encoding.UTF8);
+        writer.Write(fftSize);
+        writer.Write(imageWidth);
+        writer.Write(sampleDuration);
+        for (var i = 0; i < sampleCount; i++)
+        {
+            writer.Write((float)Math.Sin(i / 32.0) * 0.5f);
+        }
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    [Fact]
+    public void SpectrogramLoad_ValidFile_ReturnsTrue()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "a.spectrogram");
+            File.WriteAllBytes(path, BuildSpectrogramBytes(256, 1024, 256 / 8000.0, 256 * 1024));
+
+            using var spectrogram = SpectrogramData2.FromDisk(path);
+
+            Assert.True(spectrogram.Load());
+            Assert.Single(spectrogram.Images);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The unbounded hang: the image count is the sample count divided by fftSize * imageWidth, so
+    /// a corrupt 1 x 1 asked for one SKBitmap per sample and never came back.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(0, 1024)]
+    [InlineData(256, 0)]
+    [InlineData(-256, 1024)]
+    [InlineData(256, -1024)]
+    [InlineData(255, 1024)] // odd - the image height is fftSize / 2
+    public void SpectrogramLoad_CorruptMetadata_ReturnsFalse(int fftSize, int imageWidth)
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "a.spectrogram");
+            File.WriteAllBytes(path, BuildSpectrogramBytes(fftSize, imageWidth, 0.032, 4096));
+
+            using var spectrogram = SpectrogramData2.FromDisk(path);
+
+            Assert.False(spectrogram.Load());
+            Assert.Empty(spectrogram.Images);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void SpectrogramLoad_TooSmallFile_ReturnsFalse()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "a.spectrogram");
+            File.WriteAllBytes(path, new byte[8]);
+
+            using var spectrogram = SpectrogramData2.FromDisk(path);
+
+            Assert.False(spectrogram.Load());
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void SpectrogramLoad_MissingFile_ReturnsFalse()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            using var spectrogram = SpectrogramData2.FromDisk(Path.Combine(dir, "nope.spectrogram"));
+
+            Assert.False(spectrogram.Load());
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void CacheFileWrite_CreatesTheDestinationAndLeavesNoTempFile()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "sub", "peaks.wav");
+
+            WaveCacheFile.Write(path, stream => stream.Write(new byte[] { 1, 2, 3 }));
+
+            Assert.Equal(new byte[] { 1, 2, 3 }, File.ReadAllBytes(path));
+            Assert.False(File.Exists(path + WaveCacheFile.TempSuffix));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The heart of it: an interrupted write must leave the previous cache untouched rather than
+    /// overwrite it with a partial file that the loader would then choke on at every open.
+    /// </summary>
+    [Fact]
+    public void CacheFileWrite_FailedWrite_LeavesTheExistingFileIntact()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            var original = BuildPeakFileBytes(100);
+            File.WriteAllBytes(path, original);
+
+            Assert.Throws<IOException>(() => WaveCacheFile.Write(path, stream =>
+            {
+                stream.Write(new byte[] { 9, 9, 9 });
+                throw new IOException("disk full");
+            }));
+
+            Assert.Equal(original, File.ReadAllBytes(path));
+            Assert.False(File.Exists(path + WaveCacheFile.TempSuffix));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void CacheFileWrite_ReplacesAnExistingFile()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var path = Path.Combine(dir, "peaks.wav");
+            File.WriteAllBytes(path, new byte[] { 7, 7, 7, 7, 7, 7 });
+
+            WaveCacheFile.Write(path, stream => stream.Write(new byte[] { 1, 2 }));
+
+            Assert.Equal(new byte[] { 1, 2 }, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #14751.

The reporter's machine crashed, and after that Subtitle Edit hung on "Loading wave info from cache..." every time they opened the same video — with no way out short of finding and deleting the cache file by hand.

## What was wrong

The cached-waveform path trusted the cache file completely and had no way to recover from a bad one.

- **Sizes came straight off disk.** `WaveHeader2` allocated `new byte[FmtChunkSize]`, and `LoadPeaks` allocated `new byte[Header.DataChunkSize]` plus `new WavePeak2[Header.LengthInSamples + 5]`, none of them checked against the file's actual length. Garbage in those fields meant a multi-hundred-megabyte — or multi-gigabyte — allocation on the UI thread.
- **A corrupt spectrogram was worse.** `GenerateImagesFromRawData` computes `chunkCount = samples.Length / (FftSize * ImageWidth)`. A stored `1 x 1` turns one file into millions of `SKBitmap` allocations inside a `Parallel.For`, which simply never comes back.
- **Nothing ever recovered.** `needToGenerate` is `!File.Exists(peakWaveFileName)`, so a corrupt file exists and is re-read on every single open, forever. `SpectrogramData2.Load` logged its failure and swallowed it, so the caller could not even tell that the file was bad.
- **The writer invited it.** `File.Create(peakFileName)` wrote the header — carrying the *final* peak count — straight to the destination and streamed the samples after it. A crash mid-write leaves a file whose header promises far more than it holds.

## What changed

**Bound every size by the bytes the file really holds.** A fmt chunk that does not fit the file is rejected; a data chunk that overruns it is capped at what is there, so a truncated file now loads the peaks that survived rather than allocating for bytes that never landed; spectrogram metadata is validated before being used as a divisor. Zero channels, zero bits per sample and a zero sample rate are rejected instead of becoming a divide-by-zero (or an infinite length) deeper in.

**Discard a cache file that will not load and extract a fresh one.** This is the part that actually unsticks an already-corrupt cache like the reporter's. `SpectrogramData2.Load` now returns `bool` so a caller that knows the file existed can tell "corrupt" from "not there"; both loaders are wrapped, the bad file is deleted and logged, and extraction takes over (or the click-to-generate hint appears, when auto-generate is off).

**Write through a temp file.** Both cache writers now go through `WaveCacheFile.Write`, which writes `<name>.tmp` beside the destination and renames it into place — atomic on NTFS and POSIX alike — so an interrupted write leaves the previous cache, or no cache, but never a half-written one. Settings → Waveform/spectrogram → Delete sweeps any stranded temp file too, and counts it in the size it reports.

Deliberately *not* in this PR: the cached loads still run synchronously on the UI thread, unlike the extraction path which does its work on a worker and only marshals the result. That asymmetry is worth fixing, but it is a responsiveness refactor across three call sites rather than part of this correctness fix.

## Testing

New `tests/UI/Logic/WaveformCacheCorruptionTests.cs` — 21 tests covering an empty file, a zero-filled file (what a journalling filesystem hands back after a crash), fmt/data chunk sizes larger than the file, a negative fmt size, a truncated body, zero channels/sample rate, the `1 x 1` spectrogram hang and its siblings, and the temp-file write (destination intact after a failed write, no stranded temp, replacement works).

Full UI suite green: 5055 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)