### PR TITLE
Fix waveform min-gap clamp landing one frame early with snap to frames

### DIFF
--- a/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
+++ b/src/ui/Controls/AudioVisualizerControl/AudioVisualizer.cs
@@ -1713,8 +1713,9 @@ public class AudioVisualizer : Control
 
                 if (previous != null && newStart < previous.EndTime.TotalSeconds + MinGapSeconds)
                 {
-                    newStart = previous.EndTime.TotalSeconds + MinGapSeconds + 0.001;
-                    newStart = SnapToFrameCeil(newStart);
+                    // Exactly the gap, no "strictly after" nudge: a 1 ms nudge here rolled the
+                    // ceiling over to the next frame, so a 2-frame minimum gap dragged to 3.
+                    newStart = SnapToFrameCeil(previous.EndTime.TotalSeconds + MinGapSeconds);
                 }
 
                 if (newStart < _activeParagraph.EndTime.TotalSeconds - 0.1)
@@ -1739,8 +1740,9 @@ public class AudioVisualizer : Control
 
                 if (next != null && newEnd > next.StartTime.TotalSeconds - MinGapSeconds)
                 {
-                    newEnd = next.StartTime.TotalSeconds - 0.001 - MinGapSeconds;
-                    newEnd = SnapToFrameFloor(newEnd);
+                    // Exactly the gap - see the ResizingLeft clamp: minus 1 ms then floor landed
+                    // one frame early, so a 2-frame minimum gap could never be dragged to 2 frames.
+                    newEnd = SnapToFrameFloor(next.StartTime.TotalSeconds - MinGapSeconds);
                 }
 
                 if (newEnd > _activeParagraph.StartTime.TotalSeconds + 0.1)
@@ -1795,6 +1797,17 @@ public class AudioVisualizer : Control
         return Math.Round(seconds / frameDur, MidpointRounding.AwayFromZero) * frameDur;
     }
 
+    /// <summary>
+    /// Earliest frame time at or after <paramref name="seconds"/>, compared in whole milliseconds -
+    /// the resolution subtitle times are stored at (<see cref="TimeSpanExtensions.FromSecondsWholeMilliseconds"/>).
+    /// <para>
+    /// The bounds fed in here are built from stored times (a neighbour's cue plus the minimum gap),
+    /// so at a non-integer frame rate they sit up to half a millisecond off the exact frame: at
+    /// 29.97 fps frame 101 is stored as 3370 ms, not 3370.03. A plain Math.Ceiling of 3370 / 33.37
+    /// would move such a bound to frame 102 and open the gap by a frame; comparing the candidate
+    /// frames' whole-ms times against the whole-ms bound keeps it on frame 101.
+    /// </para>
+    /// </summary>
     private static double SnapToFrameCeil(double seconds)
     {
         if (!TryGetFrameDuration(out var frameDur))
@@ -1802,9 +1815,24 @@ public class AudioVisualizer : Control
             return seconds;
         }
 
-        return Math.Ceiling(seconds / frameDur) * frameDur;
+        var boundMs = Math.Round(seconds * TimeCode.BaseUnit, MidpointRounding.AwayFromZero);
+        var frame = Math.Ceiling(seconds / frameDur);
+        if (FrameToWholeMs(frame - 1, frameDur) >= boundMs)
+        {
+            frame--;
+        }
+        else if (FrameToWholeMs(frame, frameDur) < boundMs)
+        {
+            frame++;
+        }
+
+        return frame * frameDur;
     }
 
+    /// <summary>
+    /// Latest frame time at or before <paramref name="seconds"/>, compared in whole milliseconds -
+    /// the mirror of <see cref="SnapToFrameCeil"/>.
+    /// </summary>
     private static double SnapToFrameFloor(double seconds)
     {
         if (!TryGetFrameDuration(out var frameDur))
@@ -1812,7 +1840,25 @@ public class AudioVisualizer : Control
             return seconds;
         }
 
-        return Math.Floor(seconds / frameDur) * frameDur;
+        var boundMs = Math.Round(seconds * TimeCode.BaseUnit, MidpointRounding.AwayFromZero);
+        var frame = Math.Floor(seconds / frameDur);
+        if (FrameToWholeMs(frame + 1, frameDur) <= boundMs)
+        {
+            frame++;
+        }
+        else if (FrameToWholeMs(frame, frameDur) > boundMs)
+        {
+            frame--;
+        }
+
+        return frame * frameDur;
+    }
+
+    /// <summary>The whole-millisecond time a frame is stored at (the same rounding as
+    /// <see cref="TimeSpanExtensions.FromSecondsWholeMilliseconds"/>).</summary>
+    private static double FrameToWholeMs(double frame, double frameDur)
+    {
+        return Math.Round(frame * frameDur * TimeCode.BaseUnit, MidpointRounding.AwayFromZero);
     }
 
     private static bool TryGetFrameDuration(out double frameDur)

--- a/tests/UI/Controls/AudioVisualizerDragTests.cs
+++ b/tests/UI/Controls/AudioVisualizerDragTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Nikse.SubtitleEdit.Controls.AudioVisualizerControl;
 using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using System;
 using System.Collections.Generic;
@@ -35,6 +36,8 @@ public class AudioVisualizerDragTests : IDisposable
     // their window on the last line, which leaks one whenever an assertion above it fails - and one
     // stranded window is enough to take the rest of the class down with it.
     private readonly List<Window> _windows = new();
+    private readonly bool _snapToFrames = Se.Settings.Waveform.SnapToFrames;
+    private readonly double _frameRate = Se.Settings.General.CurrentFrameRate;
 
     public void Dispose()
     {
@@ -44,6 +47,8 @@ public class AudioVisualizerDragTests : IDisposable
         }
 
         _windows.Clear();
