### PR TITLE
Image-based edit: add "Move captions" and "Remove fade in/out" (BDSup2Sub features)

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -76,6 +76,7 @@ using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAdjustDuration;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryApplyDurationLimits;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryAppendSubtitle;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryChangeResolution;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryMoveCaptions;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryResizeImages;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinarySettings;
 using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.SetText;
@@ -366,6 +367,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<BinaryApplyDurationLimitsViewModel>();
         collection.AddTransient<BinaryAppendSubtitleViewModel>();
         collection.AddTransient<BinaryChangeResolutionViewModel>();
+        collection.AddTransient<BinaryMoveCaptionsViewModel>();
         collection.AddTransient<BinaryEditViewModel>();
         collection.AddTransient<BinaryOcrCharacterAddViewModel>();
         collection.AddTransient<BinaryOcrCharacterHistoryViewModel>();

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -1640,6 +1640,60 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task MoveCaptions()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (Subtitles.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Information,
+                Se.Language.Tools.ImageBasedEdit.NoImageSubtitlesLoaded,
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        await ShowMoveCaptions(Subtitles.ToList());
+    }
+
+    [RelayCommand]
+    private async Task MoveCaptionsSelectedLines()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var selectedItems = GetSelectedItems();
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        await ShowMoveCaptions(selectedItems);
+        ApplyGridSelection(selectedItems);
+    }
+
+    private async Task ShowMoveCaptions(List<BinarySubtitleItem> items)
+    {
+        // Open on the letterbox the position monitor already shows.
+        var ratioKey = SelectedLetterboxRatio.SettingsKey;
+        var barHeight = _currentLetterboxBarHeight;
+        var result = await _windowService.ShowDialogAsync<BinaryMoveCaptions.BinaryMoveCaptionsWindow, BinaryMoveCaptions.BinaryMoveCaptionsViewModel>(
+            Window!, vm => vm.Initialize(items, ScreenWidth, ScreenHeight, ratioKey, barHeight));
+
+        if (!result.OkPressed)
+        {
+            return;
+        }
+
+        UpdateOverlayPosition();
+        RefreshPositionMonitor();
+    }
+
+    [RelayCommand]
     private async Task ResizeImagesSelectedLines()
     {
         if (Window == null)

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditViewModel.cs
@@ -2516,6 +2516,64 @@ public partial class BinaryEditViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task RemoveFades()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (Subtitles.Count == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Information,
+                Se.Language.Tools.ImageBasedEdit.NoImageSubtitlesLoaded,
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var selectedItem = SelectedSubtitle;
+        var items = Subtitles.ToList();
+        var removed = FadeRemover.RemoveFades(items);
+        if (removed == 0)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Information,
+                Se.Language.Tools.ImageBasedEdit.RemoveFadeInOutNothingFound,
+                MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        foreach (var item in Subtitles)
+        {
+            item.PropertyChanged -= OnSubtitleItemPropertyChanged;
+        }
+
+        Subtitles.Clear();
+        foreach (var item in items)
+        {
+            Subtitles.Add(item);
+            item.PropertyChanged += OnSubtitleItemPropertyChanged;
+        }
+
+        Renumber();
+        _isDirty = true;
+        if (SubtitleGrid != null)
+        {
+            var newIndex = selectedItem != null ? Subtitles.IndexOf(selectedItem) : -1;
+            SubtitleGrid.ItemsSource = null;
+            SubtitleGrid.ItemsSource = Subtitles;
+            SelectAndScrollToRow(Math.Max(0, newIndex));
+        }
+
+        UpdateOverlayPosition();
+        RefreshPositionMonitor();
+        RefreshStatusText();
+
+        await MessageBox.Show(Window, Se.Language.General.Information,
+            string.Format(Se.Language.Tools.ImageBasedEdit.RemoveFadeInOutXLinesRemoved, removed),
+            MessageBoxButtons.OK, MessageBoxIcon.Information);
+    }
+
+    [RelayCommand]
     private void SortByStartTime()
     {
         var selectedItem = SelectedSubtitle;

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -360,6 +360,11 @@ public class BinaryEditWindow : Window
                 },
                 new MenuItem
                 {
+                    Header = Se.Language.Tools.ImageBasedEdit.RemoveFadeInOut,
+                    Command = vm.RemoveFadesCommand,
+                },
+                new MenuItem
+                {
                     Header = Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot,
                     Command = vm.AppendSubtitleCommand,
                 },

--- a/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryEditWindow.cs
@@ -320,6 +320,11 @@ public class BinaryEditWindow : Window
                     Header = Se.Language.General.VideoResolution + "...",
                     Command = vm.ChangeResolutionCommand,
                 },
