### PR TITLE
Prepare v5.2.0 release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,100 @@
 Subtitle Edit Changelog
 
+5.2.0 (10th of September 2026)
+
+  Subtitle Edit 5.2 collects the work of 32 betas and 7 release candidates.
+  A summary of the changes since 5.1.0:
+
+New features:
+* Assisted split and Assisted move - ranked one-click suggestions with full previews
+* Chapter editor with Matroska/MP4/OGM chapter formats (Video > More > Chapters)
+* Edit original - edit the original reference rows in place, open a non-matching original as a read-only reference, and show the original subtitle on the waveform
+* Forced narrative lines - a "Forced" column and "Save forced lines as..."
+* Error list with summary cards (Tools > List errors..., batch convert) - export to clipboard, text, Excel or web page
+* Statistics dashboard with tiles, meters, checks and a CPS histogram
+* Subtitle grid: "Columns..." dialog to reorder/hide columns, "Hide tags" formatting mode, and type-to-search in all combo boxes
+* Text boxes: drag-and-drop text (e.g. original to working text), configurable "Search via" shortcuts, "Google it", macOS "Look up", "Sentence case" and more "Surround with" slots
+* Waveform: guess start/end time from the waveform, snap to shot changes, editable video position box, per-track audio picker, and copy/paste at the video/waveform position
+* Beautify time codes using the video's real frame times, and in batch convert
+* Video offset remembers recent offsets; "Open recent video" and "Go to video position..." in the Video menu
+* Multiple replace: import/export rule categories, select all/none/invert, move shortcuts and regex match timeouts
+* Image-based subtitle editor: open DVD sup, XSUB, MP4 VobSub and more, "Video resolution..." scaling, and burn in Blu-ray sup
+* Update check settings with a stable/beta channel and a startup notification
+* Default save location, auto-break "do not break after" lists with an editor, and cut the subtitle with "Cut video"
+
+SE 4 parity:
+* Train nOCR, the minimum gap frame rate calculator, and "Remove/replace Unicode characters" (SE 4 plugin port)
+* WebVTT style manager, voices and browser preview, and configurable WebVTT cue settings
+* Import an SE 4 Settings.xml, and 22 more SE 4 shortcuts on shortcut import
+* Shortcuts: go to next empty line, go to first/last line, bookmarks, underline, toggle custom tags, recalculate duration, go to next/prev subtitle (play translate), move first word to previous subtitle, break at first space from cursor
+* Layout 10 (edit box under the waveform), "Center text in subtitle grid", the four grid double-click actions, and a toolbar frame rate that works like SE 4's
+* "Set up like Subtitle Edit 4" also arranges the waveform toolbar; "Open second subtitle file..." is back in SE 4's Video menu spot
+* Remove blank lines when opening a subtitle, full frame image export, regex snippet context menu in Find/replace, and Alt+F/Alt+R in Replace
+* Tesseract OCR: SE 4's 10 px margin and resize retry passes
+* Copy-to-clipboard grid menu items and plain text column paste are back
+
+Auto-translate and AI:
+* New "llama.cpp advanced" and "Ollama advanced" engines with batch context, system prompt and schema-forced output - also in batch convert and seconv (--translate-prompt)
+* MiLMMT-46 translation models; DeepL offers every API language; Google Translate retries via a fallback endpoint when the free service is blocked
+* Re-break translated rows that break the line profile, keep the chosen languages when the engine changes, and the original text is no longer lost after translating
+* AI review: in the grid context menu, apply suggestions in passes, Play current, start/stop the llama.cpp server, delay between requests, and new models (Gemma 4 E2B, EuroLLM, Granite 4.1)
+
+Speech to text:
+* New engines and models: WhisperX (standalone, no Python), Google Cloud Speech-to-Text v2, Voxtral (Crisp ASR) and anime-whisper for Japanese
+* Transcription quality report with non-speech and repeated-line removal
+* Crisp ASR: "Auto detect" language on all backends, a VAD off switch and a retry without VAD; live progress for WhisperX
+* The MLX Whisper engine was removed
+
+Text to speech:
+* New engines: IndexTTS 2.5, Higgs Audio v3, Fish Audio S2 Pro and FireRedTTS3 (audio.cpp), dots.tts, Confucius4-TTS and Pocket TTS (Crisp ASR), plus VibeVoice again, CosyVoice3 RL models and multilingual Chatterbox V3 (23 languages)
+* Voice cloning from the video - "Find voices in video and clone them all", and per-line cloning on Qwen3, audio.cpp, VibeVoice, MOSS-TTS, CosyVoice3 and VoxCPM2 - with a consent prompt before the first clone
+* Speaker-name detection, "leave sound/music lines silent", a Zonos language picker and custom Piper voice models
+
+OCR:
+* New engines and models: Apple Vision OCR (macOS), Paddle OCR 3.7 (PP-OCRv6), CrispEmbed PP-OCRv6 and DeepSeek-OCR-2, and llama.cpp HunyuanOCR 1.5, LFM2.5-VL 3B and custom vision models
+* Video OCR (burned-in subtitles): far more subtitles read, better text and start times, CrispEmbed engine, OCR fix engine and spell check coloring
+* OCR fix engine: new Spanish/Portuguese/Italian and Cyrillic rules, around 115 repaired replace list entries, and apostrophe straightening
+* Auto-detect the OCR language, open the matching video after OCR, "Save all images with HTML index", and faster nOCR matching
+
+Subtitle formats:
+* New: EBU-TT (Tech 3350), Manzanita DVB teletext (.dvbttx), Csv Excel, CANVASs SSTG1 (.sdb), Wistia json, DVD Junior SPC, Sonic DVD Producer, YouTube srv3 (.ytt), DaVinci Resolve marker EDL and Adobe Premiere markers
+* New exports: Final Cut Pro Xml Captions, BDN/xml 8-bit and Audacity/Tenacity labels
+* Read subtitles from fragmented MP4 (DASH/CMAF), ARIB STD-B24 captions from transport streams, and SMPTE-TT bitmap captions
+* Much better import of unknown formats (generic XML importer), "Import plain text" from the unknown format prompt, and spreadsheets from File > Open
+* EBU STL/teletext: color picker, alignment dialog, TT column, video preview with box/justification/double height, and frame-based time codes
+* SCC: colors as CEA-608 mid-row codes, a line length warning, and frame-accurate import timing
+* ASSA: embed and trim fonts, offer resampling on a resolution mismatch, new advanced effects, and "Change ASSA style properties" in batch convert
+* Ruby and emphasis in Lambda Cap and Netflix IMSC 1.1 Japanese; font colors in EBU-TT-D and IMSC Rosetta
+
+Video and image export:
+* Image-based export: advanced text effects (gradient, neon glow, 3D extrude), per-line ASSA colors and outlines, inline font face/size, and Blu-ray sup fades and overlapping subtitles
+* Burn-in: VideoToolbox hardware encoders on macOS, .webm/.ts output, letter spacing and libass style previews
+* Sync dialogs: subtitle on the video, resizable waveform, and the selected audio track
+* Smoother waveform/video cursor with mpv, faster scrubbing on long-GOP video, and fixed audio dropouts when pausing or seeking
+
+Batch convert and seconv:
+* Batch convert: Beautify time codes, convert colors to dialog, snap time codes to frames, "Add folder...", translation progress, keep the source file date/time, and every teletext page per PID
+* seconv: --json output and --help-json, --ocr-prompt, --translate-prompt, --override-position, --output-filename-append, full frame image export, .avi/XSUB reading and batched Paddle OCR
+
+Platforms and accessibility:
+* macOS: standard Window menu, open Finder files in a new window, and Apple Vision OCR
+* Linux: dead keys with ibus, Whisper XXL on glibc 2.41+, and OpenBLAS in the Flathub package
+* Keyboard-navigable dialogs (initial focus, Tab, Enter on the default button), screen reader value announcements, and undocked windows no longer stealing the foreground or staying on top
+
+Stability and performance:
+* Around 600 bugs fixed in code sweeps and random-file bug hunts - subtitle formats, dialogs, settings, OCR, batch convert and seconv
+* Faster format detection, Matroska reading on network shares, waveform generation, SCC export and grid rendering, and fixed memory leaks in several dialogs - thx ivandrofly, hisui3393
+* WSB is now import only
+
+Translations and engines:
+* New UI languages: Central Kurdish and Azerbaijani - and all language files synced with English
+* Updated engines: Crisp ASR v0.8.32, llama.cpp b10840, whisper.cpp v1.9.3, CrispEmbed v0.17.9, Paddle OCR 3.7, Tesseract 5.5.3, ffmpeg 9.0.1 (Windows), libmpv 20260814 (Windows) and yt-dlp 2026.08.19
+
+  A big thank you to everyone who tested the pre-releases, reported issues and
+  contributed code and translations - and a special thanks to Anthropic for
+  sponsoring a Claude subscription used in the development of this release :)
+
+
 5.1.0 (29th of July 2026)
 
   Subtitle Edit 5.1 is the first feature release after 5.0. A summary of the

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -76,16 +76,6 @@ Batch convert and seconv:
 * Batch convert: Beautify time codes, convert colors to dialog, snap time codes to frames, "Add folder...", translation progress, keep the source file date/time, and every teletext page per PID
 * seconv: --json output and --help-json, --ocr-prompt, --translate-prompt, --override-position, --output-filename-append, full frame image export, .avi/XSUB reading and batched Paddle OCR
 
