### PR TITLE
Add Transport Stream output settings to batch convert

### DIFF
--- a/src/libuilogic/BatchConvert/BatchConvertItem.cs
+++ b/src/libuilogic/BatchConvert/BatchConvertItem.cs
@@ -15,6 +15,13 @@ public partial class BatchConvertItem : ObservableObject
     public string LanguageCode { get; set; }
     public string TrackNumber { get; set; }
 
+    /// <summary>
+    /// True when <see cref="OutputFileName"/> already carries the track's language/track
+    /// token (Transport Stream file name ending template), so the converter must not append
+    /// its regular language post fix on top of it.
+    /// </summary>
+    public bool OutputFileNameIncludesLanguage { get; set; }
+
     // Typed as object? so this assembly does not pull in the UI-side
     // IOcrSubtitle (which transitively depends on Avalonia). Consumers in
     // the UI cast back to IOcrSubtitle. Phase 5 (OCR pipelines) tightens this.

--- a/src/libuilogic/BatchConvert/TransportStreamExportOverride.cs
+++ b/src/libuilogic/BatchConvert/TransportStreamExportOverride.cs
@@ -1,0 +1,86 @@
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+using System;
+
+namespace Nikse.SubtitleEdit.UiLogic.BatchConvert;
+
+/// <summary>
+/// Applies the Transport Stream screen size / position overrides to one export image
+/// (port of SE4's TsToBluRaySup.WriteTrack placement logic).
+/// </summary>
+public static class TransportStreamExportOverride
+{
+    /// <summary>
+    /// <paramref name="sourcePosition"/> is the bitmap's top-left in the source stream's
+    /// coordinates (negative = unknown). Adjusts the parameter's screen size, bitmap and
+    /// <see cref="ImageParameter.OverridePosition"/> in place.
+    /// </summary>
+    public static void Apply(ImageParameter param, SKPointI sourcePosition, TransportStreamExportSettings settings)
+    {
+        var position = sourcePosition;
+
+        if (settings.OverrideScreenSize && settings.ScreenWidth > 0 && settings.ScreenHeight > 0 &&
+            param.ScreenWidth > 0 && param.ScreenHeight > 0 &&
+            (param.ScreenWidth != settings.ScreenWidth || param.ScreenHeight != settings.ScreenHeight))
+        {
+            var widthFactor = settings.ScreenWidth / (double)param.ScreenWidth;
+            var heightFactor = settings.ScreenHeight / (double)param.ScreenHeight;
+
+            if (param.Bitmap != null)
+            {
+                var newWidth = Math.Max(1, (int)Math.Round(param.Bitmap.Width * widthFactor));
+                var newHeight = Math.Max(1, (int)Math.Round(param.Bitmap.Height * heightFactor));
+                var resized = param.Bitmap.Resize(new SKImageInfo(newWidth, newHeight), new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear));
+                if (resized != null)
+                {
+                    param.Bitmap.Dispose();
+                    param.Bitmap = resized;
+                }
+            }
+
+            if (position.X >= 0 && position.Y >= 0)
+            {
+                position = new SKPointI((int)Math.Round(position.X * widthFactor), (int)Math.Round(position.Y * heightFactor));
+            }
+
+            param.ScreenWidth = settings.ScreenWidth;
+            param.ScreenHeight = settings.ScreenHeight;
+        }
+
+        var bitmapWidth = param.Bitmap?.Width ?? 0;
+        var bitmapHeight = param.Bitmap?.Height ?? 0;
+
+        if (settings.OverrideXPosition || settings.OverrideYPosition)
+        {
+            var x = position.X;
+            var y = position.Y;
+
+            if (settings.OverrideXPosition)
+            {
+                var marginX = (int)Math.Round(settings.HMarginPercent * param.ScreenWidth / 100.0);
+                x = (int)Math.Round(param.ScreenWidth / 2.0 - bitmapWidth / 2.0);
+                if (string.Equals(settings.HAlign, TransportStreamExportSettings.HAlignLeft, StringComparison.OrdinalIgnoreCase))
+                {
+                    x = marginX;
+                }
+                else if (string.Equals(settings.HAlign, TransportStreamExportSettings.HAlignRight, StringComparison.OrdinalIgnoreCase))
+                {
+                    x = param.ScreenWidth - marginX - bitmapWidth;
+                }
+            }
+
+            if (settings.OverrideYPosition)
+            {
+                var marginY = (int)Math.Round(settings.BottomMarginPercent * param.ScreenHeight / 100.0);
+                y = param.ScreenHeight - marginY - bitmapHeight;
+            }
+
+            // The axis we did not touch may be unknown (-1): then let the export handler
+            // place the image by its alignment rather than feeding it a negative coordinate.
+            param.OverridePosition = x >= 0 && y >= 0 ? new SKPointI(x, y) : null;
+            return;
+        }
+
+        param.OverridePosition = position.X >= 0 && position.Y >= 0 ? position : null;
+    }
+}

