### PR TITLE
Improve Turkish (Windows-1254) encoding auto-detection

### DIFF
--- a/src/libse/Common/LanguageAutoDetect.cs
+++ b/src/libse/Common/LanguageAutoDetect.cs
@@ -342,9 +342,16 @@ namespace Nikse.SubtitleEdit.Core.Common
         private static readonly string[] AutoDetectWordsTurkish =
         {
             "için", "Tamam", "Hayır", "benim", "daha", "deðil", "önce", "lazým", "çalýþýyor", "Aldırma",
-            "burada", "efendim", "şey", "çok", "Çok", "için", "Merhaba", "Evet", "kötü", "musun",
+            "burada", "efendim", "şey", "çok", "Merhaba", "Evet", "kötü", "musun",
             "güzel", "çünkü", "büyük", "Bebeğim", "olduğunu", "istiyorum", "değilsin", "bilmiyorum",
-            "otursana", "Selam", "Tabii","konuda","istiyor","Tetekkürler", "istemiyorum", "Gerçekte"
+            "otursana", "Selam", "Tabii", "konuda", "istiyor", "Teşekkürler", "istemiyorum", "Gerçekte",
+            "değil", "değildi", "değilim", "değiller", "mı", "mısın", "mıyım", "mıydı", "mıyız",
+            "şu", "şimdi", "şey", "şeyi", "şeyler", "işte", "eğer", "artık", "yardım", "yalnız", "yalnızca",
+            "nasıl", "başka", "doğru", "karşı", "dışarı", "sanırım", "yarın", "kızım", "oğlum", "canım",
+            "tanrım", "hayatım", "aşkım", "yapıyorsun", "yapacağım", "lütfen", "kadın", "adamı", "bakalım",
+            "bırak", "dışında", "hiçbir", "ışık", "kız", "sığ", "şans", "şöyle", "yaşam", "başladı",
+            "olmalı", "bunları", "onları", "kızı", "sana", "seni", "beni", "bana", "hadi", "olur",
+            "gerçekten", "kesinlikle", "biliyorum", "olduğum", "ölmüş", "öldü", "gidiyorum", "kalsın"
         };
 
         private static readonly string[] AutoDetectWordsCroatianAndSerbian =
@@ -1853,6 +1860,17 @@ namespace Nikse.SubtitleEdit.Core.Common
                 var encoding1252 = Encoding.GetEncoding(1252); // Latin - English and some other Western languages
                 var textEnc1252 = encoding1252.GetString(buffer);
                 var counts1252 = CountWords(textEnc1252);
+
+                // Turkish: the dotless ı, ş and ğ (bytes 0xFD, 0xFE, 0xF0 in 1254) decode as ý, þ, ð in 1252,
+                // so a text whose Turkish word count grows when read as 1254 is Turkish. Checked before the
+                // Western European 1252 languages so their shared short words cannot steal it.
+                var encoding1254 = Encoding.GetEncoding(1254);
+                var turkishText = encoding1254.GetString(buffer);
+                var turkish1254Count = GetCount(turkishText, AutoDetectWordsTurkish);
+                if (turkish1254Count > wordMinCount / 2 && turkish1254Count > counts1252.Get(AutoDetectWordsTurkish))
+                {
+                    return encoding1254;
+                }
                 var pol1252Count = counts1252.Get(AutoDetectWordsPolish);
                 var pol1250Count = counts1250.Get(AutoDetectWordsPolish);
                 var encoding28592 = Encoding.GetEncoding(28592);
@@ -1960,9 +1978,6 @@ namespace Nikse.SubtitleEdit.Core.Common
                     return portugueseCount28591 > portugueseCount1252 ? encoding28591 : encoding1252;
                 }
 
-                var encoding1254 = Encoding.GetEncoding(1254);
-                var turkishText = encoding1254.GetString(buffer);
-                var turkish1254Count = GetCount(turkishText, AutoDetectWordsTurkish);
                 if (turkish1254Count > wordMinCount)
                 {
                     return encoding1254;

--- a/tests/libse/Core/LanguageAutoDetectTest.cs
+++ b/tests/libse/Core/LanguageAutoDetectTest.cs
@@ -45,6 +45,14 @@ public class LanguageAutoDetectTest
     }
 
     [Fact]