-Platforms and accessibility:
-* macOS: standard Window menu, open Finder files in a new window, and Apple Vision OCR
-* Linux: dead keys with ibus, Whisper XXL on glibc 2.41+, and OpenBLAS in the Flathub package
-* Keyboard-navigable dialogs (initial focus, Tab, Enter on the default button), screen reader value announcements, and undocked windows no longer stealing the foreground or staying on top
-
-Stability and performance:
-* Around 600 bugs fixed in code sweeps and random-file bug hunts - subtitle formats, dialogs, settings, OCR, batch convert and seconv
-* Faster format detection, Matroska reading on network shares, waveform generation, SCC export and grid rendering, and fixed memory leaks in several dialogs - thx ivandrofly, hisui3393
-* WSB is now import only
-
 Translations and engines:
 * New UI languages: Central Kurdish and Azerbaijani - and all language files synced with English
 * Updated engines: Crisp ASR v0.8.32, llama.cpp b10840, whisper.cpp v1.9.3, CrispEmbed v0.17.9, Paddle OCR 3.7, Tesseract 5.5.3, ffmpeg 9.0.1 (Windows), libmpv 20260814 (Windows) and yt-dlp 2026.08.19

--- a/change-log.txt
+++ b/change-log.txt
@@ -79,16 +79,6 @@ Batch convert and seconv:
 * Batch convert: Beautify time codes, convert colors to dialog, snap time codes to frames, "Add folder...", translation progress, keep the source file date/time, and every teletext page per PID
 * seconv: --json output and --help-json, --ocr-prompt, --translate-prompt, --override-position, --output-filename-append, full frame image export, .avi/XSUB reading and batched Paddle OCR
 