--- a/src/libuilogic/BatchConvert/TransportStreamExportSettings.cs
+++ b/src/libuilogic/BatchConvert/TransportStreamExportSettings.cs
@@ -1,0 +1,48 @@
+namespace Nikse.SubtitleEdit.UiLogic.BatchConvert;
+
+/// <summary>
+/// Batch convert's Transport Stream output settings (SE4's "TS settings..." dialog): how
+/// DVB image tracks are placed when exported to an image based format, the file name
+/// ending template for each extracted track, and the teletext-only filter.
+/// </summary>
+public class TransportStreamExportSettings
+{
+    public const string HAlignLeft = "left";
+    public const string HAlignCenter = "center";
+    public const string HAlignRight = "right";
+
+    public const string PlaceholderTwoLetter = "{two-letter-country-code}";
+    public const string PlaceholderTwoLetterUppercase = "{two-letter-country-code-uppercase}";
+    public const string PlaceholderThreeLetter = "{three-letter-country-code}";
+    public const string PlaceholderThreeLetterUppercase = "{three-letter-country-code-uppercase}";
+
+    /// <summary>Replace the DVB subtitle's own X with a horizontal alignment + margin.</summary>
+    public bool OverrideXPosition { get; set; }
+
+    /// <summary>"left", "center" or "right" (see the HAlign* constants).</summary>
+    public string HAlign { get; set; } = HAlignCenter;
+
+    /// <summary>Left/right margin in percent of the screen width (used for left/right alignment).</summary>
+    public int HMarginPercent { get; set; } = 5;
+
+    /// <summary>Replace the DVB subtitle's own Y with a bottom margin.</summary>
+    public bool OverrideYPosition { get; set; }
+
+    /// <summary>Bottom margin in percent of the screen height.</summary>
+    public int BottomMarginPercent { get; set; } = 5;
+
+    /// <summary>Scale the DVB subtitle's screen size (and bitmaps + positions) to ScreenWidth x ScreenHeight.</summary>
+    public bool OverrideScreenSize { get; set; }
+    public int ScreenWidth { get; set; } = 1920;
+    public int ScreenHeight { get; set; } = 1080;
+
+    /// <summary>
+    /// Appended to the base file name (before the extension) for every track pulled out of a
+    /// Transport Stream. Supports the Placeholder* tokens. Empty = batch convert's regular
+    /// language post fix applies instead.
+    /// </summary>
+    public string FileNameAppend { get; set; } = "." + PlaceholderTwoLetter;
+
+    /// <summary>Skip DVB image tracks - only teletext (and other text) tracks are converted.</summary>
+    public bool OnlyTeletext { get; set; }
+}

--- a/src/libuilogic/BatchConvert/TransportStreamFileNameEnding.cs
+++ b/src/libuilogic/BatchConvert/TransportStreamFileNameEnding.cs
@@ -1,0 +1,72 @@
+using Nikse.SubtitleEdit.Core.Common;
+using System.Globalization;
+
+namespace Nikse.SubtitleEdit.UiLogic.BatchConvert;
+
+/// <summary>
+/// Expands <see cref="TransportStreamExportSettings.FileNameAppend"/> for one track.
+/// </summary>
+public static class TransportStreamFileNameEnding
+{
+    /// <summary>
+    /// Builds the ending for a track. <paramref name="languageCode"/> is the track's language
+    /// as found in the stream (two- or three-letter, may be empty); when it is empty the
+    /// <paramref name="trackId"/> (PID or teletext page) stands in for both codes, so two
+    /// language-less tracks never collide.
+    /// </summary>
+    public static string Format(string? template, string? languageCode, int trackId)
+    {
+        if (string.IsNullOrEmpty(template))
+        {
+            return string.Empty;
+        }
+
+        var twoLetter = string.Empty;
+        var threeLetter = string.Empty;
+        var code = (languageCode ?? string.Empty).Trim().ToLowerInvariant();
+        if (code.Length == 3)
+        {
+            threeLetter = code;
+            twoLetter = Iso639Dash2LanguageCode.GetTwoLetterCodeFromThreeLetterCode(code);
+        }
+        else if (code.Length == 2)
+        {
+            twoLetter = code;
+            threeLetter = Iso639Dash2LanguageCode.GetThreeLetterCodeFromTwoLetterCode(code);
+        }
+        else if (code.Length > 0)
+        {
+            twoLetter = code;
+            threeLetter = code;
+        }
+
+        if (string.IsNullOrEmpty(twoLetter))
+        {
+            twoLetter = threeLetter;
+        }
+
+        if (string.IsNullOrEmpty(threeLetter))
+        {
+            threeLetter = twoLetter;
+        }
+
+        if (string.IsNullOrEmpty(twoLetter))
+        {
+            var id = trackId.ToString(CultureInfo.InvariantCulture);
+            twoLetter = id;
+            threeLetter = id;
+        }
+
+        return template
+            .Replace(TransportStreamExportSettings.PlaceholderTwoLetterUppercase, twoLetter.ToUpperInvariant())
+            .Replace(TransportStreamExportSettings.PlaceholderThreeLetterUppercase, threeLetter.ToUpperInvariant())
+            .Replace(TransportStreamExportSettings.PlaceholderTwoLetter, twoLetter)
+            .Replace(TransportStreamExportSettings.PlaceholderThreeLetter, threeLetter);
+    }
+
+    /// <summary>Sample shown in the settings dialog: "MyVideoFile" + ending + ".sup" with the tokens filled in.</summary>
+    public static string MakeSample(string? template)
+    {
+        return "MyVideoFile" + Format(template, "eng", 0) + ".sup";
+    }
+}

--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -354,6 +354,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<BatchConvertAssaViewModel>();
         collection.AddTransient<BatchConvertFixCommonErrorsSettingsViewModel>();
         collection.AddTransient<BatchConvertSettingsViewModel>();
+        collection.AddTransient<Features.Tools.BatchConvert.BatchConvertTsSettingsViewModel>();
         collection.AddTransient<BatchConvertViewModel>();
         collection.AddTransient<BatchErrorListViewModel>();
         collection.AddTransient<BeautifyTimeCodesViewModel>();

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertItemSplitter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertItemSplitter.cs
@@ -1,8 +1,10 @@
 ﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.ContainerFormats.TransportStream;
 using Nikse.SubtitleEdit.Features.Ocr.OcrSubtitle;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.BatchConvert;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 
