### PR TITLE
perf: count all language word lists in one tokenizing pass

### DIFF
--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -3,71 +3,134 @@ using System;
 #if NET8_0_OR_GREATER
 using System.Buffers;
 #endif
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Nikse.SubtitleEdit.Core.Common
 {
     public static class LanguageAutoDetect
     {
 
-        // One detection run probes ~40+ distinct word-list patterns - far more than fit in the
-        // built-in regex cache (Regex.CacheSize is 15), so with the static Regex.Matches API
-        // every AutoDetectGoogleLanguage call re-parsed every large alternation pattern from
-        // scratch. The word lists are fixed for the app lifetime, so cache compiled instances.
-        private static readonly ConcurrentDictionary<string, Regex> WordCountRegexCache = new ConcurrentDictionary<string, Regex>();
+        // Every word list below is registered in the index, which counts all of them in one
+        // tokenizing pass over the text (see WordListIndex). It used to be one compiled
+        // \b(word|word|...)\b regex per list, i.e. 40+ full scans of the text per detection
+        // plus ~1.7 ms of regex compilation per list on first use.
+        private static readonly Lazy<WordListIndex> WordIndex = new Lazy<WordListIndex>(BuildWordIndex);
 
-        /// <summary>
-        /// The same regex again, keyed on the word-list array itself. Nearly every call site
-        /// passes one of the static AutoDetectWords* fields, so the array reference alone
-        /// identifies the pattern - and looking it up that way skips the string.Join plus
-        /// concat that built a fresh multi-kilobyte cache key on every probe (one detection
-        /// run does ~150 of them). Weak keys, so the handful of call sites that pass inline
-        /// words - which allocate a throwaway params array - cannot grow this without bound;
-        /// those still land on the pattern-keyed cache below and never recompile a regex.
-        /// </summary>
-        private static readonly ConditionalWeakTable<string[], Regex> WordListRegexCache = new ConditionalWeakTable<string[], Regex>();
-
-        private static int GetCount(string text, params string[] words)
+        private static WordListIndex BuildWordIndex()
         {
-            var regex = WordListRegexCache.GetValue(words, BuildWordCountRegex);
-#if NET7_0_OR_GREATER
-            // Count walks the matches without materializing a MatchCollection and a Match per
-            // hit - and a detection run over a whole file produces a lot of hits.
-            return regex.Count(text);
-#else
-            return regex.Matches(text).Count;
-#endif
+            return new WordListIndex(new[]
+            {
+                AutoDetectWordsNorwegianOnly,
+                AutoDetectWordsDanishOnly,
+                AutoDetectWordsFrenchOnly,
+                AutoDetectWordsPortugueseOnly,
+                AutoDetectWordsRomanianOnly,
+                AutoDetectWordsSpanishOnly,
+                AutoDetectWordsEnglishUs,
+                AutoDetectWordsEnglishGb,
+                AutoDetectWordsRussianShort,
+                AutoDetectWordsBulgarianShort,
+                AutoDetectWordsRomanianShort,
+                AutoDetectWordsEnglish,
+                AutoDetectWordsDanish,
+                AutoDetectWordsNorwegian,
+                AutoDetectWordsSwedish,
+                AutoDetectWordsSpanish,
+                AutoDetectWordsItalian,
+                AutoDetectWordsFrench,
+                AutoDetectWordsPortuguese,
+                AutoDetectWordsGerman,
+                AutoDetectWordsDutch,
+                AutoDetectWordsPolish,
+                AutoDetectWordsGreek,
+                AutoDetectWordsRussian,
+                AutoDetectWordsBulgarian,
+                AutoDetectWordsUkrainian,
+                AutoDetectWordsAlbanian,
+                AutoDetectWordsArabic,
+                AutoDetectWordsFarsi,
+                AutoDetectWordsHebrew,
+                AutoDetectWordsVietnamese,
+                AutoDetectWordsHungarian,
+                AutoDetectWordsTurkish,
+                AutoDetectWordsCroatianAndSerbian,
+                AutoDetectWordsCroatian,
+                AutoDetectWordsSerbian,
+                AutoDetectWordsSerbianCyrillic,
+                AutoDetectWordsSerbianCyrillicOnly,
+                AutoDetectWordsIndonesian,
+                AutoDetectWordsCatalan,
+                AutoDetectWordsTagalog,
+                AutoDetectWordsAfrikaans,
+                AutoDetectWordsThai,
+                AutoDetectWordsKorean,
+                AutoDetectWordsMacedonian,
+                AutoDetectWordsFinnish,
+                AutoDetectWordsRomanian,
+                AutoDetectWordsCzechAndSlovak,
+                AutoDetectWordsCzech,
+                AutoDetectWordsSlovak,
+                AutoDetectWordsSlovenian,
+                AutoDetectWordsIcelandic,
+                AutoDetectWordsLatvian,
+                AutoDetectWordsLithuanian,
+                AutoDetectWordsEstonian,
+                AutoDetectWordsHindi,
+                AutoDetectWordsUrdu,
+                AutoDetectWordsSinhalese,
+            });
         }
 
-        private static Regex BuildWordCountRegex(string[] words)
+        /// <summary>
+        /// Occurrence counts of every registered word list in one text.
+        /// </summary>
+        private readonly struct WordListCounts
         {
-            // Case-insensitive so a keyword still matches when it falls at the start of a
-            // sentence (capitalized). This matters most on short/single-line subtitles, where
-            // a large share of words are sentence-initial and case-sensitive matching used to
-            // miss them (e.g. "Você"/"Burada" not matching the lowercase list entries).
-            var pattern = "\\b(" + string.Join("|", words) + ")\\b";
-            return WordCountRegexCache.GetOrAdd(pattern, p =>
-                new Regex(p, RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnoreCase));
+            private readonly WordListIndex _index;
+            private readonly int[] _counts;
+
+            public WordListCounts(WordListIndex index, string text)
+            {
+                _index = index;
+                _counts = index.Count(text);
+            }
+
+            /// <summary>
+            /// How many whole words (case-insensitive) from <paramref name="words"/> the text
+            /// contains. The list must be one of the static AutoDetectWords* fields.
+            /// </summary>
+            public int Get(string[] words)
+            {
+                return _counts[_index.IdOf(words)];
+            }
+        }
+
+        private static WordListCounts CountWords(string text)
+        {
+            return new WordListCounts(WordIndex.Value, text);
+        }
+
+        private static int GetCount(string text, string[] words)
+        {
+            return CountWords(text).Get(words);
         }
 
         private static int GetCountContains(string text, params string[] words)
         {
-            int count = 0;
+            var count = 0;
             foreach (var w in words)
             {
-                var regEx = WordCountRegexCache.GetOrAdd(w, p => new Regex(p, RegexOptions.Compiled));
-#if NET7_0_OR_GREATER
-                count += regEx.Count(text);
-#else
-                count += regEx.Matches(text).Count;
-#endif
+                var index = text.IndexOf(w, StringComparison.Ordinal);
+                while (index >= 0)
+                {
+                    count++;
+                    index = text.IndexOf(w, index + w.Length, StringComparison.Ordinal);
+                }
             }
+
             return count;
         }
 
@@ -116,6 +179,26 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return null;
             }
         }