+        Se.Settings.Waveform.SnapToFrames = _snapToFrames;
+        Se.Settings.General.CurrentFrameRate = _frameRate;
     }
 
     private const int SampleRate = 126; // Se.Settings.Waveform.WaveformMinimumSampleRate default
@@ -402,5 +407,84 @@ public class AudioVisualizerDragTests : IDisposable
         var after = FirstCachedWaveformGeometry(av);
 
         Assert.NotSame(before, after);
+    }
+
+    // A frame project with a 2-frame minimum gap (Amazon): dragging the previous line's end
+    // toward the next in-cue stopped at 3 frames. The clamp set the end to "next start minus gap
+    // minus 1 ms" and then floored to a frame, so the 1 ms nudge always cost a whole frame.
+    [AvaloniaFact]
+    public void ResizeRight_ClampsToExactlyMinGap_WhenSnappingToFrames()
+    {
+        Se.Settings.Waveform.SnapToFrames = true;
+        Se.Settings.General.CurrentFrameRate = 25; // one frame = 40 ms
+
+        var (window, av, _) = Open(Line(1, 3), Line(4, 6));
+        av.MinGapSeconds = 0.08; // 2 frames
+        var line = av.SelectedParagraph!;
+
+        // Right edge of the first line at x = 3 s * 126 = 378; drag it to ~3.97 s, inside the gap.
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(500, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        // 4000 ms - 2 frames = frame 98 = 3920 ms (the old clamp gave frame 97 = 3880 ms).
+        Assert.Equal(3920, line.EndTime.TotalMilliseconds);
+
+        window.MouseUp(new Point(500, 100), MouseButton.Left, RawInputModifiers.None);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ResizeRight_ClampsToExactlyMinGap_AtNonIntegerFrameRate()
+    {
+        // Times are stored as whole milliseconds, so at 29.97 fps frame 101 is 3370 ms (true
+        // 3370.03). A plain floor of (3370 - 67) / 33.37 = 98.99 dropped to frame 98 even without
+        // the 1 ms nudge; the bound must be compared at whole-ms resolution.
+        Se.Settings.Waveform.SnapToFrames = true;
+        Se.Settings.General.CurrentFrameRate = 29.97;
+
+        var next = new SubtitleLineViewModel
+        {
+            Text = "text",
+            StartTime = TimeSpan.FromMilliseconds(3370),
+            EndTime = TimeSpan.FromMilliseconds(5000),
+        };
+        var (window, av, _) = Open(Line(1, 3), next);
+        av.MinGapSeconds = 0.067; // 2 frames, as SubtitleFormat.FramesToMilliseconds rounds them
+        var line = av.SelectedParagraph!;
+
+        window.MouseDown(new Point(378, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(422, 100), RawInputModifiers.None); // ~3.35 s, inside the gap
+        Dispatcher.UIThread.RunJobs();
+
+        // Frame 99 = 3303.3 ms -> 3303 ms, exactly 67 ms before the next start.
+        Assert.Equal(3303, line.EndTime.TotalMilliseconds);
+
+        window.MouseUp(new Point(422, 100), MouseButton.Left, RawInputModifiers.None);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void ResizeLeft_ClampsToExactlyMinGap_WhenSnappingToFrames()
+    {
+        // The mirror clamp: "previous end plus gap plus 1 ms", then ceiling to a frame, opened the
+        // gap to 3 frames when the next line's in-cue was dragged back toward the previous out-cue.
+        Se.Settings.Waveform.SnapToFrames = true;
+        Se.Settings.General.CurrentFrameRate = 25;
+
+        var second = Line(4, 6);
+        var (window, av, _) = Open(Line(1, 3), second);
+        av.MinGapSeconds = 0.08;
+
+        // Left edge of the second line at x = 4 s * 126 = 504; drag it to ~3.05 s, inside the gap.
+        window.MouseDown(new Point(504, 100), MouseButton.Left, RawInputModifiers.None);
+        window.MouseMove(new Point(384, 100), RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+
+        // 3000 ms + 2 frames = frame 77 = 3080 ms (the old clamp gave frame 78 = 3120 ms).
+        Assert.Equal(3080, second.StartTime.TotalMilliseconds);
+
+        window.MouseUp(new Point(384, 100), MouseButton.Left, RawInputModifiers.None);
+        window.Close();
     }
 }


### PR DESCRIPTION
## Summary

In a frame project with a 2-frame minimum gap, dragging the previous line's end toward the next line's in-cue on the waveform stops at 3 frames.

**Cause:** the resize clamp in `AudioVisualizer.OnPointerMoved` set the end to "next start minus gap **minus 1 ms**" and then floored it to a frame, so the 1 ms nudge always cost a whole frame. The start-cue clamp mirrored it (plus 1 ms, then ceiling). Only visible with the waveform "Snap to frames" setting on.

**Fix:**
- Drop the 1 ms nudges so the clamp lands exactly on the minimum gap, like the keyboard frame-nudge and whole-line-move clamps already do.
- `SnapToFrameFloor` / `SnapToFrameCeil` now compare candidate frames in whole milliseconds (the resolution times are stored at). Without this, a bound built from a stored time at a non-integer frame rate still dropped a frame: at 29.97 fps frame 101 is stored as 3370 ms, not 3370.03, and a plain floor of (3370 − 67) / 33.37 = 98.99 gave frame 98 instead of 99. This also hardens the whole-line-move clamp, which uses the same helpers.

## Tests

Three regression tests in `AudioVisualizerDragTests` (headless pointer drags): right-edge clamp at 25 fps, right-edge clamp at 29.97 fps with whole-ms stored times, and the mirrored left-edge clamp. All three fail on `main` and pass with the fix; the rest of the drag, duration-box and frame-nudge tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
