### PR TITLE
fix: give VoxCPM2 a sentence ending so the last word is not chopped

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsr.cs
@@ -472,7 +472,10 @@ public class VoxCPM2CrispAsr : ITtsEngine, IPerLineCloneEngine
         var outputFileName = Path.Combine(TtsOutputFolder.Resolve(outputFolder, GetSetFolder), Guid.NewGuid() + ".wav");
 
         var speed = Math.Clamp(Se.Settings.Video.TextToSpeech.VoxCPM2CrispAsrSpeed, 0.25, 4.0);
-        var payload = BuildSpeakPayload(text, speed, isPerLineClone ? Path.GetFileName(voxVoice.FilePath) : null);
+        // The model ends a line abruptly far more often when the text has no sentence ending -
+        // see EnsureSentenceEnding. The returned TtsResult keeps the line as it was.
+        var spokenText = EnsureSentenceEnding(text);
+        var payload = BuildSpeakPayload(spokenText, speed, isPerLineClone ? Path.GetFileName(voxVoice.FilePath) : null);
 
         // Attests the user's own imported reference and the AI-disclosure duty; see
         // CrispAsrTtsProvenance. Skipped when voice cloning has not been accepted in settings.
@@ -592,6 +595,78 @@ public class VoxCPM2CrispAsr : ITtsEngine, IPerLineCloneEngine
             return $"<failed to read error body: {ex.Message}>";
         }
     }
+
+    /// <summary>
+    /// The text VoxCPM2 is asked to speak: the line with a full stop where it has no sentence
+    /// ending of its own, and with a trailing comma, ellipsis or dash replaced by one.
+    /// </summary>
+    /// <remarks>
+    /// "VoxCPM2 often cuts off the last word" (#14480). The model itself decides when to stop,
+    /// and it stops right after the last phoneme: measured over the same 20 Italian sentences
+    /// with the same seeds against the same reference, the final sound fell from -20 dB to -45 dB
+    /// within 30 ms - a chopped ending - in 8 of 20 clips when the line had no terminal
+    /// punctuation, 9 of 20 when it ended in a comma, 8 of 20 with an ellipsis, and 2 of 20 with
+    /// a full stop. No clip lost a word in any of those runs; what is heard as the missing word
+    /// is the final syllable ending without its decay. Subtitle lines that continue in the next
+    /// line have exactly those endings, so the full stop is added here for the synthesis only.
+    /// Question and exclamation marks (and their CJK and Arabic forms) already end a sentence and
+    /// are kept; a closing quote or bracket stays after the added full stop.
+    /// </remarks>
+    internal static string EnsureSentenceEnding(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return text;
+        }
+
+        var core = text.TrimEnd();
+
+        // Keep a closing quote or bracket outside the sentence ending we settle on.
+        var suffixStart = core.Length;
+        while (suffixStart > 0 && IsClosingQuoteOrBracket(core[suffixStart - 1]))
+        {
+            suffixStart--;
+        }
+
+        var suffix = core[suffixStart..];
+        core = core[..suffixStart].TrimEnd();
+        if (core.Length == 0)
+        {
+            return text;
+        }
+
+        // Endings the model reads as "more is coming": comma, colon, semicolon, dashes, an
+        // ellipsis - and the full stop itself, which is put back below in its single form.
+        var end = core.Length;
+        while (end > 0 && IsSoftEnding(core[end - 1]))
+        {
+            end--;
+        }
+
+        core = core[..end].TrimEnd();
+        if (core.Length == 0)
+        {
+            return text;
+        }
+
+        var last = core[^1];
+        if (last is '!' or '?' or '。' or '！' or '？' or '؟')
+        {
+            return core + suffix;
+        }
+
+        return core + (IsCjk(last) ? "。" : ".") + suffix;
+    }
+
+    private static bool IsClosingQuoteOrBracket(char c) =>
+        c is '"' or '\u201D' or '\u00BB' or '\u2019' or '\'' or ')' or ']' or '}' or '」' or '』';
+
+    private static bool IsCjk(char c) =>
+        c is >= '\u3040' and <= '\u30FF' or >= '\u3400' and <= '\u9FFF' or >= '\uAC00' and <= '\uD7AF';
+
+    private static bool IsSoftEnding(char c) =>
+        c is '.' or ',' or ';' or ':' or '\u2026' or '-' or '\u2013' or '\u2014' or '、' or '，' or '：' or '；'
+            || char.IsWhiteSpace(c);
 
     /// <summary>
     /// Builds the <c>/v1/audio/speech</c> JSON payload. Extracted so the voice-field rule is