@@ -17,6 +19,11 @@ public class BatchConvertTransportStreamSplitter : IBatchConvertItemSplitter
 {
     public List<BatchConvertItem> LoadTransportStream(BatchConvertItem item, CancellationToken cancellationToken)
     {
+        return LoadTransportStream(item, Se.Settings.Tools.BatchConvert.GetTransportStreamExportSettings(), cancellationToken);
+    }
+
+    public static List<BatchConvertItem> LoadTransportStream(BatchConvertItem item, TransportStreamExportSettings tsSettings, CancellationToken cancellationToken)
+    {
         var result = new List<BatchConvertItem>();
 
         var tsParser = new TransportStreamParser();
@@ -25,44 +32,34 @@ public class BatchConvertTransportStreamSplitter : IBatchConvertItemSplitter
         var programMapTableParser = new ProgramMapTableParser();
         programMapTableParser.Parse(item.FileName); // get languages
 
-        foreach (var packetId in tsParser.SubtitlePacketIds)
+        if (!tsSettings.OnlyTeletext)
         {
-            var language = string.Empty;
-            if (programMapTableParser.GetSubtitlePacketIds().Count > 0)
+            foreach (var packetId in tsParser.SubtitlePacketIds)
             {
-                language = programMapTableParser.GetSubtitleLanguage(packetId);
-            }
-
-            var subtitles = tsParser.GetDvbSubtitles(packetId);
-            if (subtitles.Count > 0)
-            {
-                result.Add(new BatchConvertItem
+                var language = string.Empty;
+                if (programMapTableParser.GetSubtitlePacketIds().Count > 0)
                 {
-                    Size = item.Size,
-                    Format = item.Format,
-                    FileName = item.FileName,
-                    LanguageCode = language,
-                    ImageSubtitle = new OcrSubtitleTransportStream(subtitles),
-                });
+                    language = programMapTableParser.GetSubtitleLanguage(packetId);
+                }
+
+                var subtitles = tsParser.GetDvbSubtitles(packetId);
+                if (subtitles.Count > 0)
+                {
+                    result.Add(MakeTrackItem(item, tsSettings, language, packetId, packetId, subtitle: null, new OcrSubtitleTransportStream(subtitles)));
+                }
             }
         }
 
         // One PID can carry several teletext subtitle pages (e.g. 888 + 889 for a second
         // language); every page is its own subtitle, so do not stop at the first one.
-        foreach (var pages in tsParser.TeletextSubtitlesLookup.Values)
+        foreach (var pidAndPages in tsParser.TeletextSubtitlesLookup)
         {
-            foreach (var paragraphs in pages.Values)
+            var language = programMapTableParser.GetSubtitleLanguage(pidAndPages.Key) ?? string.Empty;
+            foreach (var pageAndParagraphs in pidAndPages.Value)
             {
-                if (paragraphs.Count > 0)
+                if (pageAndParagraphs.Value.Count > 0)
                 {
-                    result.Add(new BatchConvertItem
-                    {
-                        Size = item.Size,
-                        Format = item.Format,
-                        FileName = item.FileName,
-                        Subtitle = new Subtitle(paragraphs),
-                        LanguageCode = string.Empty,
-                    });
+                    result.Add(MakeTrackItem(item, tsSettings, language, pidAndPages.Key, pageAndParagraphs.Key, new Subtitle(pageAndParagraphs.Value), imageSubtitle: null));
                 }
             }
         }
@@ -82,17 +79,39 @@ public class BatchConvertTransportStreamSplitter : IBatchConvertItemSplitter
                     languageCodes.TryGetValue(language.Key, out languageCode);
                 }
 
