### PR TITLE
Source view: Fix selection with extra original rows

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1879,7 +1879,11 @@ public partial class MainViewModel :
     [RelayCommand]
     private async Task ShowSourceView()
     {
-        var oldSelectedIndex = SelectedSubtitleIndex ?? 0;
+        // Source view indexes working cues only, excluding extra original rows.
+        // For an extra original row, select the preceding working cue (or the first if none).
+        var gridIndex = SelectedSubtitleIndex ?? 0;
+        var oldSelectedIndex = Math.Max(0,
+            Subtitles.Take(gridIndex + 1).Count(line => !line.IsReferenceOnly) - 1);
         var result = await ShowDialogAsync<SourceViewWindow, SourceViewViewModel>(vm =>
         {
             var subtitle = GetUpdateSubtitle();


### PR DESCRIPTION
## Problem

Extra original rows in the subtitle grid caused Source View to jump to a later cue.

## Fix

Exclude extra original rows when calculating the source view index. Selecting an extra original row uses the preceding working cue, or the first cue if none precedes it.

## Screenshots

| Before | After |
|-|-|
| <img alt="image" src="https://github.com/user-attachments/assets/1a2a65c8-1050-45bb-a8c1-bbdc26d240ed" /> | <img alt="image" src="https://github.com/user-attachments/assets/1734aa34-baa9-4f77-b5ce-9bbd16275518" /> |
| Selecting cue 193 jumps to cue 222 (29 cues ahead). | Selecting cue 193 correctly jumps to cue 193. |

## Testing

- Manually verified correct Source View navigation in SRT, VTT, and SAMI.
- Tested on Fedora 44 (x64, local build).