+    public void AutoDetectCodePage1254()
+    {
+        // Issue #10095: Turkish subtitle saved as Windows-1254 was reopened as 1252.
+        var encoding = DetectAnsiEncoding("auto_detect_windows-1254.srt");
+        Assert.Equal(1254, encoding.CodePage);
+    }
+
+    [Fact]
     public void AutoDetectCodePage1251()
     {
         var encoding = DetectAnsiEncoding("auto_detect_windows-1251.srt");

--- a/tests/libse/Files/auto_detect_windows-1254.srt
+++ b/tests/libse/Files/auto_detect_windows-1254.srt
@@ -1,0 +1,3292 @@
+1
+00:01:48,525 --> 00:01:51,820
+Kardeþinin ruhu artýk benim!
+
+2
+00:01:51,945 --> 00:01:53,030
+Liu!
+
+3
+00:01:54,072 --> 00:01:56,950
+Sýradaki sensin!
+
+4
+00:02:07,002 --> 00:02:08,504
+Chan.
+
+5
+00:02:28,732 --> 00:02:32,444
+"Liu Kang. Kardeþin öldü.
+Eve dön. Büyükbaban."
+
+6
+00:02:41,245 --> 00:02:42,246
+Gidelim!
+
+7
+00:02:43,205 --> 00:02:45,415
+Hedef çembere alýndý mý?
+
+8
+00:02:45,541 --> 00:02:48,085
+- Evet!
+- Öyle olsa iyi olur.
+Kano'yu istiyorum!
+
+9
+00:02:48,210 --> 00:02:52,422
+- Güven bana.
+- Tek bir kiþiye güvenirim.
+Þu anda onunla konuþuyorsun.
+
+10
+00:03:12,025 --> 00:03:13,652
+Aferin sana.
+
+11
+00:03:15,237 --> 00:03:17,114
+Gelmiþ.
+
+12
+00:03:17,990 --> 00:03:20,033
+Tam zamanýnda.
+
+13
+00:03:22,661 --> 00:03:25,330
+Bir kadýnda dakikliðe bayýlýrým...
+
+14
+00:03:26,415 --> 00:03:28,208
+Ya siz...
+
+15
+00:03:28,333 --> 00:03:30,043
+Bay Shang Tsung?
+
+16
+00:03:34,047 --> 00:03:36,425
+Onun peþimden
+geleceðine emin misiniz?
+
+17
+00:03:37,426 --> 00:03:39,428
+Ortaðýný öldürmüþtün
+öyle deðil mi?
+
+18
+00:03:40,929 --> 00:03:42,931
+Seni
+cehenneme kadar izleyebilir.
+
+19
+00:03:43,098 --> 00:03:45,100
+Yalnýzca o
+gemide olacaðýna emin ol.
+
+20
+00:03:45,225 --> 00:03:48,896
+Sonya Blade
+mutlaka o turnuvada olmalý.
+
+21
+00:03:52,733 --> 00:03:55,027
+Belki Sonya ile
+ayný kamarayý paylaþabiliriz.
+
+22
+00:03:55,152 --> 00:03:58,363
+Bu bizim
+küçük balayý gezimiz olur.
+
+23
+00:03:58,488 --> 00:04:01,992
+Eðer ona dokunacak olursan...
+
+24
+00:04:04,119 --> 00:04:06,038
+Rehber köpekle dolaþman gerekir.
+
+25
+00:04:42,950 --> 00:04:44,076
+Kano nerede?
+
+26
+00:04:45,994 --> 00:04:47,871
+Nerede o?
+
+27
+00:05:20,946 --> 00:05:22,030
+Hadi dansa.
+
+28
+00:05:54,938 --> 00:05:56,982
+Burada düþmen gerekiyordu.
+
+29
+00:06:01,069 --> 00:06:04,573
+Bu adamlarý nereden buldunuz?
+
+30
+00:06:04,698 --> 00:06:07,201
+Basýn bir de bu iþi
+bilmediðimi mi söylüyor?
+
+31
+00:06:07,326 --> 00:06:11,288
+- Kes! 15 dakika
+sonra baþtan alacaðýz.
+- Bunu tekrar yapmayacaðým.
+
+32
+00:06:11,413 --> 00:06:12,956
+- Bu da ne demek oluyor þimdi?
+- Yapmayacaðým demek.
+
+33
+00:06:13,081 --> 00:06:15,918
+- Bu filmin son sahnesi.
+Nereye gidiyorsun?
+- Karavanýma gidiyorum.
+
+34
+00:06:16,001 --> 00:06:18,921
+Senin filminde oynadýðým için
+kendimi vuracaðým.
+
+35
+00:06:19,046 --> 00:06:21,757
+Beni öldür. Ben de artýk
+trafik polisi olarak çalýþayým.
+
+36
+00:06:21,882 --> 00:06:24,551
+Beni böyle ortada býrakamazsýn.
+Beni öldüreceksin!
+
+37
+00:06:24,635 --> 00:06:26,470
+Seni seviyorum.
+Sana ihtiyacým var.
+
+38
+00:06:26,595 --> 00:06:28,680
+Affedersin...
+
+39
+00:06:28,847 --> 00:06:31,558
+þu tarafta seninle
+konuþmak isteyen biri var.
+
+40
+00:06:31,683 --> 00:06:34,019
+- Kimmiþ?
+- Gerçekten bilmiyorum.
+
+41
+00:06:34,144 --> 00:06:38,190
+- Sete kimi aldýðýný bilmiyor musun?
+- Hayýr tabii ki deðil, ben...
+
+42
+00:06:38,273 --> 00:06:41,527
+- Bir muhabir çýkmasa iyi olur.
+- Tanrým, hayýr.
+
+43
+00:06:41,652 --> 00:06:43,153
+Sormamý ister misin?
+
+44
+00:06:47,282 --> 00:06:48,951
+Bu harika.
+
+45
+00:06:49,034 --> 00:06:50,911
+Bayým benim
+koltuðumda oturuyorsunuz.
+
+46
+00:06:51,036 --> 00:06:52,913
+"Johnny Cage, Sahtekar!"
+
+47
+00:06:55,415 --> 00:06:57,167
+Merhaba Johnny.
+
+48
+00:06:58,502 --> 00:07:00,170
+Usta Boyd.
+
+49
+00:07:00,337 --> 00:07:04,049
+Basýn sana hala zorluk çýkarýyor.
+
+50
+00:07:04,174 --> 00:07:05,926
+Evet benim
+sahtekar olduðumu sanýyorlar.
+
+51
+00:07:06,051 --> 00:07:09,888
+Sen dünyanýn en iyi
+dövüþ sanatçýlarýndan birisin.
+
+52
+00:07:09,972 --> 00:07:12,850
+Bunu kanýtlamana yardým edebilirim.
+
+53
+00:07:12,975 --> 00:07:13,934
+Kanýtlamak mý? Nasýl?
+
+54
+00:07:14,017 --> 00:07:15,811
+Bir turnuvayla.
+
+55
+00:07:15,936 --> 00:07:17,229
+Bir turnuvayla.
+
+56
+00:07:17,312 --> 00:07:20,482
+Her nesilde
+bir kez yapýlan bir turnuva.
+
+57
+00:07:21,859 --> 00:07:24,027
+Dünyanýn en iyi
+dövüþçüleri davet edildi.
+
+58
+00:07:24,152 --> 00:07:27,739
+Turnuvayý kazanýrsan,
+saygý da kazanýrsýn.
+
+59
+00:07:27,865 --> 00:07:31,618
+Basýn dünyaya senin
+gerçekten dövüþebildiðini duyurur.
+
+60
+00:07:31,743 --> 00:07:34,037
+- Peki nasýl olacak?
+- Bir gemi var.
+
+61
+00:07:34,162 --> 00:07:36,039
+Yarýn 40. rýhtýmdan...
+
+62
+00:07:36,165 --> 00:07:38,000
+Hong Kong'a gidiyor.
+
+63
+00:07:38,125 --> 00:07:40,043
+Ona binmelisin.
+
+64
+00:07:56,101 --> 00:07:58,270
+"Iþýk tapýnaðý - Çin"
+
+65
+00:08:35,933 --> 00:08:37,392
+Liu.
+
+66
+00:08:47,027 --> 00:08:48,946
+Yer burasý mýydý?
+
+67
+00:08:49,071 --> 00:08:50,614
+Evet.
+
+68
+00:08:50,739 --> 00:08:53,367
+Cesedini bulduðumuz yer burasý.
+
+69
+00:08:53,492 --> 00:08:55,118
+Ne oldu?
+
+70
+00:08:55,244 --> 00:08:57,788
+Sen Amerika'ya gittikten sonra...
+
+71
+00:08:57,913 --> 00:08:59,915
+o da senin izinden ilerledi.
+
+72
+00:08:59,998 --> 00:09:01,875
+Turnuva için hazýrlanýyordu.
+
+73
+00:09:02,000 --> 00:09:05,963
+Büyük baba
+kafamý bu saçmalýklarla
+doldurduðun yetmedi mi?
+
+74
+00:09:06,088 --> 00:09:08,757
+Dünyayý
+kurtarmak saçmalýk deðildir.
+
+75
+00:09:08,882 --> 00:09:13,053
+Basit bir
+turnuvada dövüþen bir adam
+bu tür þeylere karar veremez.
+
+76
+00:09:13,220 --> 00:09:14,888
+Senin gibi
+bilge biri buna nasýl inanýr?
+
+77
+00:09:14,972 --> 00:09:16,890
+Buna hepimiz inandýk...
+
+78
+00:09:16,974 --> 00:09:18,976
+Kardeþin de dahil.
+
+79
+00:09:35,075 --> 00:09:37,744
+Liu Kang rüyayý gören kiþi.
+
+80
+00:09:37,870 --> 00:09:39,705
+O seçilmiþ olandýr.
+
+81
+00:09:39,830 --> 00:09:44,543
+Hayýr! O tapýnaðýmýzý terk etti.
+Bizlere sýrt çevirdi.
+
+82
+00:09:44,668 --> 00:09:47,462
+Neden buraya döndün?
+
+83
+00:09:47,629 --> 00:09:50,883
+Turnuvada lþýk Tapýnaðýný ben
+temsil etmek istiyorum.
+
+84
+00:09:51,049 --> 00:09:52,718
+Hangi nedenle?
+
+85
+00:09:52,885 --> 00:09:55,596
+Kardeþimi öldüren
+adam da orada olacak.
+
+86
+00:09:55,721 --> 00:09:58,849
+Gitmek için tek nedenin bu olamaz.
+
+87
+00:09:58,974 --> 00:10:00,976
+Yoksa baþarýsýz olursun.
+
+88
+00:10:01,101 --> 00:10:03,770
+Evet. Unutmuþum.
+
+89
+00:10:03,896 --> 00:10:06,899
+Orada dünyanýn kaderi için
+savaþacaðýz.
+
+90
+00:10:07,024 --> 00:10:09,026
+Bu yüzden tapýnaðý býrakýp...
+
+91
+00:10:09,151 --> 00:10:12,070
+kaçmýþtýn, öyle deðil mi?
+
+92
+00:10:21,205 --> 00:10:25,626
+Büyük turnuva çok fazla
+sorumluluk gerektirir.
+
+93
+00:10:25,751 --> 00:10:27,044
+Ancak intikam...
+
+94
+00:10:29,421 --> 00:10:31,590
+Bu çok daha basittir.
+
+95
+00:10:31,673 --> 00:10:33,550
+Lord Rayden.
+
+96
+00:10:37,095 --> 00:10:39,556
+Hala kaderinden
+kaçmaya çabalýyorsun.
+
+97
+00:10:44,144 --> 00:10:45,771
+Rayden mý?
+
+98
+00:10:46,605 --> 00:10:48,065
+Büyük baba ayaða kalk.
+
+99
+00:10:48,190 --> 00:10:50,901
+O sizin gök gürültüsü
+ve þimþek tanrýnýz deðil.
+
+100
+00:10:51,026 --> 00:10:53,987
+- O yalnýzca bir dilenci.
+- Onu baðýþlayýn efendi Rayden.
+
+101
+00:10:54,112 --> 00:10:57,157
+Amerikan hayatý
+aklýný çok karýþtýrdý.
+
+102
+00:10:57,324 --> 00:10:59,117
+Hep televizyon yüzünden.
+
+103
+00:10:59,243 --> 00:11:01,828
+Yani turnuvayý
+sen kazanacaksýn öyle mi?
+
+104
+00:11:01,954 --> 00:11:04,206
+- Evet doðru.
+- Nasýl yapacaðýný göster.
+
+105
+00:11:07,960 --> 00:11:10,254
+Sakýn bana basit bir dilenciden...
+
+106
+00:11:10,379 --> 00:11:11,964
+korktuðunu söyleme?
+
+107
+00:11:26,061 --> 00:11:27,938
+Eðer sen Rayden'san...
+
+108
+00:11:29,064 --> 00:11:31,191
+Chan'in ölmesine neden izin verdin?
+
+109
+00:11:31,316 --> 00:11:34,820
+- Neden onu korumadýn?
+- Peki ya sen?
+
+110
+00:11:36,321 --> 00:11:38,407
+Yeter artýk kes.
+
+111
+00:11:40,033 --> 00:11:42,911
+O turnuvada kardeþimin
+katilini bulacaðým.
+
+112
+00:11:42,995 --> 00:11:46,290
+Ýzniniz olsun ya da olmasýn.
+
+113
+00:11:55,465 --> 00:11:57,593
+O hazýr deðil efendimiz.
+
+114
+00:11:57,718 --> 00:11:59,678
+Ve biz çok vakit kaybettik.
+
+115
+00:11:59,845 --> 00:12:01,805
+Biliyorum.
+
+116
+00:12:01,972 --> 00:12:03,682
+Fakat bir baþkasý yok.
+
+117
+00:12:19,072 --> 00:12:21,408
+"Chai Wan körfezi, Hong Kong"
+
+118
+00:12:32,961 --> 00:12:34,796
+Biraz rahat verin.
+
+119
+00:12:38,967 --> 00:12:41,220
+"Sahtekar!"
+
+120
+00:12:42,346 --> 00:12:44,056
+Tabii.
+
+121
+00:12:45,390 --> 00:12:47,059
+Sen Art Lean deðil misin?
+
+122
+00:12:47,184 --> 00:12:50,187
+Seni Londra'da dövüþürken
+görmüþtüm, bir harikasýn.
+
+123
+00:12:50,312 --> 00:12:55,025
+Ben de birkaç filmini izledim.
+O hareketlerde numara yapýlamazdý.
+
+124
+00:12:55,150 --> 00:12:57,277
+Öyle ama gel de basýna anlat.
+
+125
+00:13:02,366 --> 00:13:04,660
+Hey dostum gemi geldiðinde...
+
+126
+00:13:04,785 --> 00:13:06,912
+bunlarý yükleyebilir misin?
+
+127
+00:13:07,079 --> 00:13:09,039
+Benden valizlerini
+taþýmamý mý istiyorsun?
+
+128
+00:13:09,206 --> 00:13:12,793
+Evet. Ben para öderim.
+Sen de valiz taþýrsýn.
+
+129
+00:13:12,960 --> 00:13:15,879
+- Yoksa bu çok mu karmaþýk?
+- Hayýr.
+
+130
+00:13:15,963 --> 00:13:17,047
+Anladým.
+
+131
+00:13:17,172 --> 00:13:18,632
+Güzel.
+
+132
+00:13:32,354 --> 00:13:35,524
+Tanrýya þükür arabayý
+park etmesini istememiþim.
+
+133
+00:13:39,736 --> 00:13:42,906
+Kimse kulüpteki serserinin yalan
+söylemediðini ispatlayamaz.
+
+134
+00:13:42,990 --> 00:13:45,409
+Kano þu anda buradan
+1000 km. uzakta olabilir.
+
+135
+00:13:50,455 --> 00:13:51,790
+Bu da ne?
+
+136
+00:14:01,758 --> 00:14:03,844
+Bu bir þaka olmalý.
+
+137
+00:14:21,987 --> 00:14:23,488
+Bekle.
+
+138
+00:14:23,614 --> 00:14:25,490
+Bu Blade...
+
+139
+00:14:26,200 --> 00:14:27,910
+Babana gel.
+
+140
+00:14:37,044 --> 00:14:38,921
+Sonya, sakýn o þeye binme.
+
+141
+00:14:39,004 --> 00:14:40,714
+Hey, Sonya!
+
+142
+00:15:03,237 --> 00:15:04,947
+Hey, sen.
+
+143
+00:15:05,864 --> 00:15:08,200
+Pekâlâ sert çocuk...
+
+144
+00:15:08,325 --> 00:15:09,409
+belaný mý arýyorsun?
+
+145
+00:15:09,535 --> 00:15:10,953
+Hayýr, ya sen?
+
+146
+00:15:11,078 --> 00:15:14,540
+Ben, Johnny Cage.
+Sen kimsin?
+
+147
+00:15:14,665 --> 00:15:16,542
+Kano nerede?
+
+148
+00:15:17,459 --> 00:15:19,545
+Kimden söz ettiðini bilmiyorum.
+
+149
+00:15:20,587 --> 00:15:22,464
+Ama bulmana yardým
+edebileceðimden eminim.
+
+150
+00:15:22,589 --> 00:15:24,466
+Çekil yolumdan.
+
+151
+00:15:26,844 --> 00:15:29,137
+Yine takýntýlý hayranlardan biri?
+
+152
+00:15:52,661 --> 00:15:54,872
+Seninle tanýþmak bir onurdur.
+
+153
+00:15:55,831 --> 00:15:58,250
+Ben Shang Tsung, emrindeyim.
+
+154
+00:15:59,918 --> 00:16:02,963
+Bir katili arýyorum.
+Bu gemiye binerken gördüm.
+
+155
+00:16:03,046 --> 00:16:05,632
+Çok etkilendim.
+
+156
+00:16:05,757 --> 00:16:08,927
+Ama bu benim gemim
+ve eðer tur atmak istiyorsan...
+
+157
+00:16:09,052 --> 00:16:11,763
+bunu kendim yaptýrmak isterim.
+
+158
+00:16:12,723 --> 00:16:14,600
+Hanýma karþý nazik ol.
+
+159
+00:16:14,725 --> 00:16:16,393
+O yalnýzca iþini yapýyor.
+
+160
+00:16:16,518 --> 00:16:19,646
+Bak yardým isteseydim
+telsizimi kullanýrdým.
+
+161
+00:16:26,904 --> 00:16:28,822
+Þu telsiz iþe yarýyor mu?
+
+162
+00:16:33,994 --> 00:16:36,205
+Scorpion ve Sub-Zero.
+
+163
+00:16:37,331 --> 00:16:39,750
+Düþmanlarýn en ölümcülleri...
+
+164
+00:16:39,833 --> 00:16:41,919
+Ancak benim
+gücüm altýnda birer köleler.
+
+165
+00:16:44,379 --> 00:16:45,130
+Çekilin.
+
+166
+00:17:14,660 --> 00:17:17,079
+- Yeter.
+- Lord Rayden.
+
+167
+00:17:17,204 --> 00:17:20,499
+Varlýðýnýzla
+bizi onurlandýrmanýz...
+
+168
+00:17:21,166 --> 00:17:22,376
+ne güzel.
+
+169
+00:17:24,711 --> 00:17:27,297
+Senin ucubelerin benim
+dövüþçülerime saldýrdý.
+
+170
+00:17:27,422 --> 00:17:31,093
+Bu turnuvadan önce
+açýkça yasaklanmýþtýr...
+
+171
+00:17:31,218 --> 00:17:33,178
+Ýmparatorun da bunu biliyor.
+
+172
+00:17:33,345 --> 00:17:35,889
+En içten özürlerimle.
+
+173
+00:17:36,056 --> 00:17:37,891
+Bir daha tekrarlanmayacak,
+size söz veririm.
+
+174
+00:17:38,058 --> 00:17:40,394
+- Bundan þahsen emin olacaðým.
+- Elbette.
+
+175
+00:17:41,854 --> 00:17:43,730
+Adaya varýncaya kadar...
+
+176
+00:17:43,856 --> 00:17:45,649
+Orada hakimiyetiniz sona erer.
+
+177
+00:17:45,774 --> 00:17:48,235
+Ben hakimiyetimin sýnýrlarýný
+iyi bilirim büyücü.
+
+178
+00:17:48,360 --> 00:17:50,904
+- Teþekkür ederim.
+- Ne turnuvasý?
+
+179
+00:17:52,865 --> 00:17:54,950
+Sen de seçildin Sonya.
+
+180
+00:17:56,201 --> 00:17:58,871
+Buna çok sevindiðimi bilmelisin.
+
+181
+00:18:04,918 --> 00:18:06,503
+Sen gerçekten Rayden'sýn.
+
+182
+00:18:07,129 --> 00:18:08,755
+Benimle gelin.
+
+183
+00:18:14,052 --> 00:18:15,304
+Elinden bir þeyler çýkan bir...
+
+184
+00:18:15,304 --> 00:18:17,848
+...adamýmýz var, her þeyi
+dondurabilen bir adamýmýz var...
+
+185
+00:18:17,973 --> 00:18:21,268
+Sonra da bir adam ortaya çýkýyor
+sanki elektrikten yapýlmýþ gibi.
+
+186
+00:18:21,393 --> 00:18:24,855
+Nasýl öyle ortadan kayboluyor?
+Neler oluyor burada?
+Bu adam da kim?
+
+187
+00:18:24,980 --> 00:18:26,982
+Bu konuyu
+dikkatlice düþünelim.
+
+188
+00:18:27,107 --> 00:18:29,026
+Tüm bunlarýn
+mantýklý bir açýklamasý vardýr.
+
+189
+00:18:29,151 --> 00:18:33,864
+O Rayden, Þimþek tanrýsý
+ve dünya aleminin koruyucusu.
+
+190
+00:18:33,989 --> 00:18:36,074
+- Harika.
+- Ýþte sana mantýklý bir açýklama.
+
+191
+00:18:36,200 --> 00:18:37,701
+Dinleyin.
+
+192
+00:18:39,203 --> 00:18:41,121
+Yakýnda karþýlaþmak üzere...
+
+193
+00:18:41,288 --> 00:18:43,165
+olduðunuz þey, sizin...
+
+194
+00:18:43,290 --> 00:18:45,584
+egonuzdan...
+
+195
+00:18:45,709 --> 00:18:47,211
+düþmanýnýzdan...
+
+196
+00:18:47,336 --> 00:18:50,881
+ya da intikam arzunuzdan çok
+daha büyük bir önem taþýyor.
+
+197
+00:18:51,006 --> 00:18:53,467
+Sizler kutsal
+bir göreve baþlamak üzeresiniz.
+
+198
+00:18:53,592 --> 00:18:57,012
+Sizler ölümcül dövüþ denen bu
+turnuvada dünya alemini...
+
+199
+00:18:57,137 --> 00:18:59,973
+savunmak için seçildiniz.
+
+200
+00:19:00,098 --> 00:19:01,808
+Onu kimden koruyacaðýz?
+
+201
+00:19:03,268 --> 00:19:06,647
+Sizin dünyanýz
+birçok alemden biridir.
+
+202
+00:19:06,772 --> 00:19:10,192
+Bir tanesi de Dýþ Dünya adý
+verilen terkedilmiþ topraklardýr...
+
+203
+00:19:10,317 --> 00:19:13,904
+Kendini
+imparator olarak ilan etmiþ
+bir ölümsüz tarafýndan yönetilir.
+
+204
+00:19:14,071 --> 00:19:17,533
+Þimdi fethedip köleleþtireceði
+yeni bir dünya arýyor.
+
+205
+00:19:17,699 --> 00:19:19,535
+Dur bir saniye.
+
+206
+00:19:19,660 --> 00:19:21,870
+Eðer bu adam
+bu kadar güçlüyse...
+
+207
+00:19:21,954 --> 00:19:23,914
+neden hemen iþgale baþlamýyor?
+
+208
+00:19:24,039 --> 00:19:25,958
+Ýmparator'un Dünya
+alemine girebilmesi için...
+
+209
+00:19:26,083 --> 00:19:28,836
+Kötü büyücüsü Shang Tsung'ýn,
+ve savaþçýlarýnýn...
+
+210
+00:19:28,961 --> 00:19:32,881
+ölümcül dövüþte ardý ardýna
+on zafer kazanmasý gerekir.
+
+211
+00:19:34,883 --> 00:19:36,885
+9'unu kazandýlar.
+
+212
+00:19:37,010 --> 00:19:39,972
+Bu turnuvalarýn 10.'su olacak.
+
+213
+00:19:40,097 --> 00:19:40,848
+Yani bu gemide...
+
+214
+00:19:40,848 --> 00:19:44,142
+...bulunan birkaç kiþinin dünyayý
+kurtaracaðýný mý söylüyorsun?
+
+215
+00:19:44,935 --> 00:19:46,603
+Kesinlikle.
+
+216
+00:19:47,813 --> 00:19:50,440
+Ölümcül dövüþün özü...
+
+217
+00:19:53,068 --> 00:19:54,945
+ölümle ilgili deðil...
+
+218
+00:19:55,904 --> 00:19:57,781
+hayatla ilgilidir.
+
+219
+00:19:59,074 --> 00:20:00,951
+Ölümlü erkek ve kadýnlar kendi...
+
+220
+00:20:01,034 --> 00:20:02,911
+dünyalarýný savunuyorlar.
+
+221
+00:20:02,995 --> 00:20:04,872
+Bunu neden bize anlatýyorsun?
+
+222
+00:20:04,997 --> 00:20:06,915
+Ya diðerleri ne olacak?
+
+223
+00:20:06,999 --> 00:20:09,251
+Hepsi de büyük savaþçýlar...
+
+224
+00:20:10,669 --> 00:20:13,338
+Ancak onlarýn ruhlarýna baktým...
+
+225
+00:20:14,673 --> 00:20:16,925
+sizlerinkine de.
+
+226
+00:20:17,050 --> 00:20:19,761
+Ýçinizden biri turnuvanýn
+akýbetine karar verecek.
+
+227
+00:20:22,764 --> 00:20:23,891
+Milyarlarca insanýn...
+
+228
+00:20:24,016 --> 00:20:26,643
+kaderi size baðlý olacak.
+
+229
+00:20:29,646 --> 00:20:31,148
+Affedin.
+
+230
+00:20:32,065 --> 00:20:33,317
+Peki ya Shang Tsung?
+
+231
+00:20:38,030 --> 00:20:41,116
+Demek hala intikam peþindesin?
+
+232
+00:20:41,241 --> 00:20:44,161
+Eðer Shang Tsung'a þimdi
+meydan okursan...
+
+233
+00:20:44,286 --> 00:20:46,663
+hayatýný ve ruhunu kaybedeceksin.
+
+234
+00:20:46,788 --> 00:20:48,916
+Kardeþimin
+ölümünün cezasýný çekecek.
+
+235
+00:20:50,626 --> 00:20:52,503
+Buna hazýr deðilsin.
+
+236
+00:20:55,589 --> 00:20:56,590
+Bakýn.
+
+237
+00:20:58,050 --> 00:20:59,927
+Ýþte baþladý.
+
+238
+00:21:16,944 --> 00:21:18,987
+Ýþte baþladý.
+
+239
+00:21:46,431 --> 00:21:48,141
+Kara Þahinden Kardinal'e.
+
+240
+00:21:48,267 --> 00:21:51,937
+Kara Þahinden Kardinal'e.
+Beni duyan var mý?
+
+241
+00:21:54,606 --> 00:21:57,901
+Jaxx, ben Sonya.
+Beni duyuyor musun?
+
+242
+00:21:58,026 --> 00:22:01,029
+O arada neden benim
+menajerimi de aramýyorsun?
+
+243
+00:22:01,154 --> 00:22:03,407
+Beni sekreterin mi sanmýþtýn?
+
+244
+00:22:31,018 --> 00:22:32,311
+Ne yapýyorsun?
+
+245
+00:22:32,394 --> 00:22:35,606
+Dün geceki o elektrikli patýrtý
+tüm vericileri bozmuþ olmalý.
+
+246
+00:22:35,772 --> 00:22:37,691
+Telsizin aslýnda iyi durumda.
+
+247
+00:22:37,816 --> 00:22:39,693
+Pusulana bir bak.
+
+248
+00:22:46,325 --> 00:22:48,494
+Hangi cehennemdeyiz biz?
+
+249
+00:22:48,619 --> 00:22:51,580
+- Ben seyahat acentesine
+benziyor muyum? - Tamam.
+
+250
+00:22:51,705 --> 00:22:53,457
+Tamam...
+
+251
+00:22:53,582 --> 00:22:55,042
+Pes ediyorum.
+
+252
+00:22:55,876 --> 00:22:57,002
+Neler oluyor?
+
+253
+00:22:57,127 --> 00:22:58,962
+Bilmiyorum.
+
+254
+00:23:00,005 --> 00:23:02,508
+Ya tüm efsaneler sahiden doðruysa?
+
+255
+00:23:06,845 --> 00:23:08,305
+Hangi efsaneler?
+
+256
+00:23:32,746 --> 00:23:34,623
+Sana yardým etmemi ister misin?
+
+257
+00:23:43,632 --> 00:23:45,551
+Merdivenler bitti.
+
+258
+00:23:50,722 --> 00:23:54,017
+Harika. Banyolarý görmek
+için sabýrsýzlanýyorum.
+
+259
+00:24:20,085 --> 00:24:21,211
+Biliyor musun?
+
+260
+00:24:22,129 --> 00:24:24,339
+Bir kadýn sana böyle baktýðýnda...
+
+261
+00:24:24,464 --> 00:24:26,466
+genelde özel bir anlamý vardýr.
+
+262
+00:24:37,060 --> 00:24:39,229
+Prenses Kitana.
+
+263
+00:24:39,313 --> 00:24:42,024
+Bizim en tehlikeli düþmanýmýz.
+
+264
+00:24:44,151 --> 00:24:45,819
+Onu dikkatle izle sürüngen.
+
+265
+00:24:45,986 --> 00:24:49,031
+Onu bu insanlardan uzak tut.
+
+266
+00:26:08,652 --> 00:26:09,945
+Hoþ geldiniz.
+
+267
+00:26:10,028 --> 00:26:12,573
+Sizler ölümcül dövüþte...
+
+268
+00:26:12,698 --> 00:26:14,116
+mücadele etmek için buradasýnýz.
+
+269
+00:26:14,241 --> 00:26:18,120
+Yarýn sabah
+büyük savaþ baþlayacak.
+
+270
+00:26:18,245 --> 00:26:20,873
+Ýçinizden bazýlarý Prens Goro ile...
+
+271
+00:26:20,998 --> 00:26:23,333
+bir araya gelip...
+
+272
+00:26:23,458 --> 00:26:26,920
+karþýlaþma onurunu yaþayacak.
+
+273
+00:26:27,921 --> 00:26:29,423
+Bizim yenilmez þampiyonumuzla.
+
+274
+00:26:29,590 --> 00:26:33,302
+Sizler gezegeninizin tarihindeki
+bir dönüm noktasýnýn...
+
+275
+00:26:33,427 --> 00:26:35,304
+þahitleri olacaksýnýz.
+
+276
+00:26:36,763 --> 00:26:38,640
+Bu anýn tadýný çýkarýn...
+
+277
+00:26:40,434 --> 00:26:42,394
+Son anlarýnýzmýþ gibi.
+
+278
+00:26:43,979 --> 00:26:46,648
+Þimdi size küçük bir gösteri...
+
+279
+00:28:02,975 --> 00:28:05,853
+Kusursuz zafer.
+
+280
+00:28:12,693 --> 00:28:17,447
+"Sadece küçük turnuva" demiþti.
+"Kariyerin için iyi olacak" demiþti.
+
+281
+00:28:17,573 --> 00:28:19,283
+Evet tabii.
+
+282
+00:28:19,408 --> 00:28:20,367
+Liu.
+
+283
+00:28:22,744 --> 00:28:24,830
+- Nereye gidiyorsun?
+- Shang Tsung'ý bulmaya.
+
+284
+00:28:24,913 --> 00:28:28,834
+Onun peþinden gidemezsin.
+Rayden'ýn söylediklerini
+hatýrlamýyor musun?
+
+285
+00:28:28,959 --> 00:28:32,671
+Bana bir þey söylemedi.
+Kano'nun nerede saklandýðýný biliyor.
+
+286
+00:28:33,922 --> 00:28:36,466
+Biliyor musun,
+o hayran olunacak biri.
+
+287
+00:28:36,592 --> 00:28:39,803
+Yani aklýna bir þey koyduðu zaman...
+
+288
+00:28:39,970 --> 00:28:42,014
+Hayran olduðun þey onun aklý deðil.
+
+289
+00:28:44,433 --> 00:28:45,559
+Doðru.
+
+290
+00:29:21,803 --> 00:29:25,766
+Size daha
+kaç kez söylemem gerek?
+Yardýmýnýza ihtiyacým yok.
+
+291
+00:29:25,891 --> 00:29:27,726
+Kendi baþýmýn çaresine bakarým.
+
+292
+00:29:27,851 --> 00:29:30,896
+Buna mani olamýyoruz.
+Erkekler böyledir iþte.
+
+293
+00:29:31,021 --> 00:29:33,857
+- Nereye gidiyorsun?
+- Onun peþinden gidiyorum.
+
+294
+00:29:33,982 --> 00:29:37,069
+- Ben yalnýz çalýþýrým.
+- Hayýr, Shang Tsung benim.
+
+295
+00:29:38,111 --> 00:29:39,822
+Bakýn, biz neden
+Shang'ý unutmuyoruz?
+
+296
+00:29:39,947 --> 00:29:41,657
+Onu unutmak da ne demek oluyor?
+
+297
+00:29:41,782 --> 00:29:45,160
+Ýþin aslýný öðrenmek istiyorum.
+
+298
+00:29:45,285 --> 00:29:47,204
+Siz aklýnýzý mý kaçýrdýnýz?
+
+299
+00:30:03,470 --> 00:30:05,097
+Sonya...
+
+300
+00:30:05,222 --> 00:30:08,433
+Sen önden git. O þeyin
+ne olduðunu öðren.
+
+301
+00:30:08,559 --> 00:30:11,061
+Liu ve ben burada bekleyeceðiz.
+
+302
+00:30:11,186 --> 00:30:12,396
+Ne?
+
+303
+00:30:18,819 --> 00:30:21,947
+Baksana ben
+adil bir dövüþe inanýrým.
+
+304
+00:30:22,072 --> 00:30:24,324
+Bilirsin, teke-tek, erkek erkeðe...
+
+305
+00:30:24,449 --> 00:30:27,870
+yumruk yumruða.
+Týpký babamýn bana öðrettiði gibi.
+
+306
+00:30:27,953 --> 00:30:30,706
+Ama dýþarýda gördüðüm
+þey pek adilane deðildi.
+
+307
+00:30:30,831 --> 00:30:32,875
+Bu Kano.
+
+308
+00:30:32,958 --> 00:30:34,960
+Kano'yu unut gitsin.
+
+309
+00:30:35,085 --> 00:30:36,670
+Öteki adam kim?
+
+310
+00:30:36,753 --> 00:30:39,715
+O adamý dondurmuþtu deðil mi?
+
+311
+00:30:39,840 --> 00:30:43,510
+Sonra adam patladý.
+Bütün iç organlarýný falan gördüm.
+
+312
+00:30:45,470 --> 00:30:46,930
+Neredeyse kusacaktým.
+
+313
+00:30:48,098 --> 00:30:50,058
+Bu iðrenç.
+
+314
+00:30:51,602 --> 00:30:55,147
+Benim bilmek istediðim
+Shang Tsung bu kadar büyükse...
+
+315
+00:30:55,272 --> 00:30:58,233
+gemisi neden o kadar
+berbat durumdaydý?
+
+316
+00:30:59,526 --> 00:31:02,070
+Adam tüylerimi
+diken diken ediyor...
+
+317
+00:31:02,196 --> 00:31:05,908
+"Bu anýn tadýný çýkarýn".
+
+318
+00:31:08,952 --> 00:31:11,955
+Onun niyeti de buydu.
+
+319
+00:31:12,080 --> 00:31:15,375
+Shang Tsung büyük bir büyücüdür.
+
+320
+00:31:15,501 --> 00:31:17,753
+Akýllý adamlar ona yaranýr.
+
+321
+00:31:18,879 --> 00:31:20,756
+Gücüne meydan okuyanlarsa...
+
+322
+00:31:20,881 --> 00:31:22,925
+kölesi haline gelir.
+
+323
+00:31:23,967 --> 00:31:25,594
+Öyle mi?
+
+324
+00:31:25,719 --> 00:31:27,804
+Ben etrafýnda kimseyi görmedim.
+
+325
+00:31:27,971 --> 00:31:29,890
+Seni aptal!
+
+326
+00:31:29,973 --> 00:31:32,601
+Hiçbir þey bilmiyorsun.
+
+327
+00:31:32,768 --> 00:31:35,437
+O ruhlarý köle eder.
+
+328
+00:31:35,562 --> 00:31:39,942
+Kara sanatý
+imparatorun kendisinden öðrenmiþtir.
+
+329
+00:31:40,943 --> 00:31:43,320
+Sen de þu asillerden birisin...
+
+330
+00:31:43,445 --> 00:31:45,906
+- Deðil mi?
+- Ben Goro'yum!
+
+331
+00:31:45,989 --> 00:31:48,909
+Dýþ Dünya ordularýnýn generali...
+
+332
+00:31:48,992 --> 00:31:52,204
+ve yer altý alemi Shokan'ýn prensi.
+
+333
+00:31:52,329 --> 00:31:54,289
+Yer altý mý?
+
+334
+00:31:54,414 --> 00:31:56,917
+Nedir o?
+Topraðýn altýnda bir þey mi?
+
+335
+00:31:57,042 --> 00:31:59,545
+Evet...
+
+336
+00:31:59,670 --> 00:32:00,587
+onun gibi bir þey.
+
+337
+00:32:00,712 --> 00:32:03,549
+Ben de yer altý
+patronlarýndan biriyim.
+
+338
+00:32:04,508 --> 00:32:07,052
+Yani evdeyken.
+
+339
+00:32:08,011 --> 00:32:09,930
+Ne kadar da þanslýlar...
+
+340
+00:32:10,013 --> 00:32:12,057
+"Evdekiler".
+
+341
+00:32:13,809 --> 00:32:15,269
+Bu doðru...
+
+342
+00:32:16,061 --> 00:32:17,396
+Prens Goro.
+
+343
+00:32:19,106 --> 00:32:23,944
+Böylesi itibarsýz görünen bir ahmaðý
+baþka hangi nedenle seçerim ki?
+
+344
+00:32:24,778 --> 00:32:25,863
+Ona bir bak.
+
+345
+00:32:26,655 --> 00:32:28,407
+Haysiyeti yok...
+
+346
+00:32:28,532 --> 00:32:29,908
+Terbiyesi yok.
+
+347
+00:32:29,992 --> 00:32:33,954
+dünya aleminde hala onun gibiler...
+
+348
+00:32:34,037 --> 00:32:36,707
+çok varlýklý ve neredeyse...
+
+349
+00:32:36,832 --> 00:32:39,042
+Tanrý kadar güçlü olabilir.
+
+350
+00:32:43,005 --> 00:32:47,593
+Eðer mahsuru
+yoksa olabildiðince çabuk
+kendi eðlenceme dönmek isterim.
+
+351
+00:32:47,718 --> 00:32:49,803
+Paramý ne zaman alacaðým?
+
+352
+00:32:49,928 --> 00:32:53,265
+Kýzla dövüþtükten sonra.
+Ama unutma...
+
+353
+00:32:53,390 --> 00:32:56,435
+ona zarar vermeyeceksin,
+yalnýzca küçük düþmeli.
+
+354
+00:32:57,853 --> 00:33:00,439
+Güzel Sonya için bazý planlarým var.
+
+355
+00:33:03,233 --> 00:33:07,779
+Bu ziyaretini neye borçluyuz
+acaba Shang Tsung?
+
+356
+00:33:07,946 --> 00:33:09,698
+Turnuvada Kung Lao
+soyundan birinin...
+
+357
+00:33:09,698 --> 00:33:12,451
+...mücadele edeceði hakkýnda
+uyarýda bulunmaya geldim.
+
+358
+00:33:12,618 --> 00:33:16,872
+- Ona dikkat etmen gerekiyor.
+- Liu Kang'i salondayken gördüm.
+
+359
+00:33:17,039 --> 00:33:19,917
+O bir sorun çýkarmaz.
+
+360
+00:33:20,042 --> 00:33:22,711
+Aptalca
+kibirlenmenin zamaný deðil.
+
+361
+00:33:23,921 --> 00:33:26,340
+Kesin zafere
+hiç bu kadar yakýn olmadýk.
+
+362
+00:33:26,465 --> 00:33:29,718
+Bu yüzden seni baþka bir
+tehlike hakkýnda da
+uyarmak zorundayým.
+
+363
+00:33:32,221 --> 00:33:33,972
+Prenses Kitana.
+
+364
+00:33:34,056 --> 00:33:36,934
+Ýmparator'un evlatlýk kýzý mý?
+
+365
+00:33:37,017 --> 00:33:39,186
+Onun için neden kaygýlanmalýyým?
+
+366
+00:33:39,311 --> 00:33:42,481
+Prenses Kitana
+tam on bin yaþýnda...
+
+367
+00:33:42,648 --> 00:33:45,150
+Ve Dýþ dünya tahtýnýn
+gerçek varisi o.
+
+368
+00:33:45,317 --> 00:33:48,904
+Kesinlikle Dünya aleminin
+güçlerine katýlmamalý...
+
+369
+00:33:49,071 --> 00:33:51,323
+özellikle de Liu Kang.
+
+370
+00:33:52,950 --> 00:33:54,993
+Seni bu kadar özel kýlan ne?
+
+371
+00:33:56,078 --> 00:33:57,162
+Bilmiyorum.
+
+372
+00:33:57,287 --> 00:33:59,790
+Ýmparator baþarýsýzlýða
+hoþgörü göstermeyecektir...
+
+373
+00:34:01,166 --> 00:34:03,961
+ve tabii ben de öyle.
+
+374
+00:34:04,086 --> 00:34:07,005
+Ben baþarýsýz olmam.
+
+375
+00:34:07,130 --> 00:34:09,007
+Hadi gidelim buradan.
+
+376
+00:34:13,095 --> 00:34:15,097
+Ne var?
+
+377
+00:34:15,264 --> 00:34:18,308
+Burada yalnýz deðiliz.
+
+378
+00:34:25,858 --> 00:34:28,068
+Durun biraz,
+bu odayý hatýrlamýyorum.
+
+379
+00:34:34,366 --> 00:34:35,409
+Bak!
+
+380
+00:34:37,995 --> 00:34:40,038
+Bu Prenses Kitana olmalý.
+
+381
+00:34:40,164 --> 00:34:42,499
+Sanýrým bize yardýma çalýþýyor.
+
+382
+00:34:42,624 --> 00:34:44,918
+- Uzun zamandýr yalnýz kalmýþsýn.
+- Hadi.
+
+383
+00:34:45,043 --> 00:34:47,171
+Onu unut gitsin. Kadýn on bin yaþýnda.
+
+384
+00:34:47,337 --> 00:34:49,339
+- Ne olmuþ?
+- Liu?
+
+385
+00:35:37,930 --> 00:35:40,516
+- Neler oluyor?
+- Burada bir þey var.
+
+386
+00:35:40,641 --> 00:35:42,726
+Prenses Kitana'yý takip ediyordu.
+
+387
+00:35:42,851 --> 00:35:44,978
+Prenses nerede?
+
+388
+00:35:45,103 --> 00:35:46,063
+Bilmiyorum.
+
+389
+00:35:53,237 --> 00:35:57,366
+- Nereye gittiðimizi biliyor musun?
+- Evet biliyorum hem de kesinlikle.
+
+390
+00:35:57,533 --> 00:35:59,409
+Kitana bu taraftan gitti.
+
+391
+00:36:03,038 --> 00:36:04,915
+Parfümünün kokusunu alýyorum.
+
+392
+00:36:06,625 --> 00:36:08,502
+Ben hiç koku almýyorum.
+
+393
+00:36:13,882 --> 00:36:15,300
+Ben bir koku alýyorum.
+
+394
+00:36:18,470 --> 00:36:19,930
+Saçmalýk.
+
+395
+00:36:33,235 --> 00:36:34,736
+Konuklarýmýz var.
+
+396
+00:37:30,042 --> 00:37:31,919
+Tam da beðendiðim türden.
+
+397
+00:37:32,044 --> 00:37:34,254
+Aptal ve çirkinler.
+
+398
+00:37:34,421 --> 00:37:37,216
+- Çocuk oyuncaðýydý.
+- Çocuk oyuncaðý, öyle mi?
+
+399
+00:37:37,341 --> 00:37:40,385
+- Evet benim için kolaydý.
+- Þu çeneni kapasan.
+
+400
+00:37:40,552 --> 00:37:43,222
+Sizin neyiniz var çocuklar?
+
+401
+00:37:43,347 --> 00:37:46,058
+Biz ayaktayýz,
+onlar deðil.
+
+402
+00:37:46,183 --> 00:37:48,060
+Daha ne istiyorsunuz?
+
+403
+00:37:55,901 --> 00:37:59,571
+Harika. Kesinlikle harika.
+
+404
+00:38:01,824 --> 00:38:05,244
+Peki þu konuda ne planladýðýnýzý da
+bana gösterebilir misiniz...
+
+405
+00:38:05,369 --> 00:38:06,411
+Oradalar?
+
+406
+00:38:19,675 --> 00:38:21,552
+Hiç zannetmiyorum.
+
+407
+00:38:35,190 --> 00:38:38,235
+Sanýrým þuradan
+çýkýþ yolunu bulabilirsiniz.
+
+408
+00:38:49,079 --> 00:38:51,165
+Bizi durdurduðu
+için þanslýsýnýz beyler.
+
+409
+00:39:01,425 --> 00:39:02,259
+Demek artýk neyle...
+
+410
+00:39:02,259 --> 00:39:05,095
+- ...karþýlaþacaðýnýzý biliyorsunuz?
+- Goro'dan mý söz ediyorsun?
+
+411
+00:39:05,220 --> 00:39:08,140
+- Ve Shang Tsung.
+- O da turnuvada dövüþecek mi?
+
+412
+00:39:08,265 --> 00:39:10,058
+Eðer bunu isterse.
+
+413
+00:39:10,184 --> 00:39:12,895
+Eski bir þampiyon olarak
+bunu yapmaya hakký var.
+
+414
+00:39:13,020 --> 00:39:16,940
+Ve o Goro'dan çok daha
+tehlikeli biridir.
+
+415
+00:39:17,024 --> 00:39:20,986
+Gücü yok ettiði savaþçýlarýn
+ruhlarýndan geliyor.
+
+416
+00:39:21,153 --> 00:39:23,030
+Shang Tsung'la karþýlaþmak...
+
+417
+00:39:23,197 --> 00:39:25,157
+tek bir kiþiyle deðil...
+
+418
+00:39:25,282 --> 00:39:27,534
+bir alay hasýmla yüzleþmektir.
+
+419
+00:39:27,659 --> 00:39:29,161
+Bunu hatýrlayýn.
+
+420
+00:39:34,041 --> 00:39:36,543
+Yarýn turnuva baþlayacak.
+
+421
+00:39:37,503 --> 00:39:38,962
+Hazýrlýklý olun.
+
+422
+00:39:54,102 --> 00:39:55,896
+Þu andan itibaren...
+
+423
+00:39:56,021 --> 00:39:59,107
+adam sizin savaþ alanýnýzdýr.
+
+424
+00:40:01,944 --> 00:40:02,945
+Liu Kang!
+
+425
+00:40:03,070 --> 00:40:05,280
+Ýlk sen dövüþeceksin.
+
+426
+00:40:05,405 --> 00:40:08,033
+Þimdi ölümcül dövüþ baþlasýn.
+
+427
+00:40:20,128 --> 00:40:21,630
+- Hadi!
+- Evet!
+
+428
+00:42:15,536 --> 00:42:18,622
+Ruhun artýk benim.
+
+429
+00:42:31,969 --> 00:42:33,846
+Sonuç ölüm.
+
+430
+00:42:56,910 --> 00:42:57,953
+Sonya Blade!
+
+431
+00:43:00,330 --> 00:43:02,374
+Senin için
+bir þeyim var tatlým.
+
+432
+00:43:02,499 --> 00:43:05,252
+Senden bir þey isteyen yok.
+
+433
+00:43:05,377 --> 00:43:07,754
+Tam aksine.
+
+434
+00:43:07,921 --> 00:43:11,508
+Bende çok
+fazla istediðin bir þey var.
+
+435
+00:43:11,633 --> 00:43:13,677
+Daha sonra teþekkür edebilirsin.
+
+436
+00:43:33,113 --> 00:43:34,948
+Merhaba bebeðim.
+
+437
+00:43:35,032 --> 00:43:36,992
+Beni özledin mi?
+
+438
+00:43:53,967 --> 00:43:55,969
+Hey þuna bak.
+
+439
+00:43:56,094 --> 00:43:58,972
+Bu küçük bebek bazý
+anýlarý canlandýrýyor deðil mi?
+
+440
+00:43:59,097 --> 00:44:01,600
+O býçaðý anneni sýrtýndan
+vurmak için mi kullandýn?
+
+441
+00:44:03,435 --> 00:44:06,813
+Ortaðýnýn yüzüne kocaman
+bir gülüþ kondurdum. Buradan...
+
+442
+00:44:08,982 --> 00:44:10,651
+buraya...
+
+443
+00:44:15,531 --> 00:44:17,991
+Pes etmelisin bebeðim
+bütün hareketlerini biliyorum.
+
+444
+00:44:18,075 --> 00:44:18,992
+Bunu da öðren.
+
+445
+00:44:58,949 --> 00:45:00,742
+Canýn mý acýdý bebeðim?
+
+446
+00:45:20,387 --> 00:45:21,972
+Bitir iþini.
+
+447
+00:45:23,265 --> 00:45:25,309
+Hayýr Sonya, yapma!
+
+448
+00:45:26,685 --> 00:45:29,062
+- Boynumu kýracaksýn!
+- Tamam.
+
+449
+00:46:05,766 --> 00:46:07,434
+Getir onu buraya!
+
+450
+00:46:30,749 --> 00:46:32,042
+Gel buraya!
+
+451
+00:47:38,150 --> 00:47:39,359
+Hoþ geldin!
+
+452
+00:49:27,968 --> 00:49:29,636
+Ýn aþaðý!
+
+453
+00:50:52,010 --> 00:50:55,514
+"En büyük Hayranýma
+Johnny Cage".
+
+454
+00:51:46,315 --> 00:51:47,816
+Baþlayýn!
+
+455
+00:51:57,117 --> 00:52:00,287
+Eðer tüm yüreðinle
+savaþmayacaksan hiç umut yok.
+
+456
+00:52:00,412 --> 00:52:02,080
+Kazanmamdan sana ne?
+
+457
+00:52:17,221 --> 00:52:21,183
+Bir sonraki dövüþü kazanmak için,
+hayatý saðlayan elementi kullan.
+
+458
+00:52:21,308 --> 00:52:22,351
+Ne?
+
+459
+00:52:22,434 --> 00:52:23,477
+Kitana!
+
+460
+00:52:35,030 --> 00:52:37,241
+Sözlerimi unutma.
+
+461
+00:52:37,407 --> 00:52:39,409
+Bu kadar yeter!
+
+462
+00:52:40,953 --> 00:52:42,996
+Beni hüsrana uðrattýn.
+
+463
+00:52:45,040 --> 00:52:46,667
+Pek akýllýca deðildi.
+
+464
+00:55:31,331 --> 00:55:34,126
+Hayatý
+saðlayan elementi kullan.
+
+465
+00:55:40,883 --> 00:55:42,176
+Su.
+
+466
+00:56:19,421 --> 00:56:20,964
+Vakit geldi mi?
+
+467
+00:56:21,965 --> 00:56:23,926
+Evet.
+
+468
+00:56:24,051 --> 00:56:26,345
+Ýnsanlarýn yeterince
+kazanmasýna izin verdik.
+
+469
+00:56:27,763 --> 00:56:30,224
+Sonunda.
+
+470
+00:57:24,945 --> 00:57:25,904
+Tanrým bu...
+
+471
+00:57:39,334 --> 00:57:41,086
+Evet iþte böyle! Gir ve çýk!
+
+472
+00:57:52,347 --> 00:57:53,807
+Hadi bunu baþarabilirsin!
+
+473
+00:57:53,932 --> 00:57:55,309
+Hadi! Ayaklarýný kullan!
+
+474
+00:57:56,185 --> 00:57:57,519
+Tekmele onu!
+
+475
+00:58:09,907 --> 00:58:12,701
+Hadi Art ayaða kalk!
+
+476
+00:58:24,213 --> 00:58:25,130
+Hadi kalk!
+
+477
+00:58:26,632 --> 00:58:28,008
+Göster ona.
+
+478
+00:58:29,843 --> 00:58:30,677
+Çýk oradan!
+
+479
+00:58:41,063 --> 00:58:42,981
+Goro! Goro!
+
+480
+00:58:43,065 --> 00:58:45,192
+Evet! Goro!
+
+481
+00:59:04,086 --> 00:59:05,003
+Bitir iþini!
+
+482
+00:59:09,424 --> 00:59:12,094
+Ölüm zamaný.
+
+483
+00:59:12,219 --> 00:59:13,136
+Bitir iþini.
+
+484
+00:59:52,342 --> 00:59:54,553
+Kusursuz zafer.
+
+485
+00:59:54,678 --> 00:59:58,265
+Ruhun artýk benim!
+
+486
+01:00:16,700 --> 01:00:18,118
+Artýk hiç kazanamayýz!
+
+487
+01:00:18,243 --> 01:00:21,371
+Böyle bir þeyi yenmemizi
+nasýl beklersin ki?
+
+488
+01:00:21,497 --> 01:00:23,999
+Ýyi bir soru.
+
+489
+01:00:24,166 --> 01:00:27,169
+Goro da öldürülebilir.
+
+490
+01:00:27,336 --> 01:00:32,007
+Shang Tsung'un gücü ölümlü
+erkek ve kadýnlarca yok edilebilir.
+
+491
+01:00:33,050 --> 01:00:36,470
+Güçleri size ne kadar tuhaf gibi...
+
+492
+01:00:36,553 --> 01:00:40,390
+görünse de tüm hasýmlarýnýzýn
+üstesinden gelebilirsiniz.
+
+493
+01:00:40,474 --> 01:00:43,185
+Her zaman bir yol vardýr.
+
+494
+01:00:44,353 --> 01:00:47,648
+Sizi yenebilecek
+tek bir þey var...
+
+495
+01:00:47,773 --> 01:00:49,942
+Ýçinizdeki korku.
+
+496
+01:00:50,067 --> 01:00:52,110
+Korktuðumuzu da kim söyledi?
+
+497
+01:00:54,029 --> 01:00:56,615
+Önce kendi
+korkularýnýzla yüzleþmelisiniz...
+
+498
+01:00:56,782 --> 01:00:59,618
+eðer onlarý
+alt etmek istiyorsanýz.
+
+499
+01:00:59,743 --> 01:01:02,913
+Sen, Johnny,
+sahte olmaktan korkuyorsun...
+
+500
+01:01:03,038 --> 01:01:07,125
+Öyle olmadýðýný kanýtlamak
+için her dövüþe atýlýyorsun.
+
+501
+01:01:09,294 --> 01:01:11,004
+Dövüþeceksin...
+
+502
+01:01:11,129 --> 01:01:12,923
+hem de cesaretle.
+
+503
+01:01:13,048 --> 01:01:14,883
+Ama aptalca...
+
+504
+01:01:15,008 --> 01:01:16,885
+umarsýzca...
+
+505
+01:01:17,010 --> 01:01:18,887
+ve de yenileceksin.
+
+506
+01:01:21,974 --> 01:01:24,852
+Sen, Sonya...
+
+507
+01:01:24,977 --> 01:01:28,856
+bazen yardýma ihtiyacýn olduðunu
+kabullenmekte zorlanýyorsun.
+
+508
+01:01:33,235 --> 01:01:35,946
+Eðer güvenmekten korkarsan...
+
+509
+01:01:36,989 --> 01:01:39,032
+kaybedersin.
+
+510
+01:01:45,914 --> 01:01:47,416
+Bekle.
+
+511
+01:01:48,167 --> 01:01:49,042
+Bekle.
+
+512
+01:01:50,419 --> 01:01:51,503
+Peki ya ben?
+
+513
+01:01:51,628 --> 01:01:54,006
+Sen.
+
+514
+01:01:54,131 --> 01:01:56,925
+Sen kendi
+kaderinden korkuyorsun.
+
+515
+01:01:57,050 --> 01:02:00,512
+Amerika'ya gittiðinde
+bundan bir kez kaçmýþtýn.
+
+516
+01:02:00,637 --> 01:02:02,723
+Bu nedenle Chan'in
+ölümünden suçluluk duyuyorsun.
+
+517
+01:02:02,890 --> 01:02:04,892
+Chan'in ölümünden
+yalnýzca ben sorumluyum.
+
+518
+01:02:04,975 --> 01:02:09,271
+Her ölümlü yalnýzca
+kendi kaderinden sorumludur.
+
+519
+01:02:09,396 --> 01:02:11,940
+Chan buna inandý.
+Sen niye inanmýyorsun?
+
+520
+01:02:13,942 --> 01:02:14,985
+Denedim.
+
+521
+01:02:15,110 --> 01:02:17,988
+Umutsuzluk korkularýn en büyüðüdür.
+
+522
+01:02:18,071 --> 01:02:19,948
+Ben bunu biliyorum...
+
+523
+01:02:20,032 --> 01:02:22,159
+Tabii Shang Tsung da öyle.
+
+524
+01:02:22,284 --> 01:02:25,078
+Senin ruhunu okuyabilir...
+
+525
+01:02:25,204 --> 01:02:27,998
+ve gördüðü korkuyu
+sana karþý kullanabilir.
+
+526
+01:02:28,916 --> 01:02:30,918
+Hazýrlýklý olmalýsýn.
+
+527
+01:02:54,608 --> 01:02:56,985
+Liu!
+
+528
+01:02:57,110 --> 01:02:59,488
+Sýradaki sensin.
+
+529
+01:03:12,125 --> 01:03:14,920
+Goro asla yenilmemiþ.
+
+530
+01:03:15,045 --> 01:03:17,297
+Ona meydan okursan,
+seni öldürecektir.
+
+531
+01:03:17,422 --> 01:03:18,882
+Eðer bunu yapmazsam...
+
+532
+01:03:19,007 --> 01:03:21,677
+Hepimizi teker teker öldürebilir.
+
+533
+01:03:23,178 --> 01:03:25,055
+Ona þimdi meydan okursam...
+
+534
+01:03:25,973 --> 01:03:28,642
+Bu iþi bitirebilirim.
+
+535
+01:03:28,767 --> 01:03:31,603
+Bu sanki çok basitmiþ
+gibi konuþuyorsun.
+
+536
+01:03:31,728 --> 01:03:33,230
+Evet öyle.
+
+537
+01:03:34,773 --> 01:03:38,360
+Çünka Art'a olanlarýn sana da
+olmasýna izin veremem.
+
+538
+01:03:39,945 --> 01:03:42,489
+Sana olmaz.
+
+539
+01:03:42,656 --> 01:03:46,326
+Sakýn beni korumak için
+buna kalkýþma Johnny Cage.
+
+540
+01:03:46,451 --> 01:03:48,912
+Güven bana. Bir planým var.
+
+541
+01:03:49,079 --> 01:03:52,541
+Ýþte buna inanamýyorum!
+Sen hayatýmda tanýdýðým...
+
+542
+01:03:52,666 --> 01:03:55,377
+en egoist ve en kibirli adamsýn.
+
+543
+01:03:55,502 --> 01:03:57,462
+Yakýþýklý demeyi unuttun.
+
+544
+01:04:03,594 --> 01:04:06,513
+Goro'ya meydan okumak?
+
+545
+01:04:06,638 --> 01:04:09,766
+Oysa onunla dövüþmen
+gerekmiyordu.
+
+546
+01:04:09,892 --> 01:04:12,311
+Ölmeye bu kadar hevesli misin?
+
+547
+01:04:12,394 --> 01:04:14,021
+Ölecek olan ben deðilim.
+
+548
+01:04:17,316 --> 01:04:18,817
+Anlýyorum.
+
+549
+01:04:19,610 --> 01:04:21,153
+Fazlasýyla budalasýn.
+
+550
+01:04:21,320 --> 01:04:24,031
+Gerçek bir kahramanlýk iþareti.
+
+551
+01:04:24,114 --> 01:04:26,241
+Dostlarýný korumak istiyorsun.
+
+552
+01:04:26,366 --> 01:04:29,036
+Ama sakýn unutma.
+
+553
+01:04:29,912 --> 01:04:32,289
+Goro seni yok ettikten sonra...
+
+554
+01:04:32,414 --> 01:04:35,000
+mutlak onlar da ölecek.
+
+555
+01:04:35,125 --> 01:04:37,669
+O halde sorun nedir?
+
+556
+01:04:38,754 --> 01:04:40,839
+Nasýl istersen.
+
+557
+01:04:40,964 --> 01:04:44,927
+Bu saçma isteðini,
+kabul edebilirim.
+
+558
+01:04:45,052 --> 01:04:45,844
+Karþýlýðýnda...
+
+559
+01:04:45,844 --> 01:04:49,973
+...kazanana meydan okuma hakkýmý
+kendim için saklý tutacaðým.
+
+560
+01:04:50,098 --> 01:04:52,851
+Ya da baþka
+bir seçim yapacaðým.
+
+561
+01:04:53,018 --> 01:04:56,897
+Turnuvanýn son dövüþü
+benim belirlediðim...
+
+562
+01:04:57,064 --> 01:04:58,524
+yerde gerçekleþtirilecek.
+
+563
+01:05:00,108 --> 01:05:02,569
+- Anlaþtýk ahbap.
+- Hiç sanmýyorum.
+
+564
+01:05:06,907 --> 01:05:08,951
+Çok geç efendi Rayden.
+
+565
+01:05:09,993 --> 01:05:12,079
+Kurallar gayet açýk.
+
+566
+01:05:13,080 --> 01:05:14,957
+Siz nasýl diyorsunuz?
+
+567
+01:05:16,500 --> 01:05:18,752
+Anlaþma anlaþmadýr.
+
+568
+01:05:24,299 --> 01:05:25,801
+Ne yaptýn sen?
+
+569
+01:05:25,926 --> 01:05:28,053
+Bir seçim yaptým.
+
+570
+01:05:28,178 --> 01:05:30,514
+Bu bizim turnuvamýz deðil mi?
+
+571
+01:05:30,639 --> 01:05:31,890
+Ölümlülerin savaþý.
+
+572
+01:05:32,015 --> 01:05:33,976
+Biz dövüþeceðiz.
+
+573
+01:05:40,941 --> 01:05:42,442
+Güzel.
+
+574
+01:05:42,568 --> 01:05:45,362
+En azýndan
+birisi anlamýþ oldu.
+
+575
+01:05:48,073 --> 01:05:50,951
+Goro! Goro!
+
+576
+01:06:54,306 --> 01:06:56,600
+Ýþini çabuk bitir.
+
+577
+01:06:56,725 --> 01:06:58,310
+Bana saygýný göster.
+
+578
+01:06:58,393 --> 01:07:01,980
+Bu sýska ölümlü
+sorun çýkarmayacak.
+
+579
+01:07:02,064 --> 01:07:04,233
+Onu tek darbede yok ederim.
+
+580
+01:07:04,399 --> 01:07:06,068
+Pekala.
+
+581
+01:07:07,069 --> 01:07:08,153
+Dans edelim.
+
+582
+01:07:18,288 --> 01:07:20,874
+Evet. Affedersin
+
+583
+01:07:26,922 --> 01:07:28,090
+Seni sersem.
+
+584
+01:07:32,177 --> 01:07:34,179
+Kahretsin! Caným yandý.
+
+585
+01:07:34,888 --> 01:07:36,181
+Ýzle onu.
+
+586
+01:07:36,348 --> 01:07:37,266
+Bitir iþini.
+
+587
+01:07:43,188 --> 01:07:45,691
+- Öldür!
+- Goro! Goro!
+
+588
+01:07:48,360 --> 01:07:50,696
+Öldür onu!
+
+589
+01:08:28,775 --> 01:08:31,111
+O 500 dolarlýk bir gözlüktü
+pislik herif.
+
+590
+01:08:50,964 --> 01:08:52,758
+Burada düþmen gerekiyordu.
+
+591
+01:09:07,940 --> 01:09:10,400
+Býrak beni!
+
+592
+01:09:11,485 --> 01:09:12,736
+Hayýr!
+
+593
+01:09:14,863 --> 01:09:18,367
+Þimdi meydan okuma
+hakkýmý kullanýyorum.
+
+594
+01:09:18,534 --> 01:09:20,911
+Ve ona meydan okuyorum.
+
+595
+01:09:20,994 --> 01:09:23,247
+Sen bir korkaksýn büyücü.
+
+596
+01:09:23,372 --> 01:09:24,832
+Adam gibi dövüþ.
+
+597
+01:09:24,957 --> 01:09:27,334
+Bir anlaþmamýz
+vardý unuttun mu?
+
+598
+01:09:27,459 --> 01:09:30,379
+Ölümcül dövüþ devam ediyor.
+Ben sadece...
+
+599
+01:09:30,504 --> 01:09:32,381
+yeri deðiþtiriyorum.
+
+600
+01:09:34,591 --> 01:09:36,844
+Týpký anlaþtýðýmýz gibi.
+
+601
+01:09:39,680 --> 01:09:41,598
+- Sonya!
+- Bekle!
+
+602
+01:09:44,768 --> 01:09:47,980
+- Onu nereye götürüyor?
+- Ýmparatorun kalesine...
+
+603
+01:09:48,105 --> 01:09:51,483
+Dýþ dünyadaki çorak bölgeye.
+Ben oraya gidemem.
+
+604
+01:09:51,650 --> 01:09:53,527
+Biz gidebiliriz.
+
+605
+01:09:53,652 --> 01:09:57,239
+Rayden, Sonya
+Shang Tsung'ý yenebilir mi?
+
+606
+01:09:58,949 --> 01:10:00,159
+Çok üzgünüm.
+
+607
+01:10:00,284 --> 01:10:02,911
+- Üzgün müsün.
+- Yalnýzca son bir kural daha var.
+
+608
+01:10:02,995 --> 01:10:05,205
+Bahsetmeyi ihmal ettim.
+
+609
+01:10:05,330 --> 01:10:09,293
+Meydan okumasýný kabul etmeli.
+Yoksa son dövüþ gerçekleþemez.
+
+610
+01:10:09,418 --> 01:10:13,338
+Benim sana öðretecek
+bir þeyim kalmadý Liu Kang.
+
+611
+01:10:13,463 --> 01:10:15,132
+Artýk bilgiye sahipsin.
+
+612
+01:10:15,257 --> 01:10:18,969
+Þimdi tek eksik ise irade.
+
+613
+01:10:19,094 --> 01:10:21,096
+Bizimle gelmek istemediðinden
+emin misin?
+
+614
+01:10:21,221 --> 01:10:23,891
+Dýþ dünyada
+eðer yeterince ararsanýz...
+
+615
+01:10:24,057 --> 01:10:25,934
+baþka bir rehber bulursunuz.
+
+616
+01:10:35,694 --> 01:10:37,029
+Ýyi þanslar.
+
+617
+01:10:47,956 --> 01:10:49,791
+Ýhtiyaçlarý olacak.
+
+618
+01:10:52,794 --> 01:10:54,963
+Bu hiç iyi deðil.
+
+619
+01:10:55,088 --> 01:10:57,257
+Ama ben iyiyim.
+
+620
+01:10:57,424 --> 01:10:59,468
+Bununla baþa çýkabilirim.
+
+621
+01:11:02,930 --> 01:11:06,266
+Evet, demek dýþ dünya bu.
+
+622
+01:11:06,391 --> 01:11:09,102
+Neden sahneyi deðiþtirmek
+istediklerini anlýyorum.
+
+623
+01:11:09,228 --> 01:11:11,271
+Þu kuleye doðru gitmeliyiz.
+
+624
+01:11:11,396 --> 01:11:13,690
+Sonya'yý
+oraya götürmüþ olmalý.
+
+625
+01:11:34,336 --> 01:11:35,921
+Buradan nefret ediyorum.
+
+626
+01:11:36,046 --> 01:11:39,007
+Gerçekten, sana söylüyorum.
+
+627
+01:11:39,174 --> 01:11:41,969
+Düþman bir çevredeyiz ve ben
+kýçýmý tekmelemek isteyen...
+
+628
+01:11:42,094 --> 01:11:44,680
+insanlara karþý hazýrlýksýzým.
+
+629
+01:11:44,805 --> 01:11:47,015
+Bu tekrar Lise'ye dönmek gibi!
+
+630
+01:11:48,600 --> 01:11:50,310
+Neydi o?
+
+631
+01:11:51,937 --> 01:11:53,147
+Bekle.
+
+632
+01:11:53,856 --> 01:11:55,149
+Ne?
+
+633
+01:11:55,941 --> 01:11:57,818
+Bir þeyler var.
+
+634
+01:11:57,943 --> 01:11:59,194
+Harika.
+
+635
+01:12:03,574 --> 01:12:04,992
+Ne yapýyorsun?
+
+636
+01:12:10,038 --> 01:12:11,123
+Ne yapýyorsun?
+
+637
+01:12:41,945 --> 01:12:43,197
+Sürüngen.
+
+638
+01:15:43,001 --> 01:15:44,878
+Hayýr, dur bakalým!
+
+639
+01:15:53,137 --> 01:15:54,471
+Çok iyi.
+
+640
+01:15:57,349 --> 01:15:59,685
+Sonunda öðreniyorsun Liu Kang.
+
+641
+01:15:59,810 --> 01:16:01,103
+Kitana.
+
+642
+01:16:01,937 --> 01:16:03,021
+Benimle gel..
+
+643
+01:16:06,066 --> 01:16:07,943
+Burada neler oldu?
+
+644
+01:16:08,986 --> 01:16:12,364
+Sizin dünyanýza
+olacak þeyin aynýsý...
+
+645
+01:16:12,489 --> 01:16:14,575
+Tabii siz önleyemezseniz.
+
+646
+01:16:17,077 --> 01:16:20,956
+Babam dýþ dünyanýn
+gerçek yöneticisiydi.
+
+647
+01:16:22,916 --> 01:16:26,545
+Sonra en iyi savaþçýlarý
+on ölümcül dövüþ kaybettiler.
+
+648
+01:16:26,670 --> 01:16:29,047
+Ýmparator dünyamýza girdi...
+
+649
+01:16:29,214 --> 01:16:31,842
+ailemi öldürdü
+ve tahta geçebilmek için...
+
+650
+01:16:32,009 --> 01:16:34,052
+beni evlat edindi.
+
+651
+01:16:38,640 --> 01:16:40,767
+Bir zamanlar güzel bir yerdi...
+
+652
+01:16:40,893 --> 01:16:44,980
+Shang Tsung bu yýkýma
+baþlamadan önce yani.
+
+653
+01:16:45,105 --> 01:16:48,025
+Bunun benim dünyama da
+olmasýný nasýl önleyebilirim?
+
+654
+01:16:48,150 --> 01:16:50,486
+Eðer sana inanmasaydým..
+
+655
+01:16:50,611 --> 01:16:52,404
+sana yardým etmezdim.
+
+656
+01:16:54,156 --> 01:16:57,409
+Kara kulede
+üç rakiple yüzleþeceksin.
+
+657
+01:16:57,534 --> 01:17:01,038
+Düþmanýnla yüzleþmelisin.
+Kendinle yüzleþmek zorundasýn.
+
+658
+01:17:01,163 --> 01:17:04,249
+Ve en büyük
+korkunla yüzleþmelisin.
+
+659
+01:18:20,492 --> 01:18:23,620
+Seninle dövüþmeyeceðim Shang Tsung.
+
+660
+01:18:23,745 --> 01:18:26,456
+Oyununa dahil olmayacaðým.
+
+661
+01:18:29,042 --> 01:18:30,586
+Benim tatlý Sonyam.
+
+662
+01:18:30,711 --> 01:18:32,629
+Baþka kimse yok.
+
+663
+01:18:32,713 --> 01:18:34,756
+Eðer sen dövüþmezsen...
+
+664
+01:18:34,882 --> 01:18:37,301
+Dünya alemi turnuvayý
+kaybetmiþ sayýlacak...
+
+665
+01:18:38,385 --> 01:18:40,345
+Ve büyük imparatorumuz için...
+
+666
+01:18:40,471 --> 01:18:43,140
+Tüm kapýlar açýlmýþ olacak.
+
+667
+01:18:43,307 --> 01:18:44,933
+Yalan söylüyorsun.
+
+668
+01:18:45,934 --> 01:18:47,978
+Dostlarým yardýma gelecektir.
+
+669
+01:18:49,229 --> 01:18:50,939
+Umuda karþý umut.
+
+670
+01:18:51,064 --> 01:18:55,235
+Çok sevimli bir insan tavrý.
+Ne dokunaklý! Gerçekten.
+
+671
+01:18:57,362 --> 01:18:59,823
+Son bir þans, Sonya.
+
+672
+01:18:59,948 --> 01:19:01,867
+Ölümcül dövüþte benimle savaþ.
+
+673
+01:19:01,992 --> 01:19:03,702
+Cehenneme git..
+
+674
+01:19:05,204 --> 01:19:06,872
+Götürün onu.
+
+675
+01:19:07,998 --> 01:19:10,292
+Ýmparator bundan hoþlanacak.
+
+676
+01:19:13,378 --> 01:19:14,922
+Dostlarým gelecektir.
+
+677
+01:19:18,383 --> 01:19:19,676
+Zaten buradalar.
+
+678
+01:19:22,387 --> 01:19:25,307
+- Yakalayýn onlarý.
+- Olduðunuz yerde kalýn.
+
+679
+01:19:26,683 --> 01:19:29,603
+Turnuvaya müdahale etmeye
+cesaretin var mý...
+
+680
+01:19:29,728 --> 01:19:32,231
+Ya imparatora ihanet etmeye?
+
+681
+01:19:32,314 --> 01:19:35,859
+Bu büyük krallýkta,
+Ölümcül dövüþün kalleþlikle...
+
+682
+01:19:35,984 --> 01:19:37,861
+kazanýlamayacaðýný o da bilir.
+
+683
+01:19:37,986 --> 01:19:41,114
+Ne cüretle
+kalleþlikten bahsediyorsun?
+
+684
+01:19:41,240 --> 01:19:45,118
+Kuralsýzlýðýn yüzünden
+Dünya aleminin anahtarýný...
+
+685
+01:19:45,244 --> 01:19:47,621
+sonsuza dek yitirmiþ olacaksýnýz.
+
+686
+01:19:48,705 --> 01:19:50,165
+Pekala.
+
+687
+01:19:54,878 --> 01:19:56,755
+Sana meydan okuyorum.
+
+688
+01:19:58,423 --> 01:20:00,300
+Benimle dövüþmen gerek.
+
+689
+01:20:05,722 --> 01:20:07,349
+Ben Liu Kang...
+
+690
+01:20:07,432 --> 01:20:09,935
+Kung Lao'nun soyundaným.
+
+691
+01:20:10,894 --> 01:20:13,772
+Ölümcül dövüþte
+sana meydan okuyorum.
+
+692
+01:20:13,897 --> 01:20:16,650
+Kabul edecek misin,
+kaçacak mýsýn?
+
+693
+01:20:18,485 --> 01:20:20,779
+Kabul ediyorum.
+
+694
+01:20:22,072 --> 01:20:23,532
+Çekilin.
+
+695
+01:20:26,869 --> 01:20:28,579
+Bu cüretkar ölümlünün iþini...
+
+696
+01:20:28,704 --> 01:20:31,623
+ben bitireceðim.
+
+697
+01:20:45,345 --> 01:20:47,222
+Güzel elbise.
+
+698
+01:21:55,290 --> 01:21:57,167
+Seni sersem.
+
+699
+01:22:08,053 --> 01:22:09,930
+Bu ses de ne?
+
+700
+01:22:10,055 --> 01:22:12,933
+Shang Tsung'ýn gücünün kaynaðý bu.
+
+701
+01:22:13,016 --> 01:22:14,977
+Binlerce ölü savaþçýnýn ruhu.
+
+702
+01:22:21,692 --> 01:22:23,152
+Düþmanýnla yüzleþ.
+
+703
+01:23:49,655 --> 01:23:51,824
+Tüm sahip olduðun bu mu büyücü?
+
+704
+01:23:53,200 --> 01:23:54,910
+Liu Kang!
+
+705
+01:23:56,119 --> 01:23:58,914
+Ruhunun içini görebiliyorum.
+
+706
+01:23:59,122 --> 01:24:02,584
+Ve sen öleceksin.
+
+707
+01:24:06,547 --> 01:24:08,090
+Kendinle yüzleþ.
+
+708
+01:24:08,215 --> 01:24:11,802
+Belki ruhumu görebilirsin...
+
+709
+01:24:11,927 --> 01:24:13,720
+Ama sahibi olamazsýn.
+
+710
+01:24:25,399 --> 01:24:27,442
+En büyük korkunla yüzleþ.
+
+711
+01:24:27,568 --> 01:24:29,945
+Artýk kaderimden korkmuyorum.
+
+712
+01:24:30,070 --> 01:24:31,321
+Yüzünü dön.
+
+713
+01:24:36,201 --> 01:24:37,161
+Liu.
+
+714
+01:24:39,955 --> 01:24:41,039
+Chan?
+
+715
+01:24:44,001 --> 01:24:45,335
+Bu sen olamazsýn.
+
+716
+01:24:47,838 --> 01:24:49,715
+Beni Rayden gönderdi.
+
+717
+01:24:50,466 --> 01:24:51,925
+Sana yardým için.
+
+718
+01:24:52,009 --> 01:24:53,969
+Sen aslýnda Chan deðilsin.
+
+719
+01:24:56,263 --> 01:24:58,640
+Anne-babamýzýn
+ölümünü hatýrlýyor musun?
+
+720
+01:25:01,852 --> 01:25:04,396
+Benimle hep
+ilgileneceðine söz vermiþtin?
+
+721
+01:25:08,108 --> 01:25:09,359
+Hatýrlýyorum.
+
+722
+01:25:11,111 --> 01:25:13,363
+Þimdi de benim
+sýram geldi kardeþim.
+
+723
+01:25:20,078 --> 01:25:21,371
+Benimle gel.
+
+724
+01:25:26,502 --> 01:25:27,878
+Ölmeme izin verdiðin için
+seni baðýþlýyorum.
+
+725
+01:25:33,509 --> 01:25:34,927
+Bu benim hatam deðildi.
+
+726
+01:25:37,513 --> 01:25:38,889
+- Kardeþim.
+- Hayýr.
+
+727
+01:25:41,475 --> 01:25:43,560
+Chan kendi yolunu seçti.
+
+728
+01:25:44,937 --> 01:25:47,815
+Her insan yalnýz kendi
+kaderinden sorumludur.
+
+729
+01:25:49,233 --> 01:25:51,109
+Benim kardeþimi Shang Tsung öldürdü.
+
+730
+01:25:53,111 --> 01:25:54,279
+Sen benimsin.
+
+731
+01:26:20,931 --> 01:26:23,392
+Sen mi seçilmiþsin.
+
+732
+01:26:42,119 --> 01:26:44,371
+Ben seçilmiþ olaným
+
+733
+01:26:53,505 --> 01:26:55,591
+Kölelerini duyuyor musun büyücü?
+
+734
+01:26:59,553 --> 01:27:03,182
+Onlarýn
+üzerindeki gücünü yitiriyorsun.
+Hepsi sana karþý ayaklanacak.
+
+735
+01:27:04,099 --> 01:27:05,601
+Býrak onlarý.
+
+736
+01:27:07,352 --> 01:27:11,231
+Onlar sonsuza dek benim.
+
+737
+01:27:26,371 --> 01:27:29,333
+Bunca ruhun içinde
+kendininkine sahip deðilsin.
+
+738
+01:27:29,458 --> 01:27:31,043
+Sana acýyorum büyücü.
+
+739
+01:27:34,129 --> 01:27:36,924
+Acýycak zayýf birini bul.
+
+740
+01:27:37,090 --> 01:27:38,050
+Teslim ol, bitti artýk!
+
+741
+01:27:51,855 --> 01:27:53,774
+Asla!
+
+742
+01:28:32,938 --> 01:28:35,107
+Kusursuz zafer.
+
+743
+01:29:20,986 --> 01:29:22,488
+Geleceðini biliyordum.
+
+744
+01:29:23,447 --> 01:29:24,948
+Chan.
+
+745
+01:29:28,076 --> 01:29:29,870
+Bir gün...
+
+746
+01:29:29,995 --> 01:29:31,872
+Tekrar buluþacaðýz...
+
+747
+01:29:34,082 --> 01:29:37,544
+Ama o zamana dek ruhum
+her zaman seninle olacak.
+
+748
+01:29:39,922 --> 01:29:42,007
+Huzur içinde ol kardeþim.
+
+749
+01:30:22,297 --> 01:30:24,383
+Hadi eve dönelim..
+
+750
+01:30:46,321 --> 01:30:48,365
+Ben de sizleri bekliyordum.
+
+751
+01:30:48,490 --> 01:30:50,742
+Neden bu kadar uzun sürdü?
+
+752
+01:30:50,868 --> 01:30:53,453
+Sanýrým böyle
+sona ereceðini biliyordun.
+
+753
+01:30:54,246 --> 01:30:55,622
+Bu doðru deðil.
+
+754
+01:30:58,000 --> 01:31:00,878
+Siz insanlarýn
+ne yapacaðý hiç kestirilmiyor .
+
+755
+01:31:02,713 --> 01:31:05,966
+Ama þunu söyleyebilirim,
+harika iþ çýkardýnýz.
+
+756
+01:31:08,385 --> 01:31:11,972
+- Önümde eðilin!
+- Nedir bu?
+
+757
+01:31:13,599 --> 01:31:15,100
+Ýmparator.
+
+758
+01:31:21,106 --> 01:31:24,985
+Sizi zayýf ve hastalýklý aptallar.
+Ruhlarýnýz için geldim
+
+759
+01:31:25,777 --> 01:31:27,154
+Hiç sanmýyorum.
+

--- a/tests/libse/LibSETests.csproj
+++ b/tests/libse/LibSETests.csproj
@@ -24,6 +24,9 @@
     <Content Include="Files\auto_detect_windows-1250.srt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Files\auto_detect_windows-1254.srt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Files\auto_detect_windows-1251.srt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Fixes #10095 (reopened report for 5.0.2 with a sample file).

The attached Turkish subtitle decoded as 1254 counted exactly 172 Turkish words against a minimum of 172, so the check failed and detection fell through to the generic charset library, which is version dependent and answered 1252 for the reporter.

Changes:
- Expand the Turkish word list with common words containing the Turkish-only letters ı, ş, ğ (these decode as ý, þ, ð in 1252, so they only match when the text is read as 1254). Fix the "Tetekkürler" typo and a duplicate entry.
- Check Turkish before the Western European 1252 languages, gated on the 1254 decoding counting more Turkish words than the 1252 decoding, with half the usual minimum.
- Add the sample as a regression test. It now scores 407 vs. minimum 172; the other detection test files score 0 Turkish words.

All 2006 libse tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)