-Platforms and accessibility:
-* macOS: standard Window menu, open Finder files in a new window, and Apple Vision OCR
-* Linux: dead keys with ibus, Whisper XXL on glibc 2.41+, and OpenBLAS in the Flathub package
-* Keyboard-navigable dialogs (initial focus, Tab, Enter on the default button), screen reader value announcements, and undocked windows no longer stealing the foreground or staying on top
-
-Stability and performance:
-* Around 600 bugs fixed in code sweeps and random-file bug hunts - subtitle formats, dialogs, settings, OCR, batch convert and seconv
-* Faster format detection, Matroska reading on network shares, waveform generation, SCC export and grid rendering, and fixed memory leaks in several dialogs - thx ivandrofly, hisui3393
-* WSB is now import only
-
 Translations and engines:
 * New UI languages: Central Kurdish and Azerbaijani - and all language files synced with English
 * Updated engines: Crisp ASR v0.8.32, llama.cpp b10840, whisper.cpp v1.9.3, CrispEmbed v0.17.9, Paddle OCR 3.7, Tesseract 5.5.3, ffmpeg 9.0.1 (Windows), libmpv 20260814 (Windows) and yt-dlp 2026.08.19

--- a/change-log.txt
+++ b/change-log.txt
@@ -93,22 +93,6 @@ Translations and engines:
 * New UI languages: Central Kurdish and Azerbaijani - and all language files synced with English
 * Updated engines: Crisp ASR v0.8.32, llama.cpp b10840, whisper.cpp v1.9.3, CrispEmbed v0.17.9, Paddle OCR 3.7, Tesseract 5.5.3, ffmpeg 9.0.1 (Windows), libmpv 20260814 (Windows) and yt-dlp 2026.08.19
 