+                new MenuItem
+                {
+                    Header = Se.Language.Tools.ImageBasedEdit.MoveCaptionsDotDotDot,
+                    Command = vm.MoveCaptionsCommand,
+                },
                 new Separator(),
                 new MenuItem
                 {
@@ -613,6 +618,15 @@ public class BinaryEditWindow : Window
         };
         flyout.Items.Add(menuItemCropSelectedLines);
         menuItemCropSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
+
+        var menuItemMoveCaptionsSelectedLines = new MenuItem
+        {
+            Header = Se.Language.Tools.ImageBasedEdit.MoveCaptionsDotDotDot,
+            DataContext = vm,
+            Command = vm.MoveCaptionsSelectedLinesCommand,
+        };
+        flyout.Items.Add(menuItemMoveCaptionsSelectedLines);
+        menuItemMoveCaptionsSelectedLines.Bind(MenuItem.IsVisibleProperty, new Binding(nameof(vm.HasSelection)));
 
         flyout.Items.Add(new Separator());
 

--- a/src/ui/Features/Shared/BinaryEdit/BinaryMoveCaptions/BinaryMoveCaptionsViewModel.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryMoveCaptions/BinaryMoveCaptionsViewModel.cs
@@ -1,0 +1,207 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryMoveCaptions;
+
+public enum MoveCaptionsMode
+{
+    /// <summary>Move captions into the letterbox bars (above/below the picture).</summary>
+    IntoBars,
+
+    /// <summary>Move captions out of the letterbox bars, inside the active picture.</summary>
+    IntoPicture,
+}
+
+/// <summary>
+/// BDSup2Sub's "move all captions": for letterboxed (cinemascope) video, push every caption
+/// either into the black bars or back inside the active picture, keeping a fixed offset from
+/// the bar edge. A caption whose centre is in the upper half of the screen goes to the top
+/// edge, the rest go to the bottom edge - the same rule BDSup2Sub uses.
+/// </summary>
+public partial class BinaryMoveCaptionsViewModel : ObservableObject
+{
+    [ObservableProperty] private ObservableCollection<LetterboxRatioItem> _letterboxRatios;
+    [ObservableProperty] private LetterboxRatioItem _selectedLetterboxRatio;
+    [ObservableProperty] private int _barHeight;
+    [ObservableProperty] private bool _isBarHeightEditable;
+    [ObservableProperty] private bool _moveIntoBars;
+    [ObservableProperty] private bool _moveIntoPicture;
+    [ObservableProperty] private int _offset;
+    [ObservableProperty] private string _infoText;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    private List<BinarySubtitleItem> _subtitles = new();
+    private int _screenWidth;
+    private int _screenHeight;
+    private bool _isSyncingRatio;
+
+    public BinaryMoveCaptionsViewModel()
+    {
+        var lang = Se.Language.Tools.ImageBasedEdit;
+        _letterboxRatios = new ObservableCollection<LetterboxRatioItem>
+        {
+            new("1.66:1", 1.66, false, "1.66"),
+            new("1.85:1", 1.85, false, "1.85"),
+            new("2.00:1", 2.00, false, "2.00"),
+            new("2.20:1", 2.20, false, "2.20"),
+            new("2.35:1", 2.35, false, "2.35"),
+            new("2.39:1", 2.39, false, "2.39"),
+            new("2.40:1", 2.40, false, "2.40"),
+            new(lang.LetterboxCustom, null, true, "custom"),
+        };
+        _selectedLetterboxRatio = _letterboxRatios[5];
+        _moveIntoBars = true;
+        _offset = 10;
+        _infoText = string.Empty;
+    }
+
+    /// <summary>
+    /// <paramref name="currentRatioKey"/> and <paramref name="currentBarHeight"/> come from the
+    /// main window's position monitor so the dialog opens on the letterbox the user already set up.
+    /// </summary>
+    public void Initialize(List<BinarySubtitleItem> subtitles, int screenWidth, int screenHeight, string? currentRatioKey, int currentBarHeight)
+    {
+        _subtitles = subtitles;
+        _screenWidth = screenWidth;
+        _screenHeight = screenHeight;
+
+        var preset = LetterboxRatios.FirstOrDefault(r => r.SettingsKey == currentRatioKey);
+        if (preset != null)
+        {
+            SelectedLetterboxRatio = preset;
+            if (preset.IsCustom)
+            {
+                BarHeight = Math.Max(0, currentBarHeight);
+            }
+        }
+        else
+        {
+            // Screen size was unknown in the constructor - recompute the preset's bar height now.
+            OnSelectedLetterboxRatioChanged(SelectedLetterboxRatio);
+        }
+
+        UpdateInfo();
+    }
+
+    partial void OnSelectedLetterboxRatioChanged(LetterboxRatioItem value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        IsBarHeightEditable = value.IsCustom;
+        if (!value.IsCustom && value.Ratio.HasValue)
+        {
+            _isSyncingRatio = true;
+            BarHeight = PositionMonitorLogic.CalculateBarHeight(_screenWidth, _screenHeight, value.Ratio.Value);
+            _isSyncingRatio = false;
+        }
+
+        UpdateInfo();
+    }
+
+    partial void OnBarHeightChanged(int value)
+    {
+        if (!_isSyncingRatio)
+        {
+            UpdateInfo();
+        }
+    }
+
+    partial void OnOffsetChanged(int value) => UpdateInfo();
+    partial void OnMoveIntoBarsChanged(bool value) => UpdateInfo();
+    partial void OnMoveIntoPictureChanged(bool value) => UpdateInfo();
+
+    private MoveCaptionsMode Mode => MoveIntoPicture ? MoveCaptionsMode.IntoPicture : MoveCaptionsMode.IntoBars;
+
+    private void UpdateInfo()
+    {
+        var lang = Se.Language.Tools.ImageBasedEdit;
+        var moving = _subtitles.Count(s => GetNewY(s, _screenHeight, BarHeight, Offset, Mode) != s.Y);
+        InfoText = string.Format(lang.LetterboxBarHeightXPxYOfZCaptionsWillMove, BarHeight, moving, _subtitles.Count);
+    }
+
+    /// <summary>
+    /// Computes the new Y for one caption. Captions centred in the upper half go to the top
+    /// edge, the rest to the bottom edge. The result is clamped so the image stays on screen.
+    /// </summary>
+    public static int GetNewY(BinarySubtitleItem item, int screenHeight, int barHeight, int offset, MoveCaptionsMode mode)
+    {
+        var height = item.Bitmap?.PixelSize.Height ?? 0;
+        if (screenHeight <= 0 || height <= 0)
+        {
+            return item.Y;
+        }
+
+        var isTop = item.Y + height / 2.0 < screenHeight / 2.0;
+        int y;
+        if (mode == MoveCaptionsMode.IntoBars)
+        {
+            // Sit against the outer screen edge, "offset" pixels in.
+            y = isTop ? offset : screenHeight - height - offset;
+        }
+        else
+        {
+            // Sit against the picture edge, "offset" pixels inside the active picture.
+            y = isTop ? barHeight + offset : screenHeight - barHeight - height - offset;
+        }
+
+        return Math.Clamp(y, 0, Math.Max(0, screenHeight - height));
+    }
+
+    public static void Apply(IEnumerable<BinarySubtitleItem> subtitles, int screenHeight, int barHeight, int offset, MoveCaptionsMode mode)
+    {
+        foreach (var item in subtitles)
+        {
+            item.Y = GetNewY(item, screenHeight, barHeight, offset, mode);
+        }
+    }
+
+    [RelayCommand]
+    private async Task Ok()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (BarHeight < 0 || BarHeight * 2 >= _screenHeight)
+        {
+            await MessageBox.Show(Window, Se.Language.General.Error,
+                string.Format(Se.Language.General.PleaseEnterAValidValueForX, Se.Language.Tools.ImageBasedEdit.BarHeightPx),
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        Apply(_subtitles, _screenHeight, BarHeight, Offset, Mode);
+        OkPressed = true;
+        Window.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/BinaryMoveCaptions/BinaryMoveCaptionsWindow.cs
+++ b/src/ui/Features/Shared/BinaryEdit/BinaryMoveCaptions/BinaryMoveCaptionsWindow.cs
@@ -1,0 +1,84 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryMoveCaptions;
+
+public class BinaryMoveCaptionsWindow : Window
+{
+    public BinaryMoveCaptionsWindow(BinaryMoveCaptionsViewModel vm)
+    {
+        var l = Se.Language.Tools.ImageBasedEdit;
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = l.MoveCaptions;
+        Width = 460;
+        Height = 400;
+        CanResize = false;
+        vm.Window = this;
+        DataContext = vm;
+
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 6,
+        };
+
+        panel.Children.Add(new TextBlock { Text = l.Letterbox, FontWeight = Avalonia.Media.FontWeight.Bold });
+        var comboBoxRatio = UiUtil.MakeComboBox(vm.LetterboxRatios, vm, nameof(vm.SelectedLetterboxRatio), null);
+        comboBoxRatio.HorizontalAlignment = HorizontalAlignment.Stretch;
+        panel.Children.Add(comboBoxRatio);
+
+        var barHeightRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8 };
+        barHeightRow.Children.Add(UiUtil.MakeLabel(l.BarHeightPx));
+        var numericBarHeight = UiUtil.MakeNumericUpDownInt(0, 8192, 0, 130, vm, nameof(vm.BarHeight));
+        numericBarHeight.Bind(InputElement.IsEnabledProperty, new Binding(nameof(vm.IsBarHeightEditable)));
+        barHeightRow.Children.Add(numericBarHeight);
+        panel.Children.Add(barHeightRow);
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = l.MoveCaptionsTo,
+            FontWeight = Avalonia.Media.FontWeight.Bold,
+            Margin = new Thickness(0, 10, 0, 0),
+        });
+        panel.Children.Add(UiUtil.MakeRadioButton(l.MoveCaptionsIntoBars, vm, nameof(vm.MoveIntoBars), "mode"));
+        panel.Children.Add(UiUtil.MakeRadioButton(l.MoveCaptionsIntoPicture, vm, nameof(vm.MoveIntoPicture), "mode"));
+
+        var offsetRow = new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Margin = new Thickness(0, 10, 0, 0) };
+        offsetRow.Children.Add(UiUtil.MakeLabel(l.MoveCaptionsOffset));
+        offsetRow.Children.Add(UiUtil.MakeNumericUpDownInt(0, 8192, 10, 130, vm, nameof(vm.Offset)));
+        panel.Children.Add(offsetRow);
+
+        panel.Children.Add(new TextBlock
+        {
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.InfoText)),
+            TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+            Margin = new Thickness(0, 16, 0, 0),
+            FontSize = 12,
+        });
+
+        var mainGrid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Star),
+                new RowDefinition(GridLength.Auto),
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+        };
+        mainGrid.Add(panel, 0, 0);
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        mainGrid.Add(UiUtil.MakeButtonBar(buttonOk, buttonCancel), 1, 0);
+
+        Content = mainGrid;
+
+        UiUtil.FocusOnFirstActivation(this, comboBoxRatio); // an input, not an action button - a focused button clicks on bare Space
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/FadeRemover.cs
+++ b/src/ui/Features/Shared/BinaryEdit/FadeRemover.cs
@@ -1,0 +1,207 @@
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+
+/// <summary>
+/// BDSup2Sub's "remove fade in/out": authoring tools render a fade as a run of back-to-back
+/// captions that share one image and differ only in alpha. Playing that back after editing
+/// (or in a player that ignores palette updates) gives a flicker of near-identical lines, so
+/// collapse each run into one caption that spans the whole time and uses the most opaque image.
+/// </summary>
+public static class FadeRemover
+{
+    /// <summary>Maximum gap between two captions for them to count as one fade.</summary>
+    public const int MaxGapMs = 50;
+
+    /// <summary>Positions may drift a pixel or two between the fade steps.</summary>
+    private const int MaxPositionDrift = 2;
+
+    /// <summary>Per-channel colour tolerance after undoing premultiplication.</summary>
+    private const int ColorTolerance = 16;
+
+    /// <summary>Unpremultiplied colour of very transparent pixels is noise - only compare alpha coverage there.</summary>
+    private const int MinAlphaForColorCompare = 32;
+
+    /// <summary>Fraction of pixels that may differ (anti-aliased edges) and still be the same image.</summary>
+    private const double MaxMismatchFraction = 0.005;
+
+    /// <summary>
+    /// Collapses fade runs in <paramref name="subtitles"/> in place. Removed items have their
+    /// bitmaps disposed. Returns the number of items removed.
+    /// </summary>
+    public static int RemoveFades(IList<BinarySubtitleItem> subtitles)
+    {
+        var removed = 0;
+        var i = 0;
+        while (i < subtitles.Count - 1)
+        {
+            var keep = subtitles[i];
+            if (keep.Bitmap == null)
+            {
+                i++;
+                continue;
+            }
+
+            using var keepSk = keep.Bitmap.ToSkBitmap();
+            var bestOpacity = TotalAlpha(keepSk);
+            BinarySubtitleItem? best = null;
+            var runEnd = i;
+
+            for (var j = i + 1; j < subtitles.Count; j++)
+            {
+                var prev = subtitles[j - 1];
+                var cur = subtitles[j];
+                if (cur.Bitmap == null || !IsAdjacent(prev, cur))
+                {
+                    break;
+                }
+
+                using var curSk = cur.Bitmap.ToSkBitmap();
+                if (!IsSameImage(keepSk, curSk))
+                {
+                    break;
+                }
+
+                runEnd = j;
+                var opacity = TotalAlpha(curSk);
+                if (opacity > bestOpacity)
+                {
+                    bestOpacity = opacity;
+                    best = cur;
+                }
+            }
+
+            if (runEnd == i)
+            {
+                i++;
+                continue;
+            }
+
+            var last = subtitles[runEnd];
+            keep.EndTime = last.EndTime;
+            if (best != null)
+            {
+                // Swap the most opaque image into the surviving line (a fade-in starts nearly invisible).
+                var old = keep.Bitmap;
+                keep.Bitmap = best.Bitmap;
+                keep.X = best.X;
+                keep.Y = best.Y;
+                best.Bitmap = old;
+            }
+
+            for (var j = runEnd; j > i; j--)
+            {
+                var item = subtitles[j];
+                subtitles.RemoveAt(j);
+                item.Bitmap?.Dispose();
+                item.Bitmap = null;
+                removed++;
+            }
+
+            i++;
+        }
+
+        return removed;
+    }
+
+    public static bool IsAdjacent(BinarySubtitleItem prev, BinarySubtitleItem cur)
+    {
+        var gap = Math.Abs((cur.StartTime - prev.EndTime).TotalMilliseconds);
+        return gap <= MaxGapMs
+               && Math.Abs(prev.X - cur.X) <= MaxPositionDrift
+               && Math.Abs(prev.Y - cur.Y) <= MaxPositionDrift;
+    }
+
+    /// <summary>
+    /// True when the two bitmaps show the same picture, ignoring how transparent it is: same size,
+    /// same alpha coverage, same unpremultiplied colours where the pixel is visible enough to judge.
+    /// </summary>
+    public static bool IsSameImage(SKBitmap a, SKBitmap b)
+    {
+        if (a.Width != b.Width || a.Height != b.Height || a.Width == 0 || a.Height == 0)
+        {
+            return false;
+        }
+
+        if (a.ColorType != SKColorType.Bgra8888 || b.ColorType != SKColorType.Bgra8888)
+        {
+            return false;
+        }
+
+        var maxMismatches = (int)(a.Width * a.Height * MaxMismatchFraction);
+        var mismatches = 0;
+
+        unsafe
+        {
+            for (var y = 0; y < a.Height; y++)
+            {
+                var pa = (byte*)a.GetPixels() + y * a.RowBytes;
+                var pb = (byte*)b.GetPixels() + y * b.RowBytes;
+                for (var x = 0; x < a.Width; x++, pa += 4, pb += 4)
+                {
+                    var alphaA = pa[3];
+                    var alphaB = pb[3];
+                    if ((alphaA == 0) != (alphaB == 0))
+                    {
+                        if (++mismatches > maxMismatches)
+                        {
+                            return false;
+                        }
+
+                        continue;
+                    }
+
+                    if (alphaA < MinAlphaForColorCompare || alphaB < MinAlphaForColorCompare)
+                    {
+                        continue;
+                    }
+
+                    if (!ChannelMatches(pa[0], alphaA, pb[0], alphaB, a.AlphaType, b.AlphaType)
+                        || !ChannelMatches(pa[1], alphaA, pb[1], alphaB, a.AlphaType, b.AlphaType)
+                        || !ChannelMatches(pa[2], alphaA, pb[2], alphaB, a.AlphaType, b.AlphaType))
+                    {
+                        if (++mismatches > maxMismatches)
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ChannelMatches(byte ca, byte alphaA, byte cb, byte alphaB, SKAlphaType typeA, SKAlphaType typeB)
+    {
+        var va = typeA == SKAlphaType.Premul ? ca * 255 / alphaA : ca;
+        var vb = typeB == SKAlphaType.Premul ? cb * 255 / alphaB : cb;
+        return Math.Abs(va - vb) <= ColorTolerance;
+    }
+
+    private static long TotalAlpha(SKBitmap bitmap)
+    {
+        if (bitmap.ColorType != SKColorType.Bgra8888)
+        {
+            return 0;
+        }
+
+        long total = 0;
+        unsafe
+        {
+            for (var y = 0; y < bitmap.Height; y++)
+            {
+                var p = (byte*)bitmap.GetPixels() + y * bitmap.RowBytes + 3;
+                for (var x = 0; x < bitmap.Width; x++, p += 4)
+                {
+                    total += *p;
+                }
+            }
+        }
+
+        return total;
+    }
+}

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -56,6 +56,7 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, l.ApplyDurationLimits, vm.ApplyDurationLimitsCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.SortByStartTime, vm.SortByStartTimeCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.RemoveFadeInOut, vm.RemoveFadesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AppendSubtitleDotDotDot, vm.AppendSubtitleCommand);
         root.Items.Add(new NativeMenuItem(Clean(l.Tools)) { Menu = toolsMenu });
 

--- a/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
+++ b/src/ui/Features/Shared/BinaryEdit/InitNativeMacMenuBinaryEdit.cs
@@ -46,6 +46,7 @@ public static class InitNativeMacMenuBinaryEdit
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.ResizeImagesDotDotDot, vm.ResizeImagesCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.CropImages, vm.CropCommand);
         Add(toolsMenu, Se.Language.General.VideoResolution + "...", vm.ChangeResolutionCommand);
+        Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.MoveCaptionsDotDotDot, vm.MoveCaptionsCommand);
         toolsMenu.Items.Add(new NativeMenuItemSeparator());
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustBrightnessDotDotDot, vm.AdjustBrightnessCommand);
         Add(toolsMenu, Se.Language.Tools.ImageBasedEdit.AdjustAlphaDotDotDot, vm.AdjustAlphaCommand);

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -39,6 +39,13 @@ public class LanguageImageBasedEdit
     public string LetterboxCustom { get; set; }
     public string BarHeightPx { get; set; }
     public string TitleSafePercent { get; set; }
+    public string MoveCaptions { get; set; }
+    public string MoveCaptionsDotDotDot { get; set; }
+    public string MoveCaptionsTo { get; set; }
+    public string MoveCaptionsIntoBars { get; set; }
+    public string MoveCaptionsIntoPicture { get; set; }
+    public string MoveCaptionsOffset { get; set; }
+    public string LetterboxBarHeightXPxYOfZCaptionsWillMove { get; set; }
     public string PositionSummary { get; set; }
     public string XInActivePicture { get; set; }
     public string XInTopBar { get; set; }
@@ -85,6 +92,13 @@ public class LanguageImageBasedEdit
         LetterboxCustom = "Custom bar height";
         BarHeightPx = "Bar height (px)";
         TitleSafePercent = "Title-safe (%)";
+        MoveCaptions = "Move captions";
+        MoveCaptionsDotDotDot = "Move captions...";
+        MoveCaptionsTo = "Move captions";
+        MoveCaptionsIntoBars = "Into the letterbox bars (outside the picture)";
+        MoveCaptionsIntoPicture = "Inside the picture (out of the bars)";
+        MoveCaptionsOffset = "Offset from edge (px)";
+        LetterboxBarHeightXPxYOfZCaptionsWillMove = "Bar height: {0} px - {1} of {2} captions will move";
         PositionSummary = "{0}×{1} - {2} subtitles - bar height: {3} px";
         XInActivePicture = "{0} in picture";
         XInTopBar = "{0} in top bar";

--- a/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageImageBasedEdit.cs
@@ -46,6 +46,9 @@ public class LanguageImageBasedEdit
     public string MoveCaptionsIntoPicture { get; set; }
     public string MoveCaptionsOffset { get; set; }
     public string LetterboxBarHeightXPxYOfZCaptionsWillMove { get; set; }
+    public string RemoveFadeInOut { get; set; }
+    public string RemoveFadeInOutXLinesRemoved { get; set; }
+    public string RemoveFadeInOutNothingFound { get; set; }
     public string PositionSummary { get; set; }
     public string XInActivePicture { get; set; }
     public string XInTopBar { get; set; }
@@ -99,6 +102,9 @@ public class LanguageImageBasedEdit
         MoveCaptionsIntoPicture = "Inside the picture (out of the bars)";
         MoveCaptionsOffset = "Offset from edge (px)";
         LetterboxBarHeightXPxYOfZCaptionsWillMove = "Bar height: {0} px - {1} of {2} captions will move";
+        RemoveFadeInOut = "Remove fade in/out";
+        RemoveFadeInOutXLinesRemoved = "{0} fade lines merged into the lines they belong to";
+        RemoveFadeInOutNothingFound = "No fade in/out lines found";
         PositionSummary = "{0}×{1} - {2} subtitles - bar height: {3} px";
         XInActivePicture = "{0} in picture";
         XInTopBar = "{0} in top bar";

--- a/tests/UI/Features/Shared/BinaryEdit/BinaryMoveCaptionsViewModelTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/BinaryMoveCaptionsViewModelTests.cs
@@ -1,0 +1,94 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit.BinaryMoveCaptions;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.BinaryEdit;
+
+public class BinaryMoveCaptionsViewModelTests
+{
+    private static BinarySubtitleItem MakeItem(int y, int height)
+    {
+        using var skBitmap = new SKBitmap(100, height);
+        return new BinarySubtitleItem(TimeSpan.Zero, TimeSpan.FromSeconds(1))
+        {
+            X = 0,
+            Y = y,
+            Bitmap = skBitmap.ToAvaloniaBitmap(),
+        };
+    }
+
+    [AvaloniaFact]
+    public void IntoBars_BottomCaptionSitsAgainstBottomEdge()
+    {
+        var item = MakeItem(y: 900, height: 60);
+
+        var y = BinaryMoveCaptionsViewModel.GetNewY(item, 1080, 138, 10, MoveCaptionsMode.IntoBars);
+
+        Assert.Equal(1080 - 60 - 10, y);
+    }
+
+    [AvaloniaFact]
+    public void IntoBars_TopCaptionSitsAgainstTopEdge()
+    {
+        var item = MakeItem(y: 200, height: 60);
+
+        var y = BinaryMoveCaptionsViewModel.GetNewY(item, 1080, 138, 10, MoveCaptionsMode.IntoBars);
+
+        Assert.Equal(10, y);
+    }
+
+    [AvaloniaFact]
+    public void IntoPicture_BottomCaptionSitsAboveBottomBar()
+    {
+        var item = MakeItem(y: 1010, height: 60);
+
+        var y = BinaryMoveCaptionsViewModel.GetNewY(item, 1080, 138, 10, MoveCaptionsMode.IntoPicture);
+
+        Assert.Equal(1080 - 138 - 60 - 10, y);
+    }
+
+    [AvaloniaFact]
+    public void IntoPicture_TopCaptionSitsBelowTopBar()
+    {
+        var item = MakeItem(y: 0, height: 60);
+
+        var y = BinaryMoveCaptionsViewModel.GetNewY(item, 1080, 138, 10, MoveCaptionsMode.IntoPicture);
+
+        Assert.Equal(138 + 10, y);
+    }
+
+    [AvaloniaFact]
+    public void GetNewY_ClampsSoImageStaysOnScreen()
+    {
+        var item = MakeItem(y: 500, height: 60);
+
+        var y = BinaryMoveCaptionsViewModel.GetNewY(item, 1080, 138, 5000, MoveCaptionsMode.IntoBars);
+
+        Assert.Equal(1080 - 60, y);
+    }
+
+    [Fact]
+    public void GetNewY_NoBitmapIsUntouched()
+    {
+        var item = new BinarySubtitleItem(TimeSpan.Zero, TimeSpan.FromSeconds(1)) { Y = 42 };
+
+        var y = BinaryMoveCaptionsViewModel.GetNewY(item, 1080, 138, 10, MoveCaptionsMode.IntoBars);
+
+        Assert.Equal(42, y);
+    }
+
+    [AvaloniaFact]
+    public void Apply_MovesEveryItem()
+    {
+        var top = MakeItem(y: 100, height: 40);
+        var bottom = MakeItem(y: 900, height: 40);
+
+        BinaryMoveCaptionsViewModel.Apply(new List<BinarySubtitleItem> { top, bottom }, 1080, 138, 0, MoveCaptionsMode.IntoBars);
+
+        Assert.Equal(0, top.Y);
+        Assert.Equal(1040, bottom.Y);
+    }
+}

--- a/tests/UI/Features/Shared/BinaryEdit/FadeRemoverTests.cs
+++ b/tests/UI/Features/Shared/BinaryEdit/FadeRemoverTests.cs
@@ -1,0 +1,124 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Features.Shared.BinaryEdit;
+using Nikse.SubtitleEdit.Logic;
+using SkiaSharp;
+using System.Collections.Generic;
+
+namespace UITests.Features.Shared.BinaryEdit;
+
+public class FadeRemoverTests
+{
+    /// <summary>A 20x10 white box on transparent, at the given alpha.</summary>
+    private static SKBitmap MakeBox(byte alpha, SKColor? color = null)
+    {
+        var bitmap = new SKBitmap(20, 10, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        bitmap.Erase(SKColors.Transparent);
+        var c = color ?? SKColors.White;
+        for (var y = 2; y < 8; y++)
+        {
+            for (var x = 2; x < 18; x++)
+            {
+                bitmap.SetPixel(x, y, new SKColor(c.Red, c.Green, c.Blue, alpha));
+            }
+        }
+
+        return bitmap;
+    }
+
+    private static BinarySubtitleItem MakeItem(int startMs, int endMs, byte alpha, SKColor? color = null, int x = 100, int y = 900)
+    {
+        using var sk = MakeBox(alpha, color);
+        return new BinarySubtitleItem(TimeSpan.FromMilliseconds(startMs), TimeSpan.FromMilliseconds(endMs))
+        {
+            X = x,
+            Y = y,
+            Bitmap = sk.ToAvaloniaBitmap(),
+        };
+    }
+
+    [AvaloniaFact]
+    public void FadeInRunCollapsesToOneLineWithMostOpaqueImage()
+    {
+        var items = new List<BinarySubtitleItem>
+        {
+            MakeItem(0, 40, 40),
+            MakeItem(40, 80, 120),
+            MakeItem(80, 120, 255),
+            MakeItem(120, 2000, 255),
+        };
+
+        var removed = FadeRemover.RemoveFades(items);
+
+        Assert.Equal(3, removed);
+        Assert.Single(items);
+        Assert.Equal(TimeSpan.Zero, items[0].StartTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(2000), items[0].EndTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(2000), items[0].Duration);
+        using var kept = items[0].Bitmap!.ToSkBitmap();
+        Assert.Equal(255, kept.GetPixel(10, 5).Alpha);
+    }
+
+    [AvaloniaFact]
+    public void DifferentPictureIsNotMerged()
+    {
+        var items = new List<BinarySubtitleItem>
+        {
+            MakeItem(0, 1000, 255, SKColors.White),
+            MakeItem(1000, 2000, 255, SKColors.Red),
+        };
+
+        var removed = FadeRemover.RemoveFades(items);
+
+        Assert.Equal(0, removed);
+        Assert.Equal(2, items.Count);
+    }
+
+    [AvaloniaFact]
+    public void GapLargerThanFadeThresholdIsNotMerged()
+    {
+        var items = new List<BinarySubtitleItem>
+        {
+            MakeItem(0, 1000, 255),
+            MakeItem(1500, 2000, 255),
+        };
+
+        var removed = FadeRemover.RemoveFades(items);
+
+        Assert.Equal(0, removed);
+        Assert.Equal(2, items.Count);
+    }
+
+    [AvaloniaFact]
+    public void MovedCaptionIsNotMerged()
+    {
+        var items = new List<BinarySubtitleItem>
+        {
+            MakeItem(0, 1000, 255, y: 900),
+            MakeItem(1000, 2000, 255, y: 100),
+        };
+
+        var removed = FadeRemover.RemoveFades(items);
+
+        Assert.Equal(0, removed);
+    }
+
+    [AvaloniaFact]
+    public void TwoSeparateFadesAreEachCollapsed()
+    {
+        var items = new List<BinarySubtitleItem>
+        {
+            MakeItem(0, 40, 60),
+            MakeItem(40, 1000, 255),
+            MakeItem(3000, 3040, 60, SKColors.Red),
+            MakeItem(3040, 4000, 255, SKColors.Red),
+        };
+
+        var removed = FadeRemover.RemoveFades(items);
+
+        Assert.Equal(2, removed);
+        Assert.Equal(2, items.Count);
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), items[0].EndTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(3000), items[1].StartTime);
+        Assert.Equal(TimeSpan.FromMilliseconds(4000), items[1].EndTime);
+    }
+}


### PR DESCRIPTION
Two more BDSup2Sub features (https://forum.doom9.org/showthread.php?t=145277) adapted into the image-based editor.

## Move captions
- Tools menu (all lines) and grid context menu (selected lines), plus the macOS native menu.
- Pick a letterbox ratio (1.66:1 … 2.40:1) or a custom bar height, then move captions **into the letterbox bars** or **inside the picture**, with an offset from the edge.
- Captions centred in the upper half go to the top edge, the rest to the bottom (BDSup2Sub's rule). Positions are clamped so images stay on screen.
- Opens pre-set to the letterbox ratio the position monitor is already showing.

## Remove fade in/out
- Tools menu, next to "Sort by start time".
- Runs of back-to-back captions (gap ≤ 50 ms, same size/position) showing the same picture at different alpha are collapsed into one caption spanning the run, keeping the most opaque image.
- Comparison undoes premultiplication and tolerates anti-aliased edge noise. Works on any loaded format, not only Blu-ray palette-update fades the SUP parser already merges at load.

## Tests
- `BinaryMoveCaptionsViewModelTests` (7) and `FadeRemoverTests` (5), all passing.

Strings were added to the English language class only; translated JSON files are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)