-                result.Add(new BatchConvertItem
-                {
-                    Size = item.Size,
-                    Format = item.Format,
-                    FileName = item.FileName,
-                    Subtitle = new Subtitle(language.Value),
-                    LanguageCode = languageCode ?? string.Empty,
-                });
+                result.Add(MakeTrackItem(item, tsSettings, languageCode ?? string.Empty, aribPid.Key, language.Key, new Subtitle(language.Value), imageSubtitle: null));
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// One batch item per extracted track. With a file name ending template the output name is
+    /// fixed here ("video" + ".en" + ".ts" - the converter swaps the extension), and the
+    /// converter's own language post fix is switched off so the token is not added twice.
+    /// </summary>
+    private static BatchConvertItem MakeTrackItem(BatchConvertItem source, TransportStreamExportSettings tsSettings, string language, int pid, int trackId, Subtitle? subtitle, OcrSubtitleTransportStream? imageSubtitle)
+    {
+        var trackItem = new BatchConvertItem
+        {
+            Size = source.Size,
+            Format = source.Format,
+            FileName = source.FileName,
+            LanguageCode = language,
+            TrackNumber = pid.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            Subtitle = subtitle,
+            ImageSubtitle = imageSubtitle,
+        };
+
+        var ending = TransportStreamFileNameEnding.Format(tsSettings.FileNameAppend, language, trackId);
+        if (ending.Length > 0)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(source.FileName);
+            trackItem.OutputFileName = baseName + ending + Path.GetExtension(source.FileName);
+            trackItem.OutputFileNameIncludesLanguage = true;
+        }
+
+        return trackItem;
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsViewModel.cs
@@ -1,0 +1,176 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.Media;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+
+/// <summary>
+/// Batch convert's "Transport Stream settings" dialog - SE4's BatchConvertTsSettings form.
+/// Edits <see cref="SeBatchConvert"/>'s Ts* fields; saved on OK only.
+/// </summary>
+public partial class BatchConvertTsSettingsViewModel : ObservableObject
+{
+    [ObservableProperty] private bool _overrideXPosition;
+    [ObservableProperty] private ObservableCollection<string> _horizontalAlignments;
+    [ObservableProperty] private string _selectedHorizontalAlignment;
+    [ObservableProperty] private int _horizontalMarginPercent;
+
+    [ObservableProperty] private bool _overrideYPosition;
+    [ObservableProperty] private int _bottomMarginPercent;
+
+    [ObservableProperty] private bool _overrideVideoSize;
+    [ObservableProperty] private int _videoWidth;
+    [ObservableProperty] private int _videoHeight;
+
+    [ObservableProperty] private string _fileNameEnding;
+    [ObservableProperty] private string _fileNameEndingSample;
+
+    [ObservableProperty] private bool _onlyTeletext;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    /// <summary>Set by the window so the placeholder menu can insert at the caret.</summary>
+    public Func<int>? GetFileNameEndingCaretIndex { get; set; }
+    public Action<int>? SetFileNameEndingCaretIndex { get; set; }
+
+    private readonly IFileHelper _fileHelper;
+
+    public BatchConvertTsSettingsViewModel(IFileHelper fileHelper)
+    {
+        _fileHelper = fileHelper;
+
+        HorizontalAlignments = new ObservableCollection<string>
+        {
+            Se.Language.General.Left,
+            Se.Language.General.Center,
+            Se.Language.General.Right,
+        };
+        _selectedHorizontalAlignment = HorizontalAlignments[1];
+        _fileNameEnding = string.Empty;
+        _fileNameEndingSample = string.Empty;
+
+        LoadSettings();
+    }
+
+    private void LoadSettings()
+    {
+        var s = Se.Settings.Tools.BatchConvert;
+        OverrideXPosition = s.TsOverrideXPosition;
+        HorizontalMarginPercent = Math.Clamp(s.TsOverrideHMargin, 0, 100);
+        OverrideYPosition = s.TsOverrideYPosition;
+        BottomMarginPercent = Math.Clamp(s.TsOverrideBottomMargin, 0, 100);
+        OverrideVideoSize = s.TsOverrideScreenSize;
+        VideoWidth = s.TsScreenWidth > 0 ? s.TsScreenWidth : 1920;
+        VideoHeight = s.TsScreenHeight > 0 ? s.TsScreenHeight : 1080;
+        FileNameEnding = s.TsFileNameAppend ?? string.Empty;
+        OnlyTeletext = s.TsOnlyTeletext;
+
+        if (string.Equals(s.TsOverrideHAlign, TransportStreamExportSettings.HAlignLeft, StringComparison.OrdinalIgnoreCase))
+        {
+            SelectedHorizontalAlignment = HorizontalAlignments[0];
+        }
+        else if (string.Equals(s.TsOverrideHAlign, TransportStreamExportSettings.HAlignRight, StringComparison.OrdinalIgnoreCase))
+        {
+            SelectedHorizontalAlignment = HorizontalAlignments[2];
+        }
+        else
+        {
+            SelectedHorizontalAlignment = HorizontalAlignments[1];
+        }
+    }
+
+    private void SaveSettings()
+    {
+        var s = Se.Settings.Tools.BatchConvert;
+        s.TsOverrideXPosition = OverrideXPosition;
+        s.TsOverrideHMargin = HorizontalMarginPercent;
+        s.TsOverrideYPosition = OverrideYPosition;
+        s.TsOverrideBottomMargin = BottomMarginPercent;
+        s.TsOverrideScreenSize = OverrideVideoSize;
+        s.TsScreenWidth = VideoWidth;
+        s.TsScreenHeight = VideoHeight;
+        s.TsFileNameAppend = FileNameEnding ?? string.Empty;
+        s.TsOnlyTeletext = OnlyTeletext;
+
+        var alignmentIndex = HorizontalAlignments.IndexOf(SelectedHorizontalAlignment);
+        s.TsOverrideHAlign = alignmentIndex switch
+        {
+            0 => TransportStreamExportSettings.HAlignLeft,
+            2 => TransportStreamExportSettings.HAlignRight,
+            _ => TransportStreamExportSettings.HAlignCenter,
+        };
+
+        Se.SaveSettings();
+    }
+
+    partial void OnFileNameEndingChanged(string value)
+    {
+        FileNameEndingSample = TransportStreamFileNameEnding.MakeSample(value);
+    }
+
+    [RelayCommand]
+    private void InsertPlaceholder(string placeholder)
+    {
+        var text = FileNameEnding ?? string.Empty;
+        var index = GetFileNameEndingCaretIndex?.Invoke() ?? text.Length;
+        index = Math.Clamp(index, 0, text.Length);
+        FileNameEnding = text.Insert(index, placeholder);
+        SetFileNameEndingCaretIndex?.Invoke(index + placeholder.Length);
+    }
+
+    /// <summary>Pick a video and take its frame size as the override size (SE4's "..." button).</summary>
+    [RelayCommand]
+    private async Task GetSizeFromVideo()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var fileName = await _fileHelper.PickOpenVideoFile(Window, Se.Language.General.OpenVideoFileTitle);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return;
+        }
+
+        var mediaInfo = FfmpegMediaInfo.Parse(fileName);
+        if (mediaInfo.Dimension.Width > 0 && mediaInfo.Dimension.Height > 0)
+        {
+            VideoWidth = mediaInfo.Dimension.Width;
+            VideoHeight = mediaInfo.Dimension.Height;
+            OverrideVideoSize = true;
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        SaveSettings();
+        OkPressed = true;
+        Window?.Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Window?.Close();
+        }
+    }
+}

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsWindow.cs
@@ -1,0 +1,155 @@
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+
+namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
+
+public class BatchConvertTsSettingsWindow : Window
+{
+    public BatchConvertTsSettingsWindow(BatchConvertTsSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Tools.BatchConvert.TransportStreamSettings;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        vm.Window = this;
+        DataContext = vm;
+
+        var labelInfo = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.TransportStreamSettingsInfo).WithOpacity(0.7);
+        labelInfo.MaxWidth = 520;
+
+        // X position
+        var checkBoxOverrideX = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.TransportStreamOverrideXPosition, vm, nameof(vm.OverrideXPosition));
+        var labelAlignment = UiUtil.MakeLabel(Se.Language.General.Alignment).WithMarginLeft(25);
+        var comboBoxAlignment = UiUtil.MakeComboBox(vm.HorizontalAlignments, vm, nameof(vm.SelectedHorizontalAlignment))
+            .WithBindEnabled(nameof(vm.OverrideXPosition));
+        var labelHMargin = UiUtil.MakeLabel(Se.Language.File.Export.LeftRightMargin).WithMarginLeft(15);
+        var numericHMargin = UiUtil.MakeNumericUpDownInt(0, 100, 5, 110, vm, nameof(vm.HorizontalMarginPercent))
+            .WithBindEnabled(nameof(vm.OverrideXPosition));
+        var panelX = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { labelAlignment, comboBoxAlignment, labelHMargin, numericHMargin, UiUtil.MakeLabel("%") }
+        };
+
+        // Y position
+        var checkBoxOverrideY = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.TransportStreamOverrideYPosition, vm, nameof(vm.OverrideYPosition));
+        var labelBottomMargin = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.TransportStreamBottomMargin).WithMarginLeft(25);
+        var numericBottomMargin = UiUtil.MakeNumericUpDownInt(0, 100, 5, 110, vm, nameof(vm.BottomMarginPercent))
+            .WithBindEnabled(nameof(vm.OverrideYPosition));
+        var panelY = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { labelBottomMargin, numericBottomMargin, UiUtil.MakeLabel("%") }
+        };
+
+        // Video size
+        var checkBoxOverrideSize = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.TransportStreamOverrideVideoSize, vm, nameof(vm.OverrideVideoSize));
+        var labelWidth = UiUtil.MakeLabel(Se.Language.General.Width).WithMarginLeft(25);
+        var numericWidth = UiUtil.MakeNumericUpDownInt(1, 9999, 1920, 120, vm, nameof(vm.VideoWidth))
+            .WithBindEnabled(nameof(vm.OverrideVideoSize));
+        var labelHeight = UiUtil.MakeLabel(Se.Language.General.Height).WithMarginLeft(15);
+        var numericHeight = UiUtil.MakeNumericUpDownInt(1, 9999, 1080, 120, vm, nameof(vm.VideoHeight))
+            .WithBindEnabled(nameof(vm.OverrideVideoSize));
+        var buttonGetSizeFromVideo = UiUtil.MakeButton(Se.Language.Tools.BatchConvert.TransportStreamGetSizeFromVideo, vm.GetSizeFromVideoCommand)
+            .WithMarginLeft(15);
+        var panelSize = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { labelWidth, numericWidth, labelHeight, numericHeight, buttonGetSizeFromVideo }
+        };
+
+        // File name ending
+        var labelFileNameEnding = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.TransportStreamFileNameEnding);
+        var textBoxFileNameEnding = UiUtil.MakeTextBox(260, vm, nameof(vm.FileNameEnding));
+        vm.GetFileNameEndingCaretIndex = () => textBoxFileNameEnding.CaretIndex;
+        vm.SetFileNameEndingCaretIndex = index =>
+        {
+            textBoxFileNameEnding.CaretIndex = index;
+            textBoxFileNameEnding.Focus();
+        };
+        var buttonInsertPlaceholder = new Button
+        {
+            Content = "{ }",
+            VerticalAlignment = VerticalAlignment.Center,
+            Flyout = new MenuFlyout
+            {
+                Items =
+                {
+                    MakePlaceholderMenuItem(vm, Se.Language.General.TwoLetterLanguageCode, TransportStreamExportSettings.PlaceholderTwoLetter),
+                    MakePlaceholderMenuItem(vm, Se.Language.Tools.BatchConvert.TwoLetterLanguageCodeUppercase, TransportStreamExportSettings.PlaceholderTwoLetterUppercase),
+                    MakePlaceholderMenuItem(vm, Se.Language.General.ThreeLetterLanguageCode, TransportStreamExportSettings.PlaceholderThreeLetter),
+                    MakePlaceholderMenuItem(vm, Se.Language.Tools.BatchConvert.ThreeLetterLanguageCodeUppercase, TransportStreamExportSettings.PlaceholderThreeLetterUppercase),
+                }
+            },
+        }.WithMarginLeft(5);
+        ToolTip.SetTip(buttonInsertPlaceholder, Se.Language.Tools.BatchConvert.TransportStreamFileNameEndingInfo);
+        var labelSample = UiUtil.MakeLabel(string.Empty).WithMarginLeft(10).WithOpacity(0.7);
+        labelSample.Bind(ContentControl.ContentProperty, new Avalonia.Data.Binding(nameof(vm.FileNameEndingSample)) { Source = vm });
+        var panelFileNameEnding = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Children = { labelFileNameEnding, textBoxFileNameEnding, buttonInsertPlaceholder, labelSample }
+        };
+
+        var checkBoxOnlyTeletext = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.TransportStreamOnlyTeletext, vm, nameof(vm.OnlyTeletext));
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk, buttonCancel);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            ColumnSpacing = 10,
+            RowSpacing = 8,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Add(labelInfo, 0, 0);
+        grid.Add(checkBoxOverrideX, 1, 0);
+        grid.Add(panelX, 2, 0);
+        grid.Add(checkBoxOverrideY, 3, 0);
+        grid.Add(panelY, 4, 0);
+        grid.Add(checkBoxOverrideSize, 5, 0);
+        grid.Add(panelSize, 6, 0);
+        grid.Add(panelFileNameEnding, 7, 0);
+        grid.Add(checkBoxOnlyTeletext, 8, 0);
+        grid.Add(panelButtons, 9, 0);
+
+        Content = grid;
+
+        UiUtil.FocusOnFirstActivation(this, checkBoxOverrideX); // initial focus on an input, not an action button - a focused button clicks on bare Space
+        KeyDown += (s, e) => vm.OnKeyDown(e);
+    }
+
+    private static MenuItem MakePlaceholderMenuItem(BatchConvertTsSettingsViewModel vm, string header, string placeholder)
+    {
+        return new MenuItem
+        {
+            Header = header,
+            Command = vm.InsertPlaceholderCommand,
+            CommandParameter = placeholder,
+        };
+    }
+}

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsWindow.cs
@@ -17,8 +17,11 @@ public class BatchConvertTsSettingsWindow : Window
         vm.Window = this;
         DataContext = vm;
 