-Changes since v5.2.0-rc7:
-* Add litagin/anime-whisper as a Japanese speech-to-text model - thx Mafuyu0
-* Waveform: sync the video frame preview and auto play/pause while Ctrl+Shift dragging a subtitle - thx ghostminhtoan
-* Show the logo alpha and size values in the burn-in logo window - thx rosilucia-hub
-* Find/replace: underline the button access keys, and fire Alt+F/Alt+R on the bare letter - thx DexKen
-* Make the text to speech voice settings window resizable and remember its position/size
-* Paddle OCR: read results from json, batch every seconv image, and keep batch convert cues in order
-* Fix a corrupt waveform cache hanging instead of being rebuilt - thx shamefulCake1
-* Fix an Alt shortcut activating the menu bar - thx kadrimarzouki
-* Fix applying settings jumping the video position - thx kadrimarzouki
-* Fix Subtitle Edit floating on top of other applications after closing a dialog - thx cvrle77
-* Rename the shortcut label to "Open Subtitle Edit data folder"
-* Sync all language files with English.json
-* Update French translation - thx Need74
-* Update Korean translation - thx 12si27
-
 A big thank you to everyone who tested the pre-releases, reported issues and
 contributed code and translations - and a special thanks to Anthropic for
 sponsoring a Claude subscription used in the development of this release :)

--- a/change-log.txt
+++ b/change-log.txt
@@ -3,6 +3,118 @@ Subtitle Edit Changelog
 
 -----------------------------------------------------------------------------------------------------
 