+
+        // Short disambiguation lists: words that belong to one language but not its close
+        // neighbour, probed only when the neighbour's main list already scored.
+        private static readonly string[] AutoDetectWordsNorwegianOnly = { "ut", "deg", "meg", "merkelig", "mye", "spørre" };
+        private static readonly string[] AutoDetectWordsDanishOnly = { "siger", "dig", "mig", "mærkelig", "tilbage", "spørge" };
+        private static readonly string[] AutoDetectWordsFrenchOnly = { "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque" };
+        private static readonly string[] AutoDetectWordsPortugueseOnly =
+        {
+            "[NnCc]ão", "Então", "h?ouve", "pessoal", "rapariga", "tivesse", "fizeste",
+            "jantar", "conheço", "atenção", "foste", "milhões", "devias", "ganhar", "raios",
+        };
+        private static readonly string[] AutoDetectWordsRomanianOnly = { "[Vv]reau", "[Ss]înt", "[Aa]cum", "pentru", "domnule", "aici" };
+        private static readonly string[] AutoDetectWordsSpanishOnly = { "Hola", "nada", "Vamos", "pasa", "los", "como" };
+        private static readonly string[] AutoDetectWordsEnglishUs = { "color", "flavor", "honor", "humor", "neighbor" };
+        private static readonly string[] AutoDetectWordsEnglishGb = { "colour", "flavour", "honour", "humour", "neighbour" };
+
+        // Short probe lists used when guessing a code page from a raw byte buffer.
+        private static readonly string[] AutoDetectWordsRussianShort = { "что", "быть", "весь", "этот", "один", "такой" };
+        private static readonly string[] AutoDetectWordsBulgarianShort = { "Какво", "тук", "може", "Как", "Ваше" };
+        private static readonly string[] AutoDetectWordsRomanianShort = { "să", "şi", "văzut", "regulă", "găsit", "viaţă" };
 
         private static readonly string[] AutoDetectWordsEnglish =
         {
@@ -514,6 +597,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             // control flow changed from returning on the first hit to picking the strongest.
             var best = string.Empty;
             var bestScore = -1;
+            var counts = CountWords(text);
 
             void Consider(string languageCode, int score)
             {
@@ -524,23 +608,23 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            var count = GetCount(text, AutoDetectWordsEnglish);
+            var count = counts.Get(AutoDetectWordsEnglish);
             if (count > bestCount)
             {
-                var dutchCount = GetCount(text, AutoDetectWordsDutch);
+                var dutchCount = counts.Get(AutoDetectWordsDutch);
                 if (dutchCount < count)
                 {
                     Consider("en", count);
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsDanish);
+            count = counts.Get(AutoDetectWordsDanish);
             if (count > bestCount)
             {
-                var norwegianCount = GetCount(text, "ut", "deg", "meg", "merkelig", "mye", "spørre");
-                var dutchCount = GetCount(text, AutoDetectWordsDutch);
-                var swedishCount = GetCount(text, AutoDetectWordsSwedish);
-                var icelandicCount = GetCount(text, AutoDetectWordsIcelandic);
+                var norwegianCount = counts.Get(AutoDetectWordsNorwegianOnly);
+                var dutchCount = counts.Get(AutoDetectWordsDutch);
+                var swedishCount = counts.Get(AutoDetectWordsSwedish);
+                var icelandicCount = counts.Get(AutoDetectWordsIcelandic);
                 if (norwegianCount < 2 && dutchCount < count && swedishCount < count)
                 {
                     if (icelandicCount > count * 1.5)
@@ -554,60 +638,59 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsNorwegian);
+            count = counts.Get(AutoDetectWordsNorwegian);
             if (count > bestCount)
             {
-                var danishCount = GetCount(text, "siger", "dig", "mig", "mærkelig", "tilbage", "spørge");
-                var dutchCount = GetCount(text, AutoDetectWordsDutch);
-                var swedishCount = GetCount(text, AutoDetectWordsSwedish);
+                var danishCount = counts.Get(AutoDetectWordsDanishOnly);
+                var dutchCount = counts.Get(AutoDetectWordsDutch);
+                var swedishCount = counts.Get(AutoDetectWordsSwedish);
                 if (danishCount < 2 && dutchCount < count && swedishCount < count)
                 {
                     Consider("no", count);
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsSwedish);
+            count = counts.Get(AutoDetectWordsSwedish);
             if (count > bestCount)
             {
                 Consider("sv", count);
             }
 
-            count = GetCount(text, AutoDetectWordsSpanish);
+            count = counts.Get(AutoDetectWordsSpanish);
             if (count > bestCount)
             {
-                var frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
-                var portugueseCount = GetCount(text, "[NnCc]ão", "Então", "h?ouve", "pessoal", "rapariga", "tivesse", "fizeste",
-                                                     "jantar", "conheço", "atenção", "foste", "milhões", "devias", "ganhar", "raios"); // not spanish words
+                var frenchCount = counts.Get(AutoDetectWordsFrenchOnly); // not spanish words
+                var portugueseCount = counts.Get(AutoDetectWordsPortugueseOnly); // not spanish words
                 if (frenchCount < 2 && portugueseCount < 2)
                 {
                     Consider("es", count);
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsItalian);
+            count = counts.Get(AutoDetectWordsItalian);
             if (count > bestCount)
             {
-                var frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not italian words
+                var frenchCount = counts.Get(AutoDetectWordsFrenchOnly); // not italian words
                 if (frenchCount < 2)
                 {
                     Consider("it", count);
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsFrench);
+            count = counts.Get(AutoDetectWordsFrench);
             if (count > bestCount)
             {
-                var romanianCount = GetCount(text, "[Vv]reau", "[Ss]înt", "[Aa]cum", "pentru", "domnule", "aici");
+                var romanianCount = counts.Get(AutoDetectWordsRomanianOnly);
                 if (romanianCount < 5)
                 {
                     Consider("fr", count);
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsPortuguese);
+            count = counts.Get(AutoDetectWordsPortuguese);
             if (count > bestCount)
             {
-                var slovenianCount = GetCount(text, AutoDetectWordsSlovenian);
+                var slovenianCount = counts.Get(AutoDetectWordsSlovenian);
                 if (slovenianCount > count)
                 {
                     Consider("sl", count);
@@ -618,34 +701,34 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsCatalan);
+            count = counts.Get(AutoDetectWordsCatalan);
             if (count > bestCount)
             {
                 Consider("ca", count); // Catalan
             }
 
-            count = GetCount(text, AutoDetectWordsGerman);
+            count = counts.Get(AutoDetectWordsGerman);
             if (count > bestCount)
             {
                 Consider("de", count);
             }
 
-            count = GetCount(text, AutoDetectWordsDutch);
+            count = counts.Get(AutoDetectWordsDutch);
             if (count > bestCount)
             {
                 Consider("nl", count);
             }
 
-            count = GetCount(text, AutoDetectWordsAfrikaans);
+            count = counts.Get(AutoDetectWordsAfrikaans);
             if (count > bestCount)
             {
                 Consider("af", count); // Afrikaans
             }
 
-            count = GetCount(text, AutoDetectWordsPolish);
+            count = counts.Get(AutoDetectWordsPolish);
             if (count > bestCount)
             {
-                var czechWordsCount = GetCount(text, AutoDetectWordsCzech);
+                var czechWordsCount = counts.Get(AutoDetectWordsCzech);
                 if (czechWordsCount > count)
                 {
                     Consider("cs", count);
@@ -656,18 +739,18 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsGreek);
+            count = counts.Get(AutoDetectWordsGreek);
             if (count > bestCount)
             {
                 Consider("el", count); // Greek
             }
 
-            count = GetCount(text, AutoDetectWordsRussian);
+            count = counts.Get(AutoDetectWordsRussian);
             if (count > bestCount)
             {
-                var bulgarianCount = GetCount(text, AutoDetectWordsBulgarian);
-                var ukrainianCount = GetCount(text, AutoDetectWordsUkrainian);
-                var macedonianCount = GetCount(text, AutoDetectWordsMacedonian);
+                var bulgarianCount = counts.Get(AutoDetectWordsBulgarian);
+                var ukrainianCount = counts.Get(AutoDetectWordsUkrainian);
+                var macedonianCount = counts.Get(AutoDetectWordsMacedonian);
                 if (bulgarianCount > count)
                 {
                     if (ukrainianCount > bulgarianCount && ukrainianCount > macedonianCount)
@@ -689,8 +772,8 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
                 else
                 {
-                    var serbianCount = GetCount(text, AutoDetectWordsSerbianCyrillic);
-                    var serbianWordsOnlyCount = GetCount(text, AutoDetectWordsSerbianCyrillicOnly);
+                    var serbianCount = counts.Get(AutoDetectWordsSerbianCyrillic);
+                    var serbianWordsOnlyCount = counts.Get(AutoDetectWordsSerbianCyrillicOnly);
                     if (serbianCount > count)
                     {
                         Consider("sr", count); // Serbian
@@ -706,16 +789,16 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsUkrainian);
+            count = counts.Get(AutoDetectWordsUkrainian);
             if (count > bestCount)
             {
                 Consider("uk", count); // Ukrainian
             }
 
-            count = GetCount(text, AutoDetectWordsBulgarian);
+            count = counts.Get(AutoDetectWordsBulgarian);
             if (count > bestCount)
             {
-                var macedonianCount = GetCount(text, AutoDetectWordsMacedonian);
+                var macedonianCount = counts.Get(AutoDetectWordsMacedonian);
                 if (macedonianCount > count)
                 {
                     Consider("mk", count);
@@ -726,41 +809,41 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsAlbanian);
+            count = counts.Get(AutoDetectWordsAlbanian);
             if (count > bestCount)
             {
                 Consider("sq", count); // Albanian
             }
 
-            count = GetCount(text, AutoDetectWordsArabic);
+            count = counts.Get(AutoDetectWordsArabic);
             if (count > bestCount)
             {
-                var hebrewCount = GetCount(text, AutoDetectWordsHebrew);
-                var farsiCount = GetCount(text, AutoDetectWordsFarsi);
+                var hebrewCount = counts.Get(AutoDetectWordsHebrew);
+                var farsiCount = counts.Get(AutoDetectWordsFarsi);
                 if (hebrewCount < count && farsiCount < count)
                 {
                     Consider("ar", count); // Arabic
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsHebrew);
+            count = counts.Get(AutoDetectWordsHebrew);
             if (count > bestCount)
             {
                 Consider("he", count); // Hebrew
             }
 
-            count = GetCount(text, AutoDetectWordsFarsi);
+            count = counts.Get(AutoDetectWordsFarsi);
             if (count > bestCount)
             {
                 Consider("fa", count); // Farsi (Persian)
             }
 
-            count = GetCount(text, AutoDetectWordsCroatianAndSerbian);
+            count = counts.Get(AutoDetectWordsCroatianAndSerbian);
             if (count > bestCount)
             {
-                var croatianCount = GetCount(text, AutoDetectWordsCroatian);
-                var serbianCount = GetCount(text, AutoDetectWordsSerbian);
-                var slovenianCount = GetCount(text, AutoDetectWordsSlovenian);
+                var croatianCount = counts.Get(AutoDetectWordsCroatian);
+                var serbianCount = counts.Get(AutoDetectWordsSerbian);
+                var slovenianCount = counts.Get(AutoDetectWordsSlovenian);
                 if (croatianCount > serbianCount)
                 {
                     if (slovenianCount > croatianCount)
@@ -782,55 +865,55 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsVietnamese);
+            count = counts.Get(AutoDetectWordsVietnamese);
             if (count > bestCount)
             {
                 Consider("vi", count); // Vietnamese
             }
 
-            count = GetCount(text, AutoDetectWordsHungarian);
+            count = counts.Get(AutoDetectWordsHungarian);
             if (count > bestCount)
             {
                 Consider("hu", count); // Hungarian
             }
 
-            count = GetCount(text, AutoDetectWordsTurkish);
+            count = counts.Get(AutoDetectWordsTurkish);
             if (count > bestCount)
             {
                 Consider("tr", count); // Turkish
             }
 
-            count = GetCount(text, AutoDetectWordsIndonesian);
+            count = counts.Get(AutoDetectWordsIndonesian);
             if (count > bestCount)
             {
                 Consider("id", count); // Indonesian
             }
 
-            count = GetCount(text, AutoDetectWordsTagalog);
+            count = counts.Get(AutoDetectWordsTagalog);
             if (count > bestCount)
             {
                 Consider("tl", count); // Tagalog / Filipino
             }
 
-            count = GetCount(text, AutoDetectWordsThai);
+            count = counts.Get(AutoDetectWordsThai);
             if (count > 10 || count > bestCount)
             {
                 Consider("th", count); // Thai
             }
 
-            count = GetCount(text, AutoDetectWordsKorean);
+            count = counts.Get(AutoDetectWordsKorean);
             if (count > 10 || count > bestCount)
             {
                 Consider("ko", count); // Korean
             }
 
-            count = GetCount(text, AutoDetectWordsFinnish);
+            count = counts.Get(AutoDetectWordsFinnish);
             if (count > bestCount)
             {
                 Consider("fi", count); // Finnish
             }
 
-            count = GetCount(text, AutoDetectWordsRomanian);
+            count = counts.Get(AutoDetectWordsRomanian);
             if (count > bestCount)
             {
                 Consider("ro", count); // Romanian
@@ -854,20 +937,20 @@ namespace Nikse.SubtitleEdit.Core.Common
                 Consider("zh", count); // Chinese (simplified) - not tested...
             }
 
-            count = GetCount(text, AutoDetectWordsCzechAndSlovak);
+            count = counts.Get(AutoDetectWordsCzechAndSlovak);
             if (count > bestCount)
             {
-                var lithuanianCount = GetCount(text, AutoDetectWordsLithuanian);
-                var finnishCount = GetCount(text, AutoDetectWordsFinnish);
-                var estonianCount = GetCount(text, AutoDetectWordsEstonian);
+                var lithuanianCount = counts.Get(AutoDetectWordsLithuanian);
+                var finnishCount = counts.Get(AutoDetectWordsFinnish);
+                var estonianCount = counts.Get(AutoDetectWordsEstonian);
                 if (estonianCount > count && estonianCount > lithuanianCount && estonianCount > finnishCount)
                 {
                     Consider("et", count);
                 }
                 else if (lithuanianCount <= count && finnishCount < count)
                 {
-                    int czechWordsCount = GetCount(text, AutoDetectWordsCzech);
-                    int slovakWordsCount = GetCount(text, AutoDetectWordsSlovak);
+                    int czechWordsCount = counts.Get(AutoDetectWordsCzech);
+                    int slovakWordsCount = counts.Get(AutoDetectWordsSlovak);
                     if (czechWordsCount >= slovakWordsCount)
                     {
                         Consider("cs", count); // Czech
@@ -879,10 +962,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsSlovenian);
+            count = counts.Get(AutoDetectWordsSlovenian);
             if (count > bestCount)
             {
-                var estonianCount = GetCount(text, AutoDetectWordsEstonian);
+                var estonianCount = counts.Get(AutoDetectWordsEstonian);
                 if (estonianCount > count)
                 {
                     Consider("et", count);
@@ -893,49 +976,49 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
             }
 
-            count = GetCount(text, AutoDetectWordsEstonian);
+            count = counts.Get(AutoDetectWordsEstonian);
             if (count > bestCount)
             {
                 Consider("et", count);
             }
 
-            count = GetCount(text, AutoDetectWordsLatvian);
+            count = counts.Get(AutoDetectWordsLatvian);
             if (count > bestCount * 1.2)
             {
                 Consider("lv", count);
             }
 
-            count = GetCount(text, AutoDetectWordsLithuanian);
+            count = counts.Get(AutoDetectWordsLithuanian);
             if (count > bestCount)
             {
                 Consider("lt", count);
             }
 
-            count = GetCount(text, AutoDetectWordsHindi);
+            count = counts.Get(AutoDetectWordsHindi);
             if (count > bestCount)
             {
                 Consider("hi", count);
             }
 
-            count = GetCount(text, AutoDetectWordsUrdu);
+            count = counts.Get(AutoDetectWordsUrdu);
             if (count > bestCount)
             {
                 Consider("ur", count);
             }
 
-            count = GetCount(text, AutoDetectWordsSinhalese);
+            count = counts.Get(AutoDetectWordsSinhalese);
             if (count > bestCount)
             {
                 Consider("si", count);
             }
 
-            count = GetCount(text, AutoDetectWordsMacedonian);
+            count = counts.Get(AutoDetectWordsMacedonian);
             if (count > bestCount)
             {
                 Consider("mk", count);
             }
 
-            count = GetCount(text, AutoDetectWordsIcelandic);
+            count = counts.Get(AutoDetectWordsIcelandic);
             if (count > bestCount)
             {
                 Consider("is", count);
@@ -1229,9 +1312,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                 },
             };
 
+            var counts = CountWords(text);
             foreach (var item in list)
             {
-                item.WordCount = GetCount(text, item.Words);
+                item.WordCount = counts.Get(item.Words);
             }
 
             return list;
@@ -1274,6 +1358,7 @@ namespace Nikse.SubtitleEdit.Core.Common
             var bestCount = subtitle.Paragraphs.Count / 14;
 
             var text = subtitle.GetAllTexts();
+            var counts = CountWords(text);
             var dictionaryNames = Utilities.GetDictionaryLanguages();
 
             var containsEnGb = false;
@@ -1318,11 +1403,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                 switch (shortName.Replace("-", "_").ToLowerInvariant())
                 {
                     case "da_dk":
-                        count = GetCount(text, AutoDetectWordsDanish);
+                        count = counts.Get(AutoDetectWordsDanish);
                         if (count > bestCount)
                         {
-                            int norwegianCount = GetCount(text, "ut", "deg", "meg", "merkelig", "mye", "spørre");
-                            int dutchCount = GetCount(text, AutoDetectWordsDutch);
+                            int norwegianCount = counts.Get(AutoDetectWordsNorwegianOnly);
+                            int dutchCount = counts.Get(AutoDetectWordsDutch);
                             if (norwegianCount < 2 && dutchCount < count)
                             {
                                 languageName = shortName;
@@ -1331,11 +1416,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "nb_no":
-                        count = GetCount(text, AutoDetectWordsNorwegian);
+                        count = counts.Get(AutoDetectWordsNorwegian);
                         if (count > bestCount)
                         {
-                            int danishCount = GetCount(text, "siger", "dig", "mig", "mærkelig", "tilbage", "spørge");
-                            int dutchCount = GetCount(text, AutoDetectWordsDutch);
+                            int danishCount = counts.Get(AutoDetectWordsDanishOnly);
+                            int dutchCount = counts.Get(AutoDetectWordsDutch);
                             if (danishCount < 2 && dutchCount < count)
                             {
                                 languageName = shortName;
@@ -1344,7 +1429,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "sv_se":
-                        count = GetCount(text, AutoDetectWordsSwedish);
+                        count = counts.Get(AutoDetectWordsSwedish);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1352,18 +1437,18 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "en_us":
-                        count = GetCount(text, AutoDetectWordsEnglish);
+                        count = counts.Get(AutoDetectWordsEnglish);
                         if (count > bestCount)
                         {
-                            int dutchCount = GetCount(text, AutoDetectWordsDutch);
+                            int dutchCount = counts.Get(AutoDetectWordsDutch);
                             if (dutchCount < count)
                             {
                                 languageName = shortName;
                                 bestCount = count;
                                 if (containsEnGb)
                                 {
-                                    int usCount = GetCount(text, "color", "flavor", "honor", "humor", "neighbor", "honor");
-                                    int gbCount = GetCount(text, "colour", "flavour", "honour", "humour", "neighbour", "honour");
+                                    int usCount = counts.Get(AutoDetectWordsEnglishUs);
+                                    int gbCount = counts.Get(AutoDetectWordsEnglishGb);
                                     if (gbCount > usCount)
                                     {
                                         languageName = "en_GB";
@@ -1373,18 +1458,18 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "en_gb":
-                        count = GetCount(text, AutoDetectWordsEnglish);
+                        count = counts.Get(AutoDetectWordsEnglish);
                         if (count > bestCount)
                         {
-                            int dutchCount = GetCount(text, AutoDetectWordsDutch);
+                            int dutchCount = counts.Get(AutoDetectWordsDutch);
                             if (dutchCount < count)
                             {
                                 languageName = shortName;
                                 bestCount = count;
                                 if (containsEnUs)
                                 {
-                                    int usCount = GetCount(text, "color", "flavor", "honor", "humor", "neighbor", "honor");
-                                    int gbCount = GetCount(text, "colour", "flavour", "honour", "humour", "neighbour", "honour");
+                                    int usCount = counts.Get(AutoDetectWordsEnglishUs);
+                                    int gbCount = counts.Get(AutoDetectWordsEnglishGb);
                                     if (gbCount < usCount)
                                     {
                                         languageName = "en_US";
@@ -1395,12 +1480,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "es_any":
                     case "es_es":
-                        count = GetCount(text, AutoDetectWordsSpanish);
+                        count = counts.Get(AutoDetectWordsSpanish);
                         if (count > bestCount)
                         {
-                            int frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not spanish words
-                            int portugueseCount = GetCount(text, "[NnCc]ão", "Então", "h?ouve", "pessoal", "rapariga", "tivesse", "fizeste",
-                                "jantar", "conheço", "atenção", "foste", "milhões", "devias", "ganhar", "raios"); // not spanish words
+                            int frenchCount = counts.Get(AutoDetectWordsFrenchOnly); // not spanish words
+                            int portugueseCount = counts.Get(AutoDetectWordsPortugueseOnly); // not spanish words
                             if (frenchCount < 2 && portugueseCount < 2)
                             {
                                 languageName = shortName;
@@ -1409,11 +1493,11 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "it_it":
-                        count = GetCount(text, AutoDetectWordsItalian);
+                        count = counts.Get(AutoDetectWordsItalian);
                         if (count > bestCount)
                         {
-                            int frenchCount = GetCount(text, "[Cc]'est", "pas", "vous", "pour", "suis", "Pourquoi", "maison", "souviens", "quelque"); // not italian words
-                            int spanishCount = GetCount(text, "Hola", "nada", "Vamos", "pasa", "los", "como"); // not italian words
+                            int frenchCount = counts.Get(AutoDetectWordsFrenchOnly); // not italian words
+                            int spanishCount = counts.Get(AutoDetectWordsSpanishOnly); // not italian words
                             if (frenchCount < 2 && spanishCount < 2)
                             {
                                 languageName = shortName;
@@ -1422,12 +1506,12 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "fr_fr":
-                        count = GetCount(text, AutoDetectWordsFrench);
+                        count = counts.Get(AutoDetectWordsFrench);
                         if (count > bestCount)
                         {
-                            int romanianCount = GetCount(text, "[Vv]reau", "[Ss]înt", "[Aa]cum", "pentru", "domnule", "aici");
-                            int spanishCount = GetCount(text, "Hola", "nada", "Vamos", "pasa", "los", "como"); // not french words
-                            int italianCount = GetCount(text, AutoDetectWordsItalian);
+                            int romanianCount = counts.Get(AutoDetectWordsRomanianOnly);
+                            int spanishCount = counts.Get(AutoDetectWordsSpanishOnly); // not french words
+                            int italianCount = counts.Get(AutoDetectWordsItalian);
                             if (romanianCount < 5 && spanishCount < 2 && italianCount < 2)
                             {
                                 languageName = shortName;
@@ -1436,7 +1520,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "de_de":
-                        count = GetCount(text, AutoDetectWordsGerman);
+                        count = counts.Get(AutoDetectWordsGerman);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1444,7 +1528,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "nl_nl":
-                        count = GetCount(text, AutoDetectWordsDutch);
+                        count = counts.Get(AutoDetectWordsDutch);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1452,7 +1536,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "pl_pl":
-                        count = GetCount(text, AutoDetectWordsPolish);
+                        count = counts.Get(AutoDetectWordsPolish);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1460,7 +1544,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "el_gr":
-                        count = GetCount(text, AutoDetectWordsGreek);
+                        count = counts.Get(AutoDetectWordsGreek);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1468,7 +1552,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "ru_ru":
-                        count = GetCount(text, AutoDetectWordsRussian);
+                        count = counts.Get(AutoDetectWordsRussian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1476,7 +1560,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "uk_ua":
-                        count = GetCount(text, AutoDetectWordsUkrainian);
+                        count = counts.Get(AutoDetectWordsUkrainian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1484,7 +1568,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "ro_ro":
-                        count = GetCount(text, AutoDetectWordsRomanian);
+                        count = counts.Get(AutoDetectWordsRomanian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1492,15 +1576,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "hr_hr": // Croatian
-                        count = GetCount(text, AutoDetectWordsCroatianAndSerbian);
+                        count = counts.Get(AutoDetectWordsCroatianAndSerbian);
                         if (count > bestCount)
                         {
                             bestCount = count;
                             languageName = shortName;
                             if (containsSrLatn)
                             {
-                                int croatianCount = GetCount(text, AutoDetectWordsCroatian);
-                                int serbianCount = GetCount(text, AutoDetectWordsSerbian);
+                                int croatianCount = counts.Get(AutoDetectWordsCroatian);
+                                int serbianCount = counts.Get(AutoDetectWordsSerbian);
                                 if (serbianCount > croatianCount)
                                 {
                                     languageName = "sr-Latn";
@@ -1509,15 +1593,15 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "sr_latn": // Serbian (Latin)
-                        count = GetCount(text, AutoDetectWordsCroatianAndSerbian);
+                        count = counts.Get(AutoDetectWordsCroatianAndSerbian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
                             bestCount = count;
                             if (containsHrHr)
                             {
-                                int croatianCount = GetCount(text, AutoDetectWordsCroatian);
-                                int serbianCount = GetCount(text, AutoDetectWordsSerbian);
+                                int croatianCount = counts.Get(AutoDetectWordsCroatian);
+                                int serbianCount = counts.Get(AutoDetectWordsSerbian);
                                 if (serbianCount < croatianCount)
                                 {
                                     languageName = "hr_HR";
@@ -1526,7 +1610,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "sr": // Serbian (Cyrillic)
-                        count = GetCount(text, AutoDetectWordsSerbianCyrillic);
+                        count = counts.Get(AutoDetectWordsSerbianCyrillic);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1535,7 +1619,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "pt_pt": // Portuguese Portugal
                     case "pt_br": // Portuguese Brazil
-                        count = GetCount(text, AutoDetectWordsPortuguese);
+                        count = counts.Get(AutoDetectWordsPortuguese);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1543,7 +1627,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "hu_hu": // Hungarian
-                        count = GetCount(text, AutoDetectWordsHungarian);
+                        count = counts.Get(AutoDetectWordsHungarian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1551,10 +1635,10 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "cs_cz": // Czech
-                        count = GetCount(text, AutoDetectWordsCzech);
+                        count = counts.Get(AutoDetectWordsCzech);
                         if (count > bestCount)
                         {
-                            var lithuanianCount = GetCount(text, AutoDetectWordsLithuanian);
+                            var lithuanianCount = counts.Get(AutoDetectWordsLithuanian);
                             if (count > lithuanianCount)
                             {
                                 languageName = shortName;
@@ -1563,7 +1647,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "sk_sk": // Slovak
-                        count = GetCount(text, AutoDetectWordsSlovak);
+                        count = counts.Get(AutoDetectWordsSlovak);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1571,7 +1655,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "lv_lv": // Latvian
-                        count = GetCount(text, AutoDetectWordsLatvian);
+                        count = counts.Get(AutoDetectWordsLatvian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1580,7 +1664,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "lt_lt": // Lithuanian
                     case "lt":    // Lithuanian (Neutral)
-                        count = GetCount(text, AutoDetectWordsLithuanian);
+                        count = counts.Get(AutoDetectWordsLithuanian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1589,7 +1673,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "hi_in": // Hindi
                     case "hi":
-                        count = GetCount(text, AutoDetectWordsHindi);
+                        count = counts.Get(AutoDetectWordsHindi);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1598,7 +1682,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "ur_ur": // Urdu
                     case "ur":
-                        count = GetCount(text, AutoDetectWordsUrdu);
+                        count = counts.Get(AutoDetectWordsUrdu);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1608,7 +1692,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                     case "si_si": // Sinhalese
                     case "si_lk": // Sinhala (Sri Lanka)
                     case "si":
-                        count = GetCount(text, AutoDetectWordsSinhalese);
+                        count = counts.Get(AutoDetectWordsSinhalese);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1616,7 +1700,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "tr_tr": // Turkish
-                        count = GetCount(text, AutoDetectWordsTurkish);
+                        count = counts.Get(AutoDetectWordsTurkish);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1624,7 +1708,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "he_il": // Hebrew
-                        count = GetCount(text, AutoDetectWordsHebrew);
+                        count = counts.Get(AutoDetectWordsHebrew);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1632,7 +1716,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "vi_vn": // Vietnamese
-                        count = GetCount(text, AutoDetectWordsVietnamese);
+                        count = counts.Get(AutoDetectWordsVietnamese);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1641,7 +1725,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "ar": // Arabic
                     case "ar_ar":
-                        count = GetCount(text, AutoDetectWordsArabic);
+                        count = counts.Get(AutoDetectWordsArabic);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1649,7 +1733,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "sq_al": // Albanian
-                        count = GetCount(text, AutoDetectWordsAlbanian);
+                        count = counts.Get(AutoDetectWordsAlbanian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1657,7 +1741,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "id_id": // Indonesian
-                        count = GetCount(text, AutoDetectWordsIndonesian);
+                        count = counts.Get(AutoDetectWordsIndonesian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1665,7 +1749,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "ko_kr": // Korean
-                        count = GetCount(text, AutoDetectWordsKorean);
+                        count = counts.Get(AutoDetectWordsKorean);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1673,7 +1757,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         }
                         break;
                     case "mk_mk": // Macedonian
-                        count = GetCount(text, AutoDetectWordsMacedonian);
+                        count = counts.Get(AutoDetectWordsMacedonian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1682,7 +1766,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "fa": // Farsi (Persian)
                     case "fa_ir":
-                        count = GetCount(text, AutoDetectWordsFarsi);
+                        count = counts.Get(AutoDetectWordsFarsi);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1691,7 +1775,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "sl": // Slovenian
                     case "sl_si":
-                        count = GetCount(text, AutoDetectWordsSlovenian);
+                        count = counts.Get(AutoDetectWordsSlovenian);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1700,7 +1784,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                         break;
                     case "is_is": // Icelandic
                     case "is":    // Icelandic (Neutral)
-                        count = GetCount(text, AutoDetectWordsIcelandic);
+                        count = counts.Get(AutoDetectWordsIcelandic);
                         if (count > bestCount)
                         {
                             languageName = shortName;
@@ -1724,50 +1808,53 @@ namespace Nikse.SubtitleEdit.Core.Common
 
                 var russianEncoding = Encoding.GetEncoding(1251); // Cyrillic
                 var textEnc1251 = russianEncoding.GetString(buffer);
-                if (GetCount(textEnc1251, "что", "быть", "весь", "этот", "один", "такой") > 5) // Russian
+                var counts1251 = CountWords(textEnc1251);
+                if (counts1251.Get(AutoDetectWordsRussianShort) > 5) // Russian
                 {
                     return russianEncoding;
                 }
 
                 var wordMinCount = buffer.Length / 300;
 
-                if (GetCount(textEnc1251, AutoDetectWordsSerbianCyrillic) > wordMinCount)
+                if (counts1251.Get(AutoDetectWordsSerbianCyrillic) > wordMinCount)
                 {
                     return russianEncoding;
                 }
 
-                if (GetCount(textEnc1251, "Какво", "тук", "може", "Как", "Ваше", "какво") > 5) // Bulgarian
+                if (counts1251.Get(AutoDetectWordsBulgarianShort) > 5) // Bulgarian
                 {
                     return russianEncoding;
                 }
 
 
-                if (GetCount(textEnc1251, AutoDetectWordsSerbianCyrillic) > wordMinCount) // Serbian
+                if (counts1251.Get(AutoDetectWordsSerbianCyrillic) > wordMinCount) // Serbian
                 {
                     return russianEncoding;
                 }
 
                 var encoding1250 = Encoding.GetEncoding(1250); // Central European/Eastern European: Polish, Czech, Slovak, Hungarian, Slovene, Bosnian, Croatian, Serbian (Latin script), Romanian (before 1993 spelling reform) and Albanian
                 var textEnc1250 = encoding1250.GetString(buffer);
-                if (GetCount(textEnc1250, AutoDetectWordsCroatianAndSerbian) > wordMinCount)
+                var counts1250 = CountWords(textEnc1250);
+                if (counts1250.Get(AutoDetectWordsCroatianAndSerbian) > wordMinCount)
                 {
                     return encoding1250;
                 }
 
-                if (GetCount(textEnc1250, AutoDetectWordsCzechAndSlovak) > wordMinCount)
+                if (counts1250.Get(AutoDetectWordsCzechAndSlovak) > wordMinCount)
                 {
                     return encoding1250;
                 }
 
-                if (GetCount(textEnc1250, AutoDetectWordsHungarian) > wordMinCount)
+                if (counts1250.Get(AutoDetectWordsHungarian) > wordMinCount)
                 {
                     return encoding1250;
                 }
 
                 var encoding1252 = Encoding.GetEncoding(1252); // Latin - English and some other Western languages
                 var textEnc1252 = encoding1252.GetString(buffer);
-                var pol1252Count = GetCount(textEnc1252, AutoDetectWordsPolish);
-                var pol1250Count = GetCount(textEnc1250, AutoDetectWordsPolish);
+                var counts1252 = CountWords(textEnc1252);
+                var pol1252Count = counts1252.Get(AutoDetectWordsPolish);
+                var pol1250Count = counts1250.Get(AutoDetectWordsPolish);
                 var encoding28592 = Encoding.GetEncoding(28592);
                 var pol28592Count = GetCount(encoding28592.GetString(buffer), AutoDetectWordsPolish);
                 if (pol1252Count > wordMinCount || pol1250Count > wordMinCount)
@@ -1780,31 +1867,31 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return pol1252Count > pol1250Count ? encoding1252 : encoding1250;
                 }
 
-                var dutchCount1252 = GetCount(textEnc1252, AutoDetectWordsDutch);
+                var dutchCount1252 = counts1252.Get(AutoDetectWordsDutch);
                 if (dutchCount1252 > wordMinCount)
                 {
                     return encoding1252;
                 }
 
-                var danishCount1252 = GetCount(textEnc1252, AutoDetectWordsDanish);
+                var danishCount1252 = counts1252.Get(AutoDetectWordsDanish);
                 if (danishCount1252 > wordMinCount)
                 {
                     return encoding1252;
                 }
 
-                var swedishCount1252 = GetCount(textEnc1252, AutoDetectWordsSwedish);
+                var swedishCount1252 = counts1252.Get(AutoDetectWordsSwedish);
                 if (swedishCount1252 > wordMinCount)
                 {
                     return encoding1252;
                 }
 
-                var germanCount1252 = GetCount(textEnc1252, AutoDetectWordsGerman);
+                var germanCount1252 = counts1252.Get(AutoDetectWordsGerman);
                 if (germanCount1252 > wordMinCount)
                 {
                     return encoding1252;
                 }
 
-                var spanishCount1252 = GetCount(textEnc1252, AutoDetectWordsSpanish);
+                var spanishCount1252 = counts1252.Get(AutoDetectWordsSpanish);
                 if (textEnc1252.IndexOf('¡') >= 0)
                 {
                     spanishCount1252 += 5;
@@ -1823,7 +1910,7 @@ namespace Nikse.SubtitleEdit.Core.Common
                 }
 
                 var russianEncoding28595 = Encoding.GetEncoding(28595); // Russian
-                if (GetCount(russianEncoding28595.GetString(buffer), "что", "быть", "весь", "этот", "один", "такой") > 5) // Russian
+                if (GetCount(russianEncoding28595.GetString(buffer), AutoDetectWordsRussianShort) > 5) // Russian
                 {
                     return russianEncoding28595;
                 }
@@ -1853,20 +1940,20 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return hebrewEncoding;
                 }
 
-                if (GetCount(textEnc1250, "să", "şi", "văzut", "regulă", "găsit", "viaţă") > 99)
+                if (counts1250.Get(AutoDetectWordsRomanianShort) > 99)
                 {
                     return encoding1250;
                 }
 
                 var encoding28591 = Encoding.GetEncoding(28591);
-                var frenchCount1252 = GetCount(textEnc1252, AutoDetectWordsFrench);
+                var frenchCount1252 = counts1252.Get(AutoDetectWordsFrench);
                 if (frenchCount1252 > wordMinCount)
                 {
                     var frenchCount28591 = GetCount(encoding28591.GetString(buffer), AutoDetectWordsFrench);
                     return frenchCount28591 > frenchCount1252 ? encoding28591 : encoding1252;
                 }
 
-                var portugueseCount1252 = GetCount(textEnc1252, AutoDetectWordsPortuguese);
+                var portugueseCount1252 = counts1252.Get(AutoDetectWordsPortuguese);
                 if (portugueseCount1252 > wordMinCount)
                 {
                     var portugueseCount28591 = GetCount(encoding28591.GetString(buffer), AutoDetectWordsPortuguese);

--- a/src/libse/Common/WordListIndex.cs
+++ b/src/libse/Common/WordListIndex.cs
@@ -1,0 +1,677 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.Core.Common
+{
+    /// <summary>
+    /// Counts, in a single pass over a text, how many times the words of each of a fixed set of
+    /// word lists occur in it.
+    ///
+    /// The result is the same as running <c>new Regex("\\b(" + string.Join("|", words) + ")\\b",
+    /// RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)</c> over the text once per list
+    /// and taking the match count - which is what <see cref="LanguageAutoDetect"/> used to do,
+    /// costing one full scan of the text per list (40+ per detection) plus a compiled regex
+    /// per list. Here the text is tokenized once into maximal runs of word characters, every
+    /// token is looked up in one case-insensitive hash table shared by all lists, and the few
+    /// list entries that are not plain words (a phrase with an apostrophe or space, an
+    /// alternation such as <c>quest[ao]</c>, a prefix such as <c>[Pp]řed.*</c>) are expanded or
+    /// handled by a dedicated rule that reproduces what the regex would have matched.
+    ///
+    /// A word character is what .NET's <c>\b</c> treats as one: the Unicode categories
+    /// L*, Mn, Nd and Pc, plus U+200C/U+200D (zero-width non-joiner/joiner).
+    /// </summary>
+    internal sealed class WordListIndex
+    {
+        private const char ZeroWidthNonJoiner = '\u200C';
+        private const char ZeroWidthJoiner = '\u200D';
+
+        private static readonly ulong[] WordCharBits = BuildWordCharBits();
+
+        private readonly Dictionary<string[], int> _listIds = new Dictionary<string[], int>(ArrayReferenceComparer.Instance);
+        private readonly int[] _buckets;
+        private readonly Slot[] _slots;
+        private readonly Candidate[] _candidates;
+        private readonly PrefixEntry[] _prefixes;
+        private readonly LeadingEntry[] _leading;
+        private readonly LineContainsEntry[] _lineContains;
+        private readonly ulong _lengthMask;
+        private readonly bool _requiresLines;
+
+        public int ListCount => _listIds.Count;
+
+        /// <summary>
+        /// Each list entry is a (very small) regex fragment. It is expanded into literal
+        /// alternatives up front; the only syntax accepted is what the word lists actually
+        /// use: <c>[abc]</c> character sets, <c>(a|b)</c> groups, an optional <c>?</c> after a
+        /// character or group, a whole-entry <c>.*[chars].*</c> and a trailing <c>.*</c>.
+        /// Anything else throws so that a new entry with unsupported syntax fails the tests
+        /// instead of silently not matching.
+        /// </summary>
+        public WordListIndex(IReadOnlyList<string[]> lists)
+        {
+            var slotsByKey = new Dictionary<string, List<Candidate>>(StringComparer.OrdinalIgnoreCase);
+            var prefixes = new List<PrefixEntry>();
+            var leading = new List<LeadingEntry>();
+            var lineContains = new List<LineContainsEntry>();
+
+            for (var listId = 0; listId < lists.Count; listId++)
+            {
+                var list = lists[listId];
+                if (_listIds.ContainsKey(list))
+                {
+                    throw new ArgumentException("The same word list was registered twice", nameof(lists));
+                }
+
+                _listIds.Add(list, listId);
+                var lineContainsInList = 0;
+
+                for (var entryIndex = 0; entryIndex < list.Length; entryIndex++)
+                {
+                    var entry = list[entryIndex];
+                    if (entry.StartsWith(".*", StringComparison.Ordinal))
+                    {
+                        // ".*[Řř].*": matches from the first word boundary of a line to its
+                        // end when the line contains one of the characters. The regex tried
+                        // the alternatives in order, so this only reproduces the original
+                        // count when these entries precede every other entry of the list.
+                        if (entryIndex != lineContainsInList)
+                        {
+                            throw new ArgumentException($"Line pattern '{entry}' must be at the start of its word list", nameof(lists));
+                        }
+
+                        lineContainsInList++;
+                        lineContains.Add(new LineContainsEntry(listId, ParseLineContainsChars(entry)));
+                        continue;
+                    }
+
+                    var isPrefix = entry.EndsWith(".*", StringComparison.Ordinal);
+                    var literals = ExpandPattern(isPrefix ? entry.Substring(0, entry.Length - 2) : entry);
+                    foreach (var literal in literals)
+                    {
+                        if (literal.Length == 0)
+                        {
+                            throw new ArgumentException($"Word list entry '{entry}' expands to an empty word", nameof(lists));
+                        }
+
+                        var head = LeadingWordCharCount(literal);
+                        if (isPrefix)
+                        {
+                            if (head != literal.Length)
+                            {
+                                throw new ArgumentException($"Prefix entry '{entry}' must consist of word characters", nameof(lists));
+                            }
+
+                            prefixes.Add(new PrefixEntry(listId, entryIndex, literal));
+                        }
+                        else if (head == 0)
+                        {
+                            leading.Add(new LeadingEntry(listId, literal));
+                        }
+                        else
+                        {
+                            var key = head == literal.Length ? literal : literal.Substring(0, head);
+                            var tail = head == literal.Length ? null : literal.Substring(head);
+                            if (!slotsByKey.TryGetValue(key, out var candidates))
+                            {
+                                candidates = new List<Candidate>();
+                                slotsByKey.Add(key, candidates);
+                            }
+
+                            candidates.Add(new Candidate(listId, entryIndex, tail));
+                        }
+                    }
+                }
+            }
+
+            // A prefix entry competes with the plain entries of the same list that come
+            // after it in the regex alternation; the counting loop always lets a whole-word
+            // match win, so reject lists where that would change the count.
+            foreach (var prefix in prefixes)
+            {
+                foreach (var pair in slotsByKey)
+                {
+                    if (!pair.Key.StartsWith(prefix.Head, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    foreach (var candidate in pair.Value)
+                    {
+                        if (candidate.ListId == prefix.ListId && candidate.EntryIndex > prefix.EntryIndex)
+                        {
+                            throw new ArgumentException($"Prefix entry '{prefix.Head}.*' must come after '{pair.Key}' in its word list", nameof(lists));
+                        }
+                    }
+                }
+            }
+
+            _prefixes = prefixes.ToArray();
+            _leading = leading.ToArray();
+            _lineContains = lineContains.ToArray();
+            _requiresLines = _prefixes.Length > 0 || _lineContains.Length > 0;
+
+            // Hash table: chained buckets, keys compared ordinal-ignore-case, candidates of a
+            // key ordered like the regex alternation would try them (list, then entry index).
+            var slotCount = slotsByKey.Count;
+            var bucketCount = 1;
+            while (bucketCount < slotCount * 2)
+            {
+                bucketCount <<= 1;
+            }
+
+            _buckets = new int[bucketCount];
+            _slots = new Slot[slotCount];
+            var allCandidates = new List<Candidate>();
+            var slotIndex = 0;
+            foreach (var pair in slotsByKey)
+            {
+                pair.Value.Sort((a, b) => a.ListId != b.ListId ? a.ListId.CompareTo(b.ListId) : a.EntryIndex.CompareTo(b.EntryIndex));
+                var hash = HashIgnoreCase(pair.Key.AsSpan());
+                var bucket = hash & (bucketCount - 1);
+                _slots[slotIndex] = new Slot(pair.Key, hash, _buckets[bucket] - 1, allCandidates.Count, pair.Value.Count);
+                _buckets[bucket] = slotIndex + 1;
+                allCandidates.AddRange(pair.Value);
+                if (pair.Key.Length < 64)
+                {
+                    _lengthMask |= 1UL << pair.Key.Length;
+                }
+
+                slotIndex++;
+            }
+
+            _candidates = allCandidates.ToArray();
+        }
+
+        public int IdOf(string[] list)
+        {
+            if (_listIds.TryGetValue(list, out var id))
+            {
+                return id;
+            }
+
+            throw new ArgumentException("Word list is not registered in the index", nameof(list));
+        }
+
+        /// <summary>
+        /// Returns, per registered list (indexed by <see cref="IdOf"/>), how many times a word of
+        /// that list occurs in <paramref name="text"/>.
+        /// </summary>
+        public int[] Count(string text)
+        {
+            var listCount = _listIds.Count;
+            var counts = new int[listCount];
+            // Per list: the regex consumed text up to here (a phrase, a prefix or a whole
+            // line), so tokens starting before it cannot match again for that list.
+            var skipUntil = new int[listCount];
+            // Per list: start of the token it last matched, so a token counts at most once
+            // per list even when several alternatives match it.
+            var countedAt = new int[listCount];
+            for (var i = 0; i < countedAt.Length; i++)
+            {
+                countedAt[i] = -1;
+            }
+
+            var span = text.AsSpan();
+            var length = span.Length;
+            var lineEnd = -1;
+            var position = 0;
+            while (position < length)
+            {
+                if (!IsWordChar(span[position]))
+                {
+                    position++;
+                    continue;
+                }
+
+                var start = position;
+                position++;
+                while (position < length && IsWordChar(span[position]))
+                {
+                    position++;
+                }
+
+                var end = position;
+                if (_requiresLines && start >= lineEnd)
+                {
+                    lineEnd = span.Slice(start).IndexOf('\n');
+                    lineEnd = lineEnd < 0 ? length : start + lineEnd;
+                    for (var i = 0; i < _lineContains.Length; i++)
+                    {
+                        ref readonly var entry = ref _lineContains[i];
+                        if (start >= skipUntil[entry.ListId] && span.Slice(start, lineEnd - start).IndexOfAny(entry.Chars.AsSpan()) >= 0)
+                        {
+                            counts[entry.ListId]++;
+                            skipUntil[entry.ListId] = lineEnd;
+                        }
+                    }
+                }
+
+                var tokenLength = end - start;
+                if (tokenLength < 64 && (_lengthMask & (1UL << tokenLength)) != 0)
+                {
+                    var token = span.Slice(start, tokenLength);
+                    var slot = FindSlot(token);
+                    if (slot >= 0)
+                    {
+                        var first = _slots[slot].FirstCandidate;
+                        var last = first + _slots[slot].CandidateCount;
+                        for (var i = first; i < last; i++)
+                        {
+                            ref readonly var candidate = ref _candidates[i];
+                            var listId = candidate.ListId;
+                            if (start < skipUntil[listId] || countedAt[listId] == start)
+                            {
+                                continue;
+                            }
+
+                            if (candidate.Tail == null)
+                            {
+                                counts[listId]++;
+                                countedAt[listId] = start;
+                            }
+                            else if (ContinuesWith(span, end, candidate.Tail))
+                            {
+                                counts[listId]++;
+                                countedAt[listId] = start;
+                                skipUntil[listId] = end + candidate.Tail.Length;
+                            }
+                        }
+                    }
+                }
+
+                for (var i = 0; i < _prefixes.Length; i++)
+                {
+                    ref readonly var prefix = ref _prefixes[i];
+                    var listId = prefix.ListId;
+                    if (tokenLength >= prefix.Head.Length && start >= skipUntil[listId] && countedAt[listId] != start &&
+                        span.Slice(start, prefix.Head.Length).Equals(prefix.Head.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                    {
+                        counts[listId]++;
+                        countedAt[listId] = start;
+                        skipUntil[listId] = lineEnd;
+                    }
+                }
+
+                for (var i = 0; i < _leading.Length; i++)
+                {
+                    ref readonly var entry = ref _leading[i];
+                    var listId = entry.ListId;
+                    if (end >= skipUntil[listId] && ContinuesWith(span, end, entry.Text))
+                    {
+                        counts[listId]++;
+                        skipUntil[listId] = end + entry.Text.Length;
+                    }
+                }
+            }
+
+            return counts;
+        }
+
+        private int FindSlot(ReadOnlySpan<char> token)
+        {
+            var hash = HashIgnoreCase(token);
+            var slot = _buckets[hash & (_buckets.Length - 1)] - 1;
+            while (slot >= 0)
+            {
+                ref readonly var s = ref _slots[slot];
+                if (s.Hash == hash && EqualsIgnoreCase(token, s.Key))
+                {
+                    return slot;
+                }
+
+                slot = s.Next;
+            }
+
+            return -1;
+        }
+
+        // Keys are hashed and compared through the same per-character invariant upper-casing,
+        // so equal-ignoring-case tokens always land in the same bucket (netstandard2.1 has no
+        // span overload of string.GetHashCode(StringComparison)).
+        private static int HashIgnoreCase(ReadOnlySpan<char> s)
+        {
+            var hash = unchecked((int)2166136261);
+            foreach (var c in s)
+            {
+                hash = unchecked((hash ^ ToUpperInvariantFast(c)) * 16777619);
+            }
+
+            return hash;
+        }
+
+        private static bool EqualsIgnoreCase(ReadOnlySpan<char> a, string b)
+        {
+            if (a.Length != b.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < b.Length; i++)
+            {
+                if (a[i] != b[i] && ToUpperInvariantFast(a[i]) != ToUpperInvariantFast(b[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static char ToUpperInvariantFast(char c)
+        {
+            if (c < 128)
+            {
+                return c >= 'a' && c <= 'z' ? (char)(c - 32) : c;
+            }
+
+            return char.ToUpperInvariant(c);
+        }
+
+        /// <summary>
+        /// True when the text at <paramref name="position"/> continues with <paramref name="rest"/>
+        /// (case-insensitively) and a <c>\b</c> holds after it.
+        /// </summary>
+        private static bool ContinuesWith(ReadOnlySpan<char> text, int position, string rest)
+        {
+            var endOfMatch = position + rest.Length;
+            if (endOfMatch > text.Length || !text.Slice(position, rest.Length).Equals(rest.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var lastIsWord = IsWordChar(text[endOfMatch - 1]);
+            var nextIsWord = endOfMatch < text.Length && IsWordChar(text[endOfMatch]);
+            return lastIsWord != nextIsWord;
+        }
+
+        private static int LeadingWordCharCount(string s)
+        {
+            var count = 0;
+            while (count < s.Length && IsWordChar(s[count]))
+            {
+                count++;
+            }
+
+            return count;
+        }
+
+        private static bool IsWordChar(char c)
+        {
+            return (WordCharBits[c >> 6] & (1UL << (c & 63))) != 0;
+        }
+
+        private static ulong[] BuildWordCharBits()
+        {
+            var bits = new ulong[65536 / 64];
+            for (var i = 0; i < 65536; i++)
+            {
+                var c = (char)i;
+                bool isWord;
+                if (c == ZeroWidthNonJoiner || c == ZeroWidthJoiner)
+                {
+                    isWord = true;
+                }
+                else
+                {
+                    switch (CharUnicodeInfo.GetUnicodeCategory(c))
+                    {
+                        case UnicodeCategory.UppercaseLetter:
+                        case UnicodeCategory.LowercaseLetter:
+                        case UnicodeCategory.TitlecaseLetter:
+                        case UnicodeCategory.ModifierLetter:
+                        case UnicodeCategory.OtherLetter:
+                        case UnicodeCategory.NonSpacingMark:
+                        case UnicodeCategory.DecimalDigitNumber:
+                        case UnicodeCategory.ConnectorPunctuation:
+                            isWord = true;
+                            break;
+                        default:
+                            isWord = false;
+                            break;
+                    }
+                }
+
+                if (isWord)
+                {
+                    bits[i >> 6] |= 1UL << (i & 63);
+                }
+            }
+
+            return bits;
+        }
+
+        private static char[] ParseLineContainsChars(string entry)
+        {
+            // Exactly ".*[...].*"
+            if (entry.Length < 7 || !entry.EndsWith(".*", StringComparison.Ordinal) || entry[2] != '[' || entry[entry.Length - 3] != ']')
+            {
+                throw new ArgumentException($"Unsupported word list pattern '{entry}'");
+            }
+
+            var chars = new HashSet<char>();
+            foreach (var c in entry.Substring(3, entry.Length - 6))
+            {
+                AddCharSetMember(c, chars);
+            }
+
+            var result = new char[chars.Count];
+            chars.CopyTo(result);
+            return result;
+        }
+
+        private static void ValidateCharSetMember(char c)
+        {
+            if (c == '\\' || c == '-' || c == '^' || c == '[' || c == ']')
+            {
+                throw new ArgumentException($"Unsupported character set member '{c}' in word list pattern");
+            }
+        }
+
+        private static void AddCharSetMember(char c, HashSet<char> set)
+        {
+            ValidateCharSetMember(c);
+            set.Add(c);
+            set.Add(char.ToUpperInvariant(c));
+            set.Add(char.ToLowerInvariant(c));
+        }
+
+        private static List<string> ExpandPattern(string pattern)
+        {
+            var position = 0;
+            var result = ParseAlternation(pattern, ref position);
+            if (position != pattern.Length)
+            {
+                throw new ArgumentException($"Unsupported word list pattern '{pattern}'");
+            }
+
+            var distinct = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var literal in result)
+            {
+                if (seen.Add(literal))
+                {
+                    distinct.Add(literal);
+                }
+            }
+
+            return distinct;
+        }
+
+        private static List<string> ParseAlternation(string pattern, ref int position)
+        {
+            var result = ParseSequence(pattern, ref position);
+            while (position < pattern.Length && pattern[position] == '|')
+            {
+                position++;
+                result.AddRange(ParseSequence(pattern, ref position));
+            }
+
+            return result;
+        }
+
+        private static List<string> ParseSequence(string pattern, ref int position)
+        {
+            var result = new List<string> { string.Empty };
+            while (position < pattern.Length && pattern[position] != '|' && pattern[position] != ')')
+            {
+                List<string> atom;
+                var c = pattern[position];
+                if (c == '[')
+                {
+                    position++;
+                    var members = new HashSet<char>();
+                    while (position < pattern.Length && pattern[position] != ']')
+                    {
+                        ValidateCharSetMember(pattern[position]);
+                        members.Add(pattern[position]);
+                        position++;
+                    }
+
+                    if (position >= pattern.Length)
+                    {
+                        throw new ArgumentException($"Unterminated character set in word list pattern '{pattern}'");
+                    }
+
+                    position++;
+                    atom = new List<string>();
+                    foreach (var member in members)
+                    {
+                        atom.Add(member.ToString());
+                    }
+                }
+                else if (c == '(')
+                {
+                    position++;
+                    atom = ParseAlternation(pattern, ref position);
+                    if (position >= pattern.Length || pattern[position] != ')')
+                    {
+                        throw new ArgumentException($"Unterminated group in word list pattern '{pattern}'");
+                    }
+
+                    position++;
+                }
+                else if (c == '.' || c == '*' || c == '+' || c == '?' || c == '\\' || c == '{' || c == '}' || c == '^' || c == '$' || c == ']')
+                {
+                    throw new ArgumentException($"Unsupported word list pattern '{pattern}'");
+                }
+                else
+                {
+                    atom = new List<string> { c.ToString() };
+                    position++;
+                }
+
+                if (position < pattern.Length && pattern[position] == '?')
+                {
+                    atom.Add(string.Empty);
+                    position++;
+                }
+
+                var combined = new List<string>(result.Count * atom.Count);
+                foreach (var prefix in result)
+                {
+                    foreach (var suffix in atom)
+                    {
+                        combined.Add(prefix + suffix);
+                    }
+                }
+
+                result = combined;
+            }
+
+            return result;
+        }
+
+        private readonly struct Slot
+        {
+            public readonly string Key;
+            public readonly int Hash;
+            public readonly int Next;
+            public readonly int FirstCandidate;
+            public readonly int CandidateCount;
+
+            public Slot(string key, int hash, int next, int firstCandidate, int candidateCount)
+            {
+                Key = key;
+                Hash = hash;
+                Next = next;
+                FirstCandidate = firstCandidate;
+                CandidateCount = candidateCount;
+            }
+        }
+
+        /// <summary>A whole-word entry (Tail null) or a phrase: whole word followed by Tail.</summary>
+        private readonly struct Candidate
+        {
+            public readonly int ListId;
+            public readonly int EntryIndex;
+            public readonly string Tail;
+
+            public Candidate(int listId, int entryIndex, string tail)
+            {
+                ListId = listId;
+                EntryIndex = entryIndex;
+                Tail = tail;
+            }
+        }
+
+        /// <summary>"[Pp]řed.*": a token starting with Head consumes the rest of its line.</summary>
+        private readonly struct PrefixEntry
+        {
+            public readonly int ListId;
+            public readonly int EntryIndex;
+            public readonly string Head;
+
+            public PrefixEntry(int listId, int entryIndex, string head)
+            {
+                ListId = listId;
+                EntryIndex = entryIndex;
+                Head = head;
+            }
+        }
+
+        /// <summary>
+        /// An entry starting with a non-word character (" pouvoir"): \b then requires the
+        /// preceding character to be a word character, so it can only match at a token end.
+        /// </summary>
+        private readonly struct LeadingEntry
+        {
+            public readonly int ListId;
+            public readonly string Text;
+
+            public LeadingEntry(int listId, string text)
+            {
+                ListId = listId;
+                Text = text;
+            }
+        }
+
+        /// <summary>".*[Řř].*": one match per line containing any of Chars.</summary>
+        private readonly struct LineContainsEntry
+        {
+            public readonly int ListId;
+            public readonly char[] Chars;
+
+            public LineContainsEntry(int listId, char[] chars)
+            {
+                ListId = listId;
+                Chars = chars;
+            }
+        }
+
+        private sealed class ArrayReferenceComparer : IEqualityComparer<string[]>
+        {
+            public static readonly ArrayReferenceComparer Instance = new ArrayReferenceComparer();
+
+            public bool Equals(string[] x, string[] y)
+            {
+                return ReferenceEquals(x, y);
+            }
+
+            public int GetHashCode(string[] obj)
+            {
+                return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+            }
+        }
+    }
+}

--- a/tests/libse/Core/LanguageAutoDetectWordCountTest.cs
+++ b/tests/libse/Core/LanguageAutoDetectWordCountTest.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using Nikse.SubtitleEdit.Core.Common;
+
+namespace LibSETests.Core;
+
+/// <summary>
+/// The word-list counter behind language auto-detection (WordListIndex) replaced one
+/// \b(word|word|...)\b regex per list with a single tokenizing pass. These pin down the
+/// regex semantics it has to reproduce, through the public GetLanguagesWithCount API.
+/// </summary>
+public class LanguageAutoDetectWordCountTest
+{
+    private static int Count(string languageCode, string text)
+    {
+        return LanguageAutoDetect.GetLanguagesWithCount(text).First(l => l.LanguageCode == languageCode).WordCount;
+    }
+
+    [Fact]
+    public void CountsWholeWordsCaseInsensitively()
+    {
+        // "we", "are", "what", "your" are English entries; "wearing" and "yours" must not count.
+        Assert.Equal(5, Count("en", "We ARE what we wearing? Your yours."));
+    }
+
+    [Fact]
+    public void CountsEveryListInOnePass()
+    {
+        var text = "Jeg kan ikke finde på noget at lave i dag.\r\nWe are here because of your money.";
+        Assert.Equal(5, Count("en", text));
+        Assert.Equal(1, Count("da", text));
+        Assert.Equal(1, Count("no", text));
+        Assert.Equal(0, Count("th", text));
+    }
+
+    [Fact]
+    public void PhraseEntryMatchesAcrossApostropheAndSpace()
+    {
+        // "You're" and "I'll" are English entries; "Das ist" and "Du bist" are German.
+        Assert.Equal(2, Count("en", "You're sure? I'll go."));
+        Assert.Equal(0, Count("en", "Youre sure? Ill go."));
+        Assert.Equal(2, Count("de", "Das ist gut. Du bist müde."));
+        // "bist" alone is also a German entry; neither phrase matches here.
+        Assert.Equal(1, Count("de", "Das  ist gut. Du-bist müde."));
+    }
+
+    [Fact]
+    public void AlternationEntriesExpand()
+    {
+        // Italian "quest[ao]", "tutt[io]"; Spanish "estoy?".
+        Assert.Equal(4, Count("it", "questo questa tutti tutto queste"));
+        Assert.Equal(2, Count("es", "esto estoy estoyo"));
+    }
+
+    [Fact]
+    public void LinePatternCountsOncePerLine()
+    {
+        // Czech ".*[Řř].*" matched the whole line, so the Czech words "jsem", "ještě" and "ne"
+        // on that line did not add; on a line without ř they count normally.
+        Assert.Equal(1, Count("cs", "Řekl jsem, že ještě ne."));
+        Assert.Equal(2, Count("cs", "Řekl jsem\r\nještě ne"));
+        Assert.Equal(2, Count("cs", "Řekl jsem\r\nŘekl jsem"));
+        Assert.Equal(3, Count("cs", "jsem, ne, nic."));
+    }
+
+    [Fact]
+    public void PrefixEntryConsumesRestOfLine()
+    {
+        // Slovak "[Pp]red.*" ("som" is a Slovak entry).
+        Assert.Equal(1, Count("sk", "predtým som"));
+        Assert.Equal(2, Count("sk", "som predtým"));
+        Assert.Equal(3, Count("sk", "som predtým\r\nsom"));
+    }
+
+    [Fact]
+    public void WordBoundaryFollowsDotNetWordCharacters()
+    {
+        // Digits and underscore are word characters for \b, so they glue to the word.
+        Assert.Equal(1, Count("en", "we1 _are your_ we"));
+        // Combining marks (Mn) are word characters too: Arabic with tanwin is one word.
+        Assert.Equal(2, Count("ar", "حسناً حسناً"));
+        // Precomposed accented letters, any casing.
+        Assert.Equal(3, Count("vi", "tôi Tôi TÔI"));
+    }
+
+    [Fact]
+    public void GreekFinalSigmaFoldsToCapitalSigma()
+    {
+        // Known (intended) difference from the regex: an all-caps word ending in Σ now
+        // matches its lowercase entry ending in final sigma ς.
+        Assert.Equal(1, Count("el", "ξερεις"));
+        Assert.Equal(1, Count("el", "ΞΕΡΕΙΣ"));
+    }
+
+    [Fact]
+    public void EveryWordListIsRegistered()
+    {
+        var getCount = typeof(LanguageAutoDetect).GetMethod("GetCount", BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(string), typeof(string[]) }, null);
+        Assert.NotNull(getCount);
+        var lists = typeof(LanguageAutoDetect)
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(f => f.FieldType == typeof(string[]) && f.Name.StartsWith("AutoDetectWords", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(lists.Count > 50);
+        foreach (var field in lists)
+        {
+            var words = (string[])field.GetValue(null)!;
+            // Throws if the list is not registered in the index or contains unsupported syntax.
+            var count = (int)getCount!.Invoke(null, new object[] { string.Join(" ", words), words })!;
+            Assert.True(count > 0, field.Name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Alternative to #14668, which found the regex cache itself is not where the time goes: `LanguageAutoDetect` ran one compiled `\b(word|word|...)\b` regex per word list, so a detection scanned the whole text 40+ times and paid ~1.7 ms of regex compilation per list on first use.

- New `WordListIndex` tokenizes the text **once** (maximal runs of `\b` word characters: L*, Mn, Nd, Pc, ZWJ/ZWNJ) and looks every token up in one case-insensitive hash table shared by all 58 lists. `AutoDetectGoogleLanguage`, `AutoDetectLanguageName`, `GetLanguagesWithCount` and `DetectAnsiEncoding` read all their counts from that single pass.
- The few list entries that are not plain words keep their regex meaning: `[TW]hat's`, `quest[ao]`, `estoy?`, `[Jj](ít|du|de|deme|dou)` are expanded to literals; `You're`, `I'll`, `Das ist`, `Du bist` are phrases; the Czech/Slovak `.*[Řř].*` entries count once per line containing the character (and consume the line, as the regex did); `[Pp]red.*` consumes the rest of its line; ` pouvoir` (leading space) only matches right after a word. Unsupported syntax throws at index build, which the tests exercise.
- `GetCountContains` (ja/zh) is an ordinal `IndexOf` loop instead of a compiled regex per character.
- The inline `params` word lists are hoisted to static fields (as in #14668) so every list is registered; a test checks all `AutoDetectWords*` fields against the index.
- No `System.Text.RegularExpressions` left in the detector.

## Performance

Same corpus files, min of 60 calls in one process (Apple M4, .NET 10, Release), main built in a separate worktree:

| File | lines | `AutoDetectGoogleLanguage(sub, 500)` main → PR | `AutoDetectGoogleLanguageOrNull` main → PR |
|---|---:|---:|---:|
| Kick-Ass (en) | 1320 | 5.0 ms → 0.17 ms | 13.3 ms → 0.96 ms |
| Richard Jewel | 1521 | 5.0 ms → 0.16 ms | 16.2 ms → 1.04 ms |
| auto_detect_Danish | 301 | 3.7 ms → 0.12 ms | 3.7 ms → 0.21 ms |
| auto_detect_Russian | 183 | 1.1 ms → 0.17 ms | 1.1 ms → 0.24 ms |
| auto_detect_windows-1250 (sr) | 1132 | 5.6 ms → 0.14 ms | 11.8 ms → 0.68 ms |
| Erai-raws (en) | 205 | 2.1 ms → 0.09 ms | 2.2 ms → 0.15 ms |

First detection in a fresh process: 217-246 ms → 30-43 ms (no regex JIT). `HotPathRound8Benchmarks.AutoDetectLanguage` (`--inProcess --job short`): 5.157 ms → 126 µs, allocation 100.6 KB → 101.3 KB (the joined text dominates both).

## Behaviour

A harness compared the regex count with the new count for every one of the 58 lists over: the four `tests/libse/Files/auto_detect_*.srt` and six other subtitle files, each decoded as UTF-8 and eleven code pages; a synthetic text with every list entry in four casings; a 900 KB random word soup with apostrophes, hyphens, quotes, digits and mixed line endings; and hand-written edge cases. All counts identical except one: an all-caps Greek word ending in `Σ` now matches its lowercase entry ending in final sigma `ς` (the regex's invariant case table does not fold `ς` to `Σ`). Every file in the corpus detects the same language as on main.

## Test plan

- [x] `LibSE.csproj` builds for `netstandard2.1` and `net10.0`
- [x] `tests/libse`: 2005/2005 (including the new `LanguageAutoDetectWordCountTest`)
- [x] `tests/seconv`: 475 passed, 2 skipped
- [x] `src/ui/UI.csproj` builds
- [x] Differential harness (above): counts identical to the regex
- [ ] Open a few subtitles in different languages and confirm the auto-detected language / encoding guess is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