-        var labelInfo = UiUtil.MakeLabel(Se.Language.Tools.BatchConvert.TransportStreamSettingsInfo).WithOpacity(0.7);
-        labelInfo.MaxWidth = 520;
+        var labelInfo = UiUtil.MakeTextBlock(Se.Language.Tools.BatchConvert.TransportStreamSettingsInfo);
+        labelInfo.TextWrapping = Avalonia.Media.TextWrapping.Wrap;
+        labelInfo.MaxWidth = 560;
+        labelInfo.Opacity = 0.7;
+        labelInfo.Margin = new Avalonia.Thickness(0, 0, 0, 6);
 
         // X position
         var checkBoxOverrideX = UiUtil.MakeCheckBox(Se.Language.Tools.BatchConvert.TransportStreamOverrideXPosition, vm, nameof(vm.OverrideXPosition));

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -78,6 +78,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [ObservableProperty] private double _progressMaxValue;
     [ObservableProperty] private string _actionsSelected;
     [ObservableProperty] private bool _isTargetFormatSettingsVisible;
+    [ObservableProperty] private bool _isTransportStreamSettingsVisible;
     [ObservableProperty] private ObservableCollection<string> _filterItems;
     [ObservableProperty] private string? _selectedFilterItem;
     [ObservableProperty] private string _filterText;