+v5.2.0 (10th of September 2026)
+
+Subtitle Edit 5.2 collects the work of 32 betas and 7 release candidates.
+A summary of the changes since v5.1.0 (full details in the pre-release entries below):
+
+New features:
+* Assisted split and Assisted move - ranked one-click suggestions with full previews
+* Chapter editor with Matroska/MP4/OGM chapter formats (Video > More > Chapters)
+* Edit original - edit the original reference rows in place, open a non-matching original as a read-only reference, and show the original subtitle on the waveform
+* Forced narrative lines - a "Forced" column and "Save forced lines as..."
+* Error list with summary cards (Tools > List errors..., batch convert) - export to clipboard, text, Excel or web page
+* Statistics dashboard with tiles, meters, checks and a CPS histogram
+* Subtitle grid: "Columns..." dialog to reorder/hide columns, "Hide tags" formatting mode, and type-to-search in all combo boxes
+* Text boxes: drag-and-drop text (e.g. original to working text), configurable "Search via" shortcuts, "Google it", macOS "Look up", "Sentence case" and more "Surround with" slots
+* Waveform: guess start/end time from the waveform, snap to shot changes, editable video position box, per-track audio picker, and copy/paste at the video/waveform position
+* Beautify time codes using the video's real frame times, and in batch convert
+* Video offset remembers recent offsets; "Open recent video" and "Go to video position..." in the Video menu
+* Multiple replace: import/export rule categories, select all/none/invert, move shortcuts and regex match timeouts
+* Image-based subtitle editor: open DVD sup, XSUB, MP4 VobSub and more, "Video resolution..." scaling, and burn in Blu-ray sup
+* Update check settings with a stable/beta channel and a startup notification
+* Default save location, auto-break "do not break after" lists with an editor, and cut the subtitle with "Cut video"
+
+SE 4 parity:
+* Train nOCR, the minimum gap frame rate calculator, and "Remove/replace Unicode characters" (SE 4 plugin port)
+* WebVTT style manager, voices and browser preview, and configurable WebVTT cue settings
+* Import an SE 4 Settings.xml, and 22 more SE 4 shortcuts on shortcut import
+* Shortcuts: go to next empty line, go to first/last line, bookmarks, underline, toggle custom tags, recalculate duration, go to next/prev subtitle (play translate), move first word to previous subtitle, break at first space from cursor
+* Layout 10 (edit box under the waveform), "Center text in subtitle grid", the four grid double-click actions, and a toolbar frame rate that works like SE 4's
+* "Set up like Subtitle Edit 4" also arranges the waveform toolbar; "Open second subtitle file..." is back in SE 4's Video menu spot
+* Remove blank lines when opening a subtitle, full frame image export, regex snippet context menu in Find/replace, and Alt+F/Alt+R in Replace
+* Tesseract OCR: SE 4's 10 px margin and resize retry passes
+* Copy-to-clipboard grid menu items and plain text column paste are back
+
+Auto-translate and AI:
+* New "llama.cpp advanced" and "Ollama advanced" engines with batch context, system prompt and schema-forced output - also in batch convert and seconv (--translate-prompt)
+* MiLMMT-46 translation models; DeepL offers every API language; Google Translate retries via a fallback endpoint when the free service is blocked
+* Re-break translated rows that break the line profile, keep the chosen languages when the engine changes, and the original text is no longer lost after translating
+* AI review: in the grid context menu, apply suggestions in passes, Play current, start/stop the llama.cpp server, delay between requests, and new models (Gemma 4 E2B, EuroLLM, Granite 4.1)
+
+Speech to text:
+* New engines and models: WhisperX (standalone, no Python), Google Cloud Speech-to-Text v2, Voxtral (Crisp ASR) and anime-whisper for Japanese
+* Transcription quality report with non-speech and repeated-line removal
+* Crisp ASR: "Auto detect" language on all backends, a VAD off switch and a retry without VAD; live progress for WhisperX
+* The MLX Whisper engine was removed
+
+Text to speech:
+* New engines: IndexTTS 2.5, Higgs Audio v3, Fish Audio S2 Pro and FireRedTTS3 (audio.cpp), dots.tts, Confucius4-TTS and Pocket TTS (Crisp ASR), plus VibeVoice again, CosyVoice3 RL models and multilingual Chatterbox V3 (23 languages)
+* Voice cloning from the video - "Find voices in video and clone them all", and per-line cloning on Qwen3, audio.cpp, VibeVoice, MOSS-TTS, CosyVoice3 and VoxCPM2 - with a consent prompt before the first clone
+* Speaker-name detection, "leave sound/music lines silent", a Zonos language picker and custom Piper voice models
+
+OCR:
+* New engines and models: Apple Vision OCR (macOS), Paddle OCR 3.7 (PP-OCRv6), CrispEmbed PP-OCRv6 and DeepSeek-OCR-2, and llama.cpp HunyuanOCR 1.5, LFM2.5-VL 3B and custom vision models
+* Video OCR (burned-in subtitles): far more subtitles read, better text and start times, CrispEmbed engine, OCR fix engine and spell check coloring
+* OCR fix engine: new Spanish/Portuguese/Italian and Cyrillic rules, around 115 repaired replace list entries, and apostrophe straightening
+* Auto-detect the OCR language, open the matching video after OCR, "Save all images with HTML index", and faster nOCR matching
+
+Subtitle formats:
+* New: EBU-TT (Tech 3350), Manzanita DVB teletext (.dvbttx), Csv Excel, CANVASs SSTG1 (.sdb), Wistia json, DVD Junior SPC, Sonic DVD Producer, YouTube srv3 (.ytt), DaVinci Resolve marker EDL and Adobe Premiere markers
+* New exports: Final Cut Pro Xml Captions, BDN/xml 8-bit and Audacity/Tenacity labels
+* Read subtitles from fragmented MP4 (DASH/CMAF), ARIB STD-B24 captions from transport streams, and SMPTE-TT bitmap captions
+* Much better import of unknown formats (generic XML importer), "Import plain text" from the unknown format prompt, and spreadsheets from File > Open
+* EBU STL/teletext: color picker, alignment dialog, TT column, video preview with box/justification/double height, and frame-based time codes
+* SCC: colors as CEA-608 mid-row codes, a line length warning, and frame-accurate import timing
+* ASSA: embed and trim fonts, offer resampling on a resolution mismatch, new advanced effects, and "Change ASSA style properties" in batch convert
+* Ruby and emphasis in Lambda Cap and Netflix IMSC 1.1 Japanese; font colors in EBU-TT-D and IMSC Rosetta
+
+Video and image export:
+* Image-based export: advanced text effects (gradient, neon glow, 3D extrude), per-line ASSA colors and outlines, inline font face/size, and Blu-ray sup fades and overlapping subtitles
+* Burn-in: VideoToolbox hardware encoders on macOS, .webm/.ts output, letter spacing and libass style previews
+* Sync dialogs: subtitle on the video, resizable waveform, and the selected audio track
+* Smoother waveform/video cursor with mpv, faster scrubbing on long-GOP video, and fixed audio dropouts when pausing or seeking
+
+Batch convert and seconv:
+* Batch convert: Beautify time codes, convert colors to dialog, snap time codes to frames, "Add folder...", translation progress, keep the source file date/time, and every teletext page per PID
+* seconv: --json output and --help-json, --ocr-prompt, --translate-prompt, --override-position, --output-filename-append, full frame image export, .avi/XSUB reading and batched Paddle OCR
+
+Platforms and accessibility:
+* macOS: standard Window menu, open Finder files in a new window, and Apple Vision OCR
+* Linux: dead keys with ibus, Whisper XXL on glibc 2.41+, and OpenBLAS in the Flathub package
+* Keyboard-navigable dialogs (initial focus, Tab, Enter on the default button), screen reader value announcements, and undocked windows no longer stealing the foreground or staying on top
+
+Stability and performance:
+* Around 600 bugs fixed in code sweeps and random-file bug hunts - subtitle formats, dialogs, settings, OCR, batch convert and seconv
+* Faster format detection, Matroska reading on network shares, waveform generation, SCC export and grid rendering, and fixed memory leaks in several dialogs - thx ivandrofly, hisui3393
+* WSB is now import only
+
+Translations and engines:
+* New UI languages: Central Kurdish and Azerbaijani - and all language files synced with English
+* Updated engines: Crisp ASR v0.8.32, llama.cpp b10840, whisper.cpp v1.9.3, CrispEmbed v0.17.9, Paddle OCR 3.7, Tesseract 5.5.3, ffmpeg 9.0.1 (Windows), libmpv 20260814 (Windows) and yt-dlp 2026.08.19
+
+Changes since v5.2.0-rc7:
+* Add litagin/anime-whisper as a Japanese speech-to-text model - thx Mafuyu0
+* Waveform: sync the video frame preview and auto play/pause while Ctrl+Shift dragging a subtitle - thx ghostminhtoan
+* Show the logo alpha and size values in the burn-in logo window - thx rosilucia-hub
+* Find/replace: underline the button access keys, and fire Alt+F/Alt+R on the bare letter - thx DexKen
+* Make the text to speech voice settings window resizable and remember its position/size
+* Paddle OCR: read results from json, batch every seconv image, and keep batch convert cues in order
+* Fix a corrupt waveform cache hanging instead of being rebuilt - thx shamefulCake1
+* Fix an Alt shortcut activating the menu bar - thx kadrimarzouki
+* Fix applying settings jumping the video position - thx kadrimarzouki
+* Fix Subtitle Edit floating on top of other applications after closing a dialog - thx cvrle77
+* Rename the shortcut label to "Open Subtitle Edit data folder"
+* Sync all language files with English.json
+* Update French translation - thx Need74
+* Update Korean translation - thx 12si27
+
+A big thank you to everyone who tested the pre-releases, reported issues and
+contributed code and translations - and a special thanks to Anthropic for
+sponsoring a Claude subscription used in the development of this release :)
+
+-----------------------------------------------------------------------------------------------------
+
 v5.2.0-rc7 (9th of September 2026)
 
 * Add CANVASs SSTG1 (.sdb) subtitle import - thx magsmike