--- a/tests/UI/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsrTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsrTests.cs
@@ -1,0 +1,76 @@
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+public class VoxCPM2CrispAsrTests
+{
+    // #14480: VoxCPM2 stops right after the last phoneme when the line has no sentence ending,
+    // which is heard as the last word being cut off. Measured with fixed seeds: 8-9 of 20 chopped
+    // endings without terminal punctuation / with a comma / with an ellipsis, 2 of 20 with a full
+    // stop. The full stop is added for the synthesis text only.
+    [Theory]
+    [InlineData("Non mi aspettavo che tornasse", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse,", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse...", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse\u2026", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse -", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse\u2014", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse:", "Non mi aspettavo che tornasse.")]
+    [InlineData("Non mi aspettavo che tornasse  ", "Non mi aspettavo che tornasse.")]
+    [InlineData("彼が戻るとは思わなかった", "彼が戻るとは思わなかった。")]
+    [InlineData("彼が戻るとは思わなかった、", "彼が戻るとは思わなかった。")]
+    public void EnsureSentenceEnding_GivesAFullStopToALineWithoutASentenceEnding(string text, string expected)
+    {
+        Assert.Equal(expected, VoxCPM2CrispAsr.EnsureSentenceEnding(text));
+    }
+
+    [Theory]
+    [InlineData("Perché hai spento le luci?")]
+    [InlineData("Vattene!")]
+    [InlineData("Il treno parte alle sette.")]
+    [InlineData("これは何ですか？")]
+    [InlineData("行こう。")]
+    [InlineData("ماذا تريد؟")]
+    public void EnsureSentenceEnding_KeepsALineThatAlreadyEndsASentence(string text)
+    {
+        Assert.Equal(text, VoxCPM2CrispAsr.EnsureSentenceEnding(text));
+    }
+
+    [Theory]
+    [InlineData("Perché hai spento le luci?...", "Perché hai spento le luci?")]
+    [InlineData("Vattene!,", "Vattene!")]
+    public void EnsureSentenceEnding_DropsASoftEndingAfterARealOne(string text, string expected)
+    {
+        Assert.Equal(expected, VoxCPM2CrispAsr.EnsureSentenceEnding(text));
+    }
+
+    [Theory]
+    [InlineData("\"Non mi aspettavo che tornasse\"", "\"Non mi aspettavo che tornasse.\"")]
+    [InlineData("\"Non mi aspettavo che tornasse,\"", "\"Non mi aspettavo che tornasse.\"")]
+    [InlineData("(non mi aspettavo che tornasse)", "(non mi aspettavo che tornasse.)")]
+    [InlineData("\"Perché?\"", "\"Perché?\"")]
+    [InlineData("\u00ABNon mi aspettavo che tornasse\u00BB", "\u00ABNon mi aspettavo che tornasse.\u00BB")]
+    public void EnsureSentenceEnding_KeepsAClosingQuoteOrBracketAfterTheFullStop(string text, string expected)
+    {
+        Assert.Equal(expected, VoxCPM2CrispAsr.EnsureSentenceEnding(text));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("...")]
+    [InlineData("\"\"")]
+    public void EnsureSentenceEnding_LeavesALineWithNoWordsAlone(string text)
+    {
+        Assert.Equal(text, VoxCPM2CrispAsr.EnsureSentenceEnding(text));
+    }
+
+    [Fact]
+    public void BuildSpeakPayload_ForAPerLineClone_SendsTheStagedFileNameAsVoice()
+    {
+        var payload = VoxCPM2CrispAsr.BuildSpeakPayload("hello.", 1.0, "se-per-line-line-0007.wav");
+
+        Assert.Equal("se-per-line-line-0007.wav", payload["voice"]);
+        Assert.Equal("hello.", payload["input"]);
+    }
+}


### PR DESCRIPTION
Follow-up to #14480: invio-a11y reports that VoxCPM2 "often cuts off the last word" ([comment](https://github.com/SubtitleEdit/subtitleedit/issues/14480#issuecomment-5617649865)).

## What is actually happening

Measured locally (crispasr 0.8.31 and a 0.8.32 build, voxcpm2-q4_k, Metal), ~180 clips in English and Italian, long and short references, abrupt and cleaned reference endings, each transcribed back with Parakeet v3: **no clip ever lost a word**. What is heard as the missing word is the final syllable ending without its decay: the model itself decides when to stop and stops right after the last phoneme, so the last sound falls from -20 dB to -45 dB (relative to the clip peak) within 30 ms.

How the line ends decides how often that happens. Same 20 Italian sentences, same per-request seeds, same reference:

| line ending | chopped endings (decay <= 30 ms) |
|---|---|
| full stop | 2 / 20 |
| no punctuation | 8 / 20 |
| trailing comma | 9 / 20 |
| ellipsis | 8 / 20 |

Subtitle lines that continue in the next line end exactly like the bad rows.

## Fix

`VoxCPM2CrispAsr.EnsureSentenceEnding`: for the synthesis text only, a trailing comma, colon, semicolon, dash, ellipsis or full-stop run is replaced by a single full stop (`。` after CJK), a line with no sentence ending gets one, `! ? 。！？؟` are kept, and a closing quote or bracket stays after the added stop. The `TtsResult` keeps the line unchanged.

## What did not help (so nobody retries it)

- Conditioning on a trimmed + faded + silence-padded reference (the Higgs `CloneReferenceTail` treatment): 3/20 vs 4/20, noise.
- An ellipsis instead of the full stop (upstream maintainers' suggestion in OpenBMB/VoxCPM#213): as bad as no punctuation.
- Letting the CrispASR AR loop run one extra patch after the stop predictor fires (patched 0.8.32 build): 6/20 vs 8/20, and the extra patch is ~150 ms of silence, not decay.
- The CrispASR port's stop logic matches upstream `_inference` (patch appended, then stop check, `min_len` 2, `p_stop > 0.5`), so there is no port bug to fix.

## Tests

`tests/UI/Features/Video/TextToSpeech/Engines/VoxCPM2CrispAsrTests.cs` (28 cases) - all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)