@@ -2416,6 +2417,8 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         var total = _allBatchItems.Count;
         var shown = BatchItems.Count;
 
+        IsTransportStreamSettingsVisible = _allBatchItems.Any(p => p.Format != null && p.Format.StartsWith("Transport Stream", StringComparison.Ordinal));
+
         if (total == 0)
         {
             BatchItemsInfo = string.Empty;
@@ -2622,6 +2625,12 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     {
         await _windowService.ShowDialogAsync<BatchConvertSettingsWindow, BatchConvertSettingsViewModel>(Window!);
         UpdateOutputProperties();
+    }
+
+    [RelayCommand]
+    private async Task ShowTransportStreamSettings()
+    {
+        await _windowService.ShowDialogAsync<BatchConvertTsSettingsWindow, BatchConvertTsSettingsViewModel>(Window!);
     }
 
     [RelayCommand]

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -242,6 +242,11 @@ public class BatchConvertWindow : Window
             .WithMarginLeft(5)
             .WithMarginRight(5);
         buttonTargetFormatSettings.WithBindIsVisible(vm, nameof(vm.IsTargetFormatSettingsVisible));
+        // Only offered while a Transport Stream file is in the list - the settings apply to nothing else.
+        var buttonTransportStreamSettings = UiUtil.MakeButton(vm.ShowTransportStreamSettingsCommand, IconNames.FileCog, Se.Language.Tools.BatchConvert.TransportStreamSettingsDotDotDot)
+            .WithMarginLeft(5)
+            .WithMarginRight(5);
+        buttonTransportStreamSettings.WithBindIsVisible(vm, nameof(vm.IsTransportStreamSettingsVisible));
         var buttonSettings = UiUtil.MakeButton(vm.ShowOutputPropertiesCommand, IconNames.Settings, Se.Language.General.Settings).WithMarginLeft(15).WithMarginRight(5);
 
         var panelFileControls = new StackPanel
@@ -259,6 +264,7 @@ public class BatchConvertWindow : Window
                 UiUtil.MakeLabel(Se.Language.General.TargetFormat).WithMarginLeft(15),
                 comboBoxSubtitleFormat,
                 buttonTargetFormatSettings,
+                buttonTransportStreamSettings,
                 buttonSettings,
                 MakeOutputPropertiesGrid(vm),
             }

--- a/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConverter.cs
@@ -1827,7 +1827,13 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
                 FullFrameBackgroundColor = profile.FullFrameBackgroundColor.FromHexToColor().ToSKColor(),
             };
             var position = imageSubtitle.GetPosition(i);
-            if (position.X >= 0 && position.Y >= 0)
+            if (imageSubtitle is OcrSubtitleTransportStream)
+            {
+                // DVB tracks honour the Transport Stream output settings: rescale to a chosen
+                // video size and/or re-anchor X/Y (SE4's "TS settings...").
+                TransportStreamExportOverride.Apply(param, position, Se.Settings.Tools.BatchConvert.GetTransportStreamExportSettings());
+            }
+            else if (position.X >= 0 && position.Y >= 0)
             {
                 param.OverridePosition = position;
             }
@@ -3539,7 +3545,9 @@ public class BatchConverter : IBatchConverter, IFixCallbacks
 
         var targetExtension = extension;
 
-        var languagePart = GetLanguagePostFix(item);
+        // A Transport Stream track named by the file name ending template already carries its
+        // language/track token - the regular post fix would double it ("video.eng.en.srt").
+        var languagePart = item.OutputFileNameIncludesLanguage ? string.Empty : GetLanguagePostFix(item);
         if (languagePart.Length > 0 && fileName.EndsWith(languagePart, StringComparison.InvariantCultureIgnoreCase))
         {
             languagePart = string.Empty; // base name already carries the language token

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -59,6 +59,19 @@ public class LanguageBatchConvert
     public string IncludeSubfolders { get; set; }
     public string KeepSourceFileTimestamp { get; set; }
     public string ScanningFolderX { get; set; }
+    public string TransportStreamSettings { get; set; }
+    public string TransportStreamSettingsDotDotDot { get; set; }
+    public string TransportStreamSettingsInfo { get; set; }
+    public string TransportStreamOverrideXPosition { get; set; }
+    public string TransportStreamOverrideYPosition { get; set; }
+    public string TransportStreamOverrideVideoSize { get; set; }
+    public string TransportStreamBottomMargin { get; set; }
+    public string TransportStreamFileNameEnding { get; set; }
+    public string TransportStreamFileNameEndingInfo { get; set; }
+    public string TransportStreamOnlyTeletext { get; set; }
+    public string TransportStreamGetSizeFromVideo { get; set; }
+    public string TwoLetterLanguageCodeUppercase { get; set; }
+    public string ThreeLetterLanguageCodeUppercase { get; set; }
 
     public LanguageBatchConvert()
     {
@@ -116,5 +129,18 @@ public class LanguageBatchConvert
         IncludeSubfolders = "Include subfolders when adding a folder";
         KeepSourceFileTimestamp = "Keep source file date/time on output files";
         ScanningFolderX = "Scanning {0}...";
+        TransportStreamSettings = "Transport Stream settings";
+        TransportStreamSettingsDotDotDot = "Transport Stream settings...";
+        TransportStreamSettingsInfo = "Applies to subtitle tracks extracted from Transport Stream files (.ts/.m2ts). Position and video size only affect DVB image tracks exported to an image based format.";
+        TransportStreamOverrideXPosition = "Override original X position";
+        TransportStreamOverrideYPosition = "Override original Y position";
+        TransportStreamOverrideVideoSize = "Override original video size";
+        TransportStreamBottomMargin = "Bottom margin";
+        TransportStreamFileNameEnding = "File name ending";
+        TransportStreamFileNameEndingInfo = "Added before the extension for each extracted track. Leave empty to use the regular language post fix.";
+        TransportStreamOnlyTeletext = "Only teletext";
+        TransportStreamGetSizeFromVideo = "Get size from video...";
+        TwoLetterLanguageCodeUppercase = "Two-letter language code (uppercase)";
+        ThreeLetterLanguageCodeUppercase = "Three-letter language code (uppercase)";
     }
 }