--- a/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
+++ b/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
@@ -74,6 +74,18 @@
   </screenshots>
 
   <releases>
+    <release version="5.2.0" date="2026-09-10">
+      <url>https://github.com/SubtitleEdit/subtitleedit/releases/tag/v5.2.0</url>
+      <description>
+        <p>Assisted split/move, a chapter editor, editable original subtitles, voice cloning from the video, new text to speech, speech to text and OCR engines, many new subtitle formats, SE 4 parity features, and around 600 bug fixes.</p>
+      </description>
+    </release>
+    <release version="5.1.0" date="2026-07-29">
+      <url>https://github.com/SubtitleEdit/subtitleedit/releases/tag/v5.1.0</url>
+      <description>
+        <p>AI review and AI assistant, new auto-translate, speech to text and text to speech engines, EBU-TT-D, multi-window support on macOS, and a large performance and stability pass.</p>
+      </description>
+    </release>
     <release version="5.0.0" date="2026-06-22">
       <url>https://github.com/SubtitleEdit/subtitleedit/releases/tag/v5.0.0</url>
       <description>

--- a/src/libse/LibSE.csproj
+++ b/src/libse/LibSE.csproj
@@ -8,7 +8,7 @@
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<PackageId>libse</PackageId>
 		<!-- Default version for local packs; the publish-nuget workflow overrides this with -p:Version= -->
