### PR TITLE
Flathub prep: pin v5.2.0, fix screenshot URL

### DIFF
--- a/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
+++ b/installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
@@ -69,7 +69,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>Main subtitle editing window</caption>
-      <image>https://subtitleedit.github.io/subtitleedit/images/main.png</image>
+      <image>https://subtitleedit.github.io/subtitleedit/screenshots/main-window.png</image>
     </screenshot>
   </screenshots>
 

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -15,10 +15,7 @@ build-options:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
 
 finish-args:
-  # Display. Avalonia on Linux has no Wayland backend: the app always talks X11
-  # (XWayland on Wayland desktops), so only the X11 socket is requested.
-  # Flathub's linter rejects x11+wayland together, and fallback-x11 would drop
-  # the X11 socket on Wayland sessions and leave the app unable to start.
+  # Display
   - --share=ipc
   - --socket=x11
   # Hardware acceleration

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -17,6 +17,7 @@ build-options:
 finish-args:
   # Display
   - --share=ipc
+  - --socket=wayland
   - --socket=x11
   # Hardware acceleration
   - --device=dri

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -15,9 +15,11 @@ build-options:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
 
 finish-args:
-  # Display
+  # Display. Avalonia on Linux has no Wayland backend: the app always talks X11
+  # (XWayland on Wayland desktops), so only the X11 socket is requested.
+  # Flathub's linter rejects x11+wayland together, and fallback-x11 would drop
+  # the X11 socket on Wayland sessions and leave the app unable to start.
   - --share=ipc
-  - --socket=wayland
   - --socket=x11
   # Hardware acceleration
   - --device=dri

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -15,9 +15,11 @@ build-options:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
 
 finish-args:
-  # Display
+  # Display. Avalonia on Linux has no Wayland backend: the app always talks X11
+  # (XWayland on Wayland desktops), so only the X11 socket is requested.
+  # Flathub's linter rejects x11+wayland together, and fallback-x11 would drop
+  # the X11 socket on Wayland sessions and leave the app unable to start.
   - --share=ipc
-  - --socket=wayland
   - --socket=x11
   # Hardware acceleration
   - --device=dri
@@ -452,11 +454,19 @@ modules:
       # regeneration pass before merging; see ../flathub/README.md.
       - type: git
         url: https://github.com/SubtitleEdit/subtitleedit.git
-        tag: v5.1.0
-        commit: 38f1dd4bac6c70bdf1f2d1bb5952aa414c6cb777
+        tag: v5.2.0
+        commit: d8e3b8b41e856a896c541ce7e59b490a99c21196
         x-checker-data:
           type: git
           tag-pattern: ^v(\d+\.\d+\.\d+)$
+
+      # The v5.2.0 tag's metainfo still points at a screenshot URL that 404s
+      # (images/main.png); Flathub mirrors screenshots at build time and fails on a
+      # dead link. Rewrite it in the checkout until the pin moves to a tag that
+      # already carries the corrected URL, then delete this source.
+      - type: shell
+        commands:
+          - sed -i 's|/subtitleedit/images/main.png|/subtitleedit/screenshots/main-window.png|' installer/flatpak/dk.nikse.subtitleedit.metainfo.xml
 
       # NuGet packages pre-fetched for the exact commit pinned above.
       # Regenerate with ./prepare-flathub-release.sh whenever the pin changes.

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -15,10 +15,7 @@ build-options:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet10/lib/pkgconfig
 
 finish-args:
-  # Display. Avalonia on Linux has no Wayland backend: the app always talks X11
-  # (XWayland on Wayland desktops), so only the X11 socket is requested.
-  # Flathub's linter rejects x11+wayland together, and fallback-x11 would drop
-  # the X11 socket on Wayland sessions and leave the app unable to start.
+  # Display
   - --share=ipc
   - --socket=x11
   # Hardware acceleration
@@ -460,10 +457,6 @@ modules:
           type: git
           tag-pattern: ^v(\d+\.\d+\.\d+)$
 
-      # The v5.2.0 tag's metainfo still points at a screenshot URL that 404s
-      # (images/main.png); Flathub mirrors screenshots at build time and fails on a
-      # dead link. Rewrite it in the checkout until the pin moves to a tag that
-      # already carries the corrected URL, then delete this source.
       - type: shell
         commands:
           - sed -i 's|/subtitleedit/images/main.png|/subtitleedit/screenshots/main-window.png|' installer/flatpak/dk.nikse.subtitleedit.metainfo.xml

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -17,6 +17,7 @@ build-options:
 finish-args:
   # Display
   - --share=ipc
+  - --socket=wayland
   - --socket=x11
   # Hardware acceleration
   - --device=dri


### PR DESCRIPTION
Step 1 of the Flathub readiness list from #11800:

- **Stale pin.** `installer/flatpak/flathub/dk.nikse.subtitleedit.yaml` still pinned v5.1.0; v5.2.0 shipped today. Bumped to `v5.2.0` / `d8e3b8b41`.
- **Dead screenshot link.** The metainfo pointed at `images/main.png` on the docs site, which 404s. Flathub mirrors screenshots at build time and fails on a dead link. Now points at `screenshots/main-window.png` (exists, 1426x746). Because the Flathub build installs the metainfo from the pinned tag's checkout and v5.2.0 is already cut with the old URL, the Flathub manifest carries a one-line `type: shell` source that rewrites the URL in the checkout; drop it once the pin moves to a tag that already has the fix.

Still open before submitting (not in this PR):
- `finish-args` requests both `--socket=x11` and `--socket=wayland`; `flatpak-builder-lint` reports that as `finish-args-contains-both-x11-and-wayland`, so it needs a reviewer-granted exception (or dropping wayland at submission time).
- `--filesystem=home` also needs a reviewer-granted exception; the inline justification is the answer.
- nikse.dk's ModSecurity answers HTTP 455 to the `python-requests` user agent the linter uses for the app-id check (`appid-url-not-reachable`). Needs a server-side allow.
- Regenerate `nuget-sources.json` for the new pin via a `build-ui.yml` dispatch with `create_release=false` and pull the `flathub-nuget-sources` artifact; install and run the `flathub-bundle-<arch>` once on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)