--- a/src/ui/Logic/Config/SeBatchConvert.cs
+++ b/src/ui/Logic/Config/SeBatchConvert.cs
@@ -1,4 +1,5 @@
 ﻿using Nikse.SubtitleEdit.UiLogic.AutoTranslate;
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
 
 namespace Nikse.SubtitleEdit.Logic.Config;
 
@@ -151,6 +152,35 @@ public class SeBatchConvert
     public double ImageAdjustAlphaThreshold { get; set; }
     public bool ImageAdjustColorOn { get; set; }
     public string ImageAdjustColorValue { get; set; } = "#FFFFFFFF";
+
+    // Transport Stream output settings (SE4's "TS settings..."), see TransportStreamExportSettings.
+    public bool TsOverrideXPosition { get; set; }
+    public string TsOverrideHAlign { get; set; } = TransportStreamExportSettings.HAlignCenter;
+    public int TsOverrideHMargin { get; set; } = 5; // percent
+    public bool TsOverrideYPosition { get; set; }
+    public int TsOverrideBottomMargin { get; set; } = 5; // percent
+    public bool TsOverrideScreenSize { get; set; }
+    public int TsScreenWidth { get; set; } = 1920;
+    public int TsScreenHeight { get; set; } = 1080;
+    public string TsFileNameAppend { get; set; } = "." + TransportStreamExportSettings.PlaceholderTwoLetter;
+    public bool TsOnlyTeletext { get; set; }
+
+    public TransportStreamExportSettings GetTransportStreamExportSettings()
+    {
+        return new TransportStreamExportSettings
+        {
+            OverrideXPosition = TsOverrideXPosition,
+            HAlign = TsOverrideHAlign ?? TransportStreamExportSettings.HAlignCenter,
+            HMarginPercent = TsOverrideHMargin,
+            OverrideYPosition = TsOverrideYPosition,
+            BottomMarginPercent = TsOverrideBottomMargin,
+            OverrideScreenSize = TsOverrideScreenSize,
+            ScreenWidth = TsScreenWidth,
+            ScreenHeight = TsScreenHeight,
+            FileNameAppend = TsFileNameAppend ?? string.Empty,
+            OnlyTeletext = TsOnlyTeletext,
+        };
+    }
 
     public SeBatchConvert()
     {

--- a/tests/libuilogic/BatchConvert/TransportStreamExportSettingsTests.cs
+++ b/tests/libuilogic/BatchConvert/TransportStreamExportSettingsTests.cs
@@ -1,0 +1,160 @@
+using Nikse.SubtitleEdit.UiLogic.BatchConvert;
+using Nikse.SubtitleEdit.UiLogic.Export;
+using SkiaSharp;
+
+namespace LibUiLogicTests.BatchConvert;
+
+public class TransportStreamExportSettingsTests
+{
+    [Fact]
+    public void FileNameEnding_EmptyTemplate_GivesNothing()
+    {
+        Assert.Equal(string.Empty, TransportStreamFileNameEnding.Format(string.Empty, "eng", 1234));
+        Assert.Equal(string.Empty, TransportStreamFileNameEnding.Format(null, "eng", 1234));
+    }
+
+    [Fact]
+    public void FileNameEnding_ThreeLetterLanguage_FillsAllPlaceholders()
+    {
+        var template = ".{two-letter-country-code}-{two-letter-country-code-uppercase}-{three-letter-country-code}-{three-letter-country-code-uppercase}";
+        Assert.Equal(".en-EN-eng-ENG", TransportStreamFileNameEnding.Format(template, "eng", 1234));
+    }
+
+    [Fact]
+    public void FileNameEnding_TwoLetterLanguage_ExpandsToThreeLetter()
+    {
+        Assert.Equal(".dan", TransportStreamFileNameEnding.Format(".{three-letter-country-code}", "da", 1234));
+    }
+
+    [Fact]
+    public void FileNameEnding_NoLanguage_FallsBackToTrackId()
+    {
+        // No language in the PMT: SE4 used the PID/page so two anonymous tracks never collide.
+        Assert.Equal(".888", TransportStreamFileNameEnding.Format(".{two-letter-country-code}", string.Empty, 888));
+        Assert.Equal(".888", TransportStreamFileNameEnding.Format(".{three-letter-country-code-uppercase}", null, 888));
+    }
+
+    [Fact]
+    public void FileNameEnding_LiteralTextIsKept()
+    {
+        Assert.Equal("_sub_en", TransportStreamFileNameEnding.Format("_sub_{two-letter-country-code}", "eng", 1));
+    }
+
+    [Fact]
+    public void Sample_UsesEnglish()
+    {
+        Assert.Equal("MyVideoFile.en.sup", TransportStreamFileNameEnding.MakeSample(".{two-letter-country-code}"));
+    }
+
+    [Fact]
+    public void Override_NothingEnabled_KeepsOriginalPosition()
+    {
+        var param = MakeParam(720, 576, 100, 40);
+        TransportStreamExportOverride.Apply(param, new SKPointI(50, 500), new TransportStreamExportSettings());
+
+        Assert.Equal(720, param.ScreenWidth);
+        Assert.Equal(576, param.ScreenHeight);
+        Assert.Equal(new SKPointI(50, 500), param.OverridePosition);
+        Assert.Equal(100, param.Bitmap.Width);
+    }
+
+    [Fact]
+    public void Override_UnknownPosition_LeavesOverrideNull()
+    {
+        var param = MakeParam(720, 576, 100, 40);
+        TransportStreamExportOverride.Apply(param, new SKPointI(-1, -1), new TransportStreamExportSettings());
+        Assert.Null(param.OverridePosition);
+    }
+
+    [Fact]
+    public void Override_ScreenSize_ScalesBitmapAndPosition()
+    {
+        var param = MakeParam(720, 576, 100, 40);
+        var settings = new TransportStreamExportSettings { OverrideScreenSize = true, ScreenWidth = 1440, ScreenHeight = 1152 };
+        TransportStreamExportOverride.Apply(param, new SKPointI(50, 500), settings);
+
+        Assert.Equal(1440, param.ScreenWidth);
+        Assert.Equal(1152, param.ScreenHeight);
+        Assert.Equal(200, param.Bitmap.Width);
+        Assert.Equal(80, param.Bitmap.Height);
+        Assert.Equal(new SKPointI(100, 1000), param.OverridePosition);
+    }
+
+    [Fact]
+    public void Override_XCenter_YBottomMargin()
+    {
+        var param = MakeParam(1920, 1080, 200, 60);
+        var settings = new TransportStreamExportSettings
+        {
+            OverrideXPosition = true,
+            HAlign = TransportStreamExportSettings.HAlignCenter,
+            OverrideYPosition = true,
+            BottomMarginPercent = 10,
+        };
+        TransportStreamExportOverride.Apply(param, new SKPointI(5, 5), settings);
+
+        // centered: (1920 - 200) / 2; bottom: 1080 - 108 - 60
+        Assert.Equal(new SKPointI(860, 912), param.OverridePosition);
+    }
+
+    [Fact]
+    public void Override_XLeftAndRight_UseMarginPercent()
+    {
+        var settings = new TransportStreamExportSettings
+        {
+            OverrideXPosition = true,
+            HAlign = TransportStreamExportSettings.HAlignLeft,
+            HMarginPercent = 5,
+        };
+
+        var left = MakeParam(1920, 1080, 200, 60);
+        TransportStreamExportOverride.Apply(left, new SKPointI(700, 900), settings);
+        Assert.Equal(new SKPointI(96, 900), left.OverridePosition); // X replaced, Y kept
+
+        settings.HAlign = TransportStreamExportSettings.HAlignRight;
+        var right = MakeParam(1920, 1080, 200, 60);
+        TransportStreamExportOverride.Apply(right, new SKPointI(700, 900), settings);
+        Assert.Equal(new SKPointI(1920 - 96 - 200, 900), right.OverridePosition);
+    }
+
+    [Fact]
+    public void Override_OnlyY_WithUnknownX_LeavesOverrideNull()
+    {
+        var param = MakeParam(1920, 1080, 200, 60);
+        var settings = new TransportStreamExportSettings { OverrideYPosition = true };
+        TransportStreamExportOverride.Apply(param, new SKPointI(-1, -1), settings);
+        Assert.Null(param.OverridePosition);
+    }
+
+    [Fact]
+    public void Override_ScreenSizeThenPosition_UsesNewScreen()
+    {
+        var param = MakeParam(720, 576, 100, 40);
+        var settings = new TransportStreamExportSettings
+        {
+            OverrideScreenSize = true,
+            ScreenWidth = 1920,
+            ScreenHeight = 1080,
+            OverrideXPosition = true,
+            OverrideYPosition = true,
+            BottomMarginPercent = 5,
+        };
+        TransportStreamExportOverride.Apply(param, new SKPointI(50, 500), settings);
+
+        var bitmapWidth = param.Bitmap.Width; // 100 * 1920/720 = 267
+        var bitmapHeight = param.Bitmap.Height; // 40 * 1080/576 = 75
+        Assert.Equal(267, bitmapWidth);
+        Assert.Equal(75, bitmapHeight);
+        Assert.Equal(new SKPointI((int)Math.Round(1920 / 2.0 - bitmapWidth / 2.0), 1080 - 54 - bitmapHeight), param.OverridePosition);
+    }
+
+    private static ImageParameter MakeParam(int screenWidth, int screenHeight, int bitmapWidth, int bitmapHeight)
+    {
+        return new ImageParameter
+        {
+            ScreenWidth = screenWidth,
+            ScreenHeight = screenHeight,
+            Bitmap = new SKBitmap(bitmapWidth, bitmapHeight),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Ports SE4's `BatchConvertTsSettings` ("TS settings...") to SE5. Batch convert splits Transport Stream tracks on input but had none of SE4's export controls.

- **New dialog** `BatchConvertTsSettingsWindow`: override X position (left/center/right + margin %), override Y position (bottom margin %), override video size (width/height, plus "Get size from video..." via ffmpeg), file name ending template with a placeholder menu and live sample, and "Only teletext". Opens from a button in the batch convert window that is visible while a Transport Stream file is in the list.
- **Settings** persisted as new `Ts*` fields on `SeBatchConvert` with SE4 defaults (center, 5 %, 1920x1080, `.{two-letter-country-code}`).
- **Track splitting** skips DVB image tracks when "Only teletext" is on, reads the PMT language for teletext PIDs, and names each track from the template. A new `OutputFileNameIncludesLanguage` flag on `BatchConvertItem` keeps the converter's regular language post fix from doubling the token.
- **Image export** routes DVB tracks through `TransportStreamExportOverride`, which rescales bitmap + position to the chosen video size and re-anchors X/Y the way SE4's `TsToBluRaySup` did. Non-TS sources are unchanged.
- Pure helpers live in libuilogic (`TransportStreamExportSettings`, `TransportStreamFileNameEnding`, `TransportStreamExportOverride`) so the placeholder expansion and placement math are unit-tested.

## Behavior notes

- Default template gives the same names as before for DVB tracks with a language. Teletext pages without a PMT language now get the page number as the token (SE4 behavior) instead of the `_2` counter.
- Empty template falls back to the regular language post fix setting.
- Auto-translate's target-language post fix is bypassed when a template is active (as in SE4).

## Test plan

- [x] 13 new libuilogic tests pass
- [x] Existing BatchConvert UI tests: 86 passed, 1 skipped
- [ ] Manual: add a .ts with DVB + teletext tracks, open TS settings, convert to Blu-ray sup with position/size overrides and check placement and file names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