-		<Version>5.1.0</Version>
+		<Version>5.2.0</Version>
 		<Description>Subtitle Edit's subtitle library - read/write 300+ subtitle formats (SubRip, ASSA, WebVTT, EBU STL, Blu-ray sup, and many more), fix common errors, auto-break lines, convert formats, and more.</Description>
 		<PackageProjectUrl>https://github.com/SubtitleEdit/subtitleedit/tree/main/src/libse</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/SubtitleEdit/subtitleedit</RepositoryUrl>

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -1,6 +1,6 @@
 ﻿{
   "title": "Subtitle Edit",
-  "version": "v5.2.0-rc7",
+  "version": "v5.2.0",
   "translatedBy": "",
   "cultureName": "en-US",
   "general": {

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -20,7 +20,7 @@ public class Se
     internal const int CurrentMacOsFontMigrationVersion = 1;
     internal const int CurrentShortcutsMigrationVersion = 3;
 
-    public static string Version { get; set; } = "v5.2.0-rc7";
+    public static string Version { get; set; } = "v5.2.0";
 
     public SeGeneral General { get; set; } = new();
     public List<SeShortCut> Shortcuts { get; set; } = new();


### PR DESCRIPTION
## Summary
- Bump version `v5.2.0-rc7` → `v5.2.0` in `Se.cs` and `English.json`, and the libse package default in `LibSE.csproj` (5.1.0 → 5.2.0)
- `change-log.txt`: new **v5.2.0** section with a grouped summary of everything since v5.1.0 (32 betas + 7 RCs):
  New features · SE 4 parity · Auto-translate and AI · Speech to text · Text to speech · OCR · Subtitle formats · Video and image export · Batch convert and seconv · Translations and engines
- `Changelog.txt`: the same grouped summary as a 5.2.0 entry (stable releases only)
- Flatpak metainfo: add `<release>` entries for 5.2.0 and the missing 5.1.0. `build-ui.yml`'s `verify-metainfo-release-entry` job blocks a non-prerelease build without the entry. `update-metainfo-version.sh --check` passes locally.

## After merge
```
gh workflow run "Build and release UI" --ref main -f release_tag=v5.2.0 -f is_prerelease=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)