### PR TITLE
Add UI for the hidden rc-stage settings

### DIFF
--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -559,15 +559,6 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowFullscreenButton, nameof(_vm.ShowFullscreenButton)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FullscreenHideControls, nameof(_vm.FullscreenHideControls)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoOpenVideoFile, nameof(_vm.AutoOpenVideoFile)),
-            new SettingsItem(Se.Language.Options.Settings.MpvAudioBufferSeconds, () => new NumericUpDown
-            {
-                Width = 150,
-                Minimum = 0,
-                Maximum = 5,
-                Increment = 0.05m,
-                FormatString = "0.##",
-                [!NumericUpDown.ValueProperty] = new Binding(nameof(_vm.MpvAudioBufferSeconds)) { Source = _vm, Mode = BindingMode.TwoWay },
-            }),
             new SettingsItem(!_vm.IsLibMpvDownloadVisible, Se.Language.Options.Settings.DownloadMpv, () => new StackPanel
             {
                 Children =

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -559,6 +559,15 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.ShowFullscreenButton, nameof(_vm.ShowFullscreenButton)),
             MakeCheckboxSetting(Se.Language.Options.Settings.FullscreenHideControls, nameof(_vm.FullscreenHideControls)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoOpenVideoFile, nameof(_vm.AutoOpenVideoFile)),
+            new SettingsItem(Se.Language.Options.Settings.MpvAudioBufferSeconds, () => new NumericUpDown
+            {
+                Width = 150,
+                Minimum = 0,
+                Maximum = 5,
+                Increment = 0.05m,
+                FormatString = "0.##",
+                [!NumericUpDown.ValueProperty] = new Binding(nameof(_vm.MpvAudioBufferSeconds)) { Source = _vm, Mode = BindingMode.TwoWay },
+            }),
             new SettingsItem(!_vm.IsLibMpvDownloadVisible, Se.Language.Options.Settings.DownloadMpv, () => new StackPanel
             {
                 Children =
@@ -774,6 +783,7 @@ public class SettingsPage : UserControl
         sections.Add(new SettingsSection(Se.Language.General.Tools, IconNames.Tools, "#f0885a",
         [
             MakeCheckboxSetting(Se.Language.Options.Settings.AllowSingleLetterShortcutsInTextbox, nameof(_vm.AllowSingleLetterShortcutsInTextbox)),
+            MakeCheckboxSetting(Se.Language.Options.Settings.AllowTextNavigationShortcutsInTextbox, nameof(_vm.AllowTextNavigationShortcutsInTextbox)),
             MakeCheckboxSetting(Se.Language.Options.Settings.GoToLineNumberSetsVideoPosition, nameof(_vm.GoToLineNumberAlsoSetVideoPosition)),
             MakeCheckboxSetting(Se.Language.Options.Settings.AdjustAllTimesRememberLineSelectionChoice, nameof(_vm.AdjustAllTimesRememberLineSelectionChoice)),
             MakeCheckboxSetting(Se.Language.Options.Settings.MergeKeepEndTime, nameof(_vm.MergeKeepEndTime)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -110,6 +110,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private MpvJustifyDisplay _mpvPreviewSelectedJustify;
     [ObservableProperty] private int _mpvPreviewMargin;
     [ObservableProperty] private bool _mpvPreviewUsePositionFromFile;
+    [ObservableProperty] private double _mpvAudioBufferSeconds;
     [ObservableProperty] private bool _mpvPreviewMarginIsPartOfSubtitleArea;
     [ObservableProperty] private Color _mpvPreviewColorPrimary;
     [ObservableProperty] private Color _mpvPreviewColorOutline;
@@ -186,6 +187,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _selectedSaveAsAppendLanguageCode;
 
     [ObservableProperty] private bool _allowSingleLetterShortcutsInTextbox;
+    [ObservableProperty] private bool _allowTextNavigationShortcutsInTextbox;
     [ObservableProperty] private bool _goToLineNumberAlsoSetVideoPosition;
     [ObservableProperty] private bool _adjustAllTimesRememberLineSelectionChoice;
     [ObservableProperty] private bool _mergeKeepEndTime;
@@ -829,6 +831,7 @@ public partial class SettingsViewModel : ObservableObject
         }
 
         AllowSingleLetterShortcutsInTextbox = Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox;
+        AllowTextNavigationShortcutsInTextbox = Se.Settings.Tools.AllowTextNavigationShortcutsInTextbox;
         SpellCheckEnglishTreatInApostropheAsIng = Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng;
         GoToLineNumberAlsoSetVideoPosition = Se.Settings.Tools.GoToLineNumberAlsoSetVideoPosition;
         AdjustAllTimesRememberLineSelectionChoice = Se.Settings.Synchronization.AdjustAllTimesRememberLineSelectionChoice;
@@ -1043,6 +1046,7 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewFontBold = video.MpvPreviewFontBold;
         MpvPreviewMargin = video.MpvPreviewMargin;
         MpvPreviewUsePositionFromFile = video.MpvPreviewUsePositionFromFile;
+        MpvAudioBufferSeconds = video.MpvAudioBufferSeconds;
         MpvPreviewMarginIsPartOfSubtitleArea = video.MpvPreviewMarginIsPartOfSubtitleArea;
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments.FirstOrDefault(p => p.Code == video.MpvPreviewAlignment) ?? MpvPreviewFontAlignments[7];
         MpvPreviewSelectedJustify = MpvPreviewJustifyItems.FirstOrDefault(p => p.Code == video.MpvPreviewJustify) ?? MpvPreviewJustifyItems[0];
@@ -1673,6 +1677,7 @@ public partial class SettingsViewModel : ObservableObject
         general.FavoriteLanguages = string.Join(";", FavoriteLanguages.Select(l => l.Code));
 
         Se.Settings.Tools.AllowSingleLetterShortcutsInTextbox = AllowSingleLetterShortcutsInTextbox;
+        Se.Settings.Tools.AllowTextNavigationShortcutsInTextbox = AllowTextNavigationShortcutsInTextbox;
         Se.Settings.Tools.SpellCheckEnglishTreatInApostropheAsIng = SpellCheckEnglishTreatInApostropheAsIng;
         Se.Settings.Tools.GoToLineNumberAlsoSetVideoPosition = GoToLineNumberAlsoSetVideoPosition;
         Se.Settings.Synchronization.AdjustAllTimesRememberLineSelectionChoice = AdjustAllTimesRememberLineSelectionChoice;
@@ -1869,6 +1874,7 @@ public partial class SettingsViewModel : ObservableObject
         video.MpvPreviewFontBold = MpvPreviewFontBold;
         video.MpvPreviewMargin = MpvPreviewMargin;
         video.MpvPreviewUsePositionFromFile = MpvPreviewUsePositionFromFile;
+        video.MpvAudioBufferSeconds = MpvAudioBufferSeconds;
         video.MpvPreviewMarginIsPartOfSubtitleArea = MpvPreviewMarginIsPartOfSubtitleArea;
         video.MpvPreviewOutlineWidth = MpvPreviewOutlineWidth;
         video.MpvPreviewAlignment = MpvPreviewSelectedFontAlignment.Code;

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -110,7 +110,6 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private MpvJustifyDisplay _mpvPreviewSelectedJustify;
     [ObservableProperty] private int _mpvPreviewMargin;
     [ObservableProperty] private bool _mpvPreviewUsePositionFromFile;
-    [ObservableProperty] private double _mpvAudioBufferSeconds;
     [ObservableProperty] private bool _mpvPreviewMarginIsPartOfSubtitleArea;
     [ObservableProperty] private Color _mpvPreviewColorPrimary;
     [ObservableProperty] private Color _mpvPreviewColorOutline;
@@ -1046,7 +1045,6 @@ public partial class SettingsViewModel : ObservableObject
         MpvPreviewFontBold = video.MpvPreviewFontBold;
         MpvPreviewMargin = video.MpvPreviewMargin;
         MpvPreviewUsePositionFromFile = video.MpvPreviewUsePositionFromFile;
-        MpvAudioBufferSeconds = video.MpvAudioBufferSeconds;
         MpvPreviewMarginIsPartOfSubtitleArea = video.MpvPreviewMarginIsPartOfSubtitleArea;
         MpvPreviewSelectedFontAlignment = MpvPreviewFontAlignments.FirstOrDefault(p => p.Code == video.MpvPreviewAlignment) ?? MpvPreviewFontAlignments[7];
         MpvPreviewSelectedJustify = MpvPreviewJustifyItems.FirstOrDefault(p => p.Code == video.MpvPreviewJustify) ?? MpvPreviewJustifyItems[0];
@@ -1874,7 +1872,6 @@ public partial class SettingsViewModel : ObservableObject
         video.MpvPreviewFontBold = MpvPreviewFontBold;
         video.MpvPreviewMargin = MpvPreviewMargin;
         video.MpvPreviewUsePositionFromFile = MpvPreviewUsePositionFromFile;
-        video.MpvAudioBufferSeconds = MpvAudioBufferSeconds;
         video.MpvPreviewMarginIsPartOfSubtitleArea = MpvPreviewMarginIsPartOfSubtitleArea;
         video.MpvPreviewOutlineWidth = MpvPreviewOutlineWidth;
         video.MpvPreviewAlignment = MpvPreviewSelectedFontAlignment.Code;

--- a/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
+++ b/src/ui/Features/Video/SpeechToText/Engines/GoogleCloudSttEngine.cs
@@ -72,13 +72,13 @@ public class GoogleCloudSttEngine : IOnlineSttEngine
         " 2. Create a service account with the roles 'Cloud Speech Client' and 'Storage Admin'.\n" +
         " 3. Add a JSON key to the service account, download it, and pick it as the key file.\n\n" +
         "If your organisation does not allow service account keys, leave the key file empty and run " +
-        "'gcloud auth application-default login' instead. Those credentials rarely name a project, so also set " +
-        "GoogleCloudSttProjectId in Settings.json.\n\n" +
+        "'gcloud auth application-default login' instead. Those credentials rarely name a project, so also fill " +
+        "in the project ID.\n\n" +
         "Long audio must be read from a Cloud Storage bucket, so one named <project>-subtitle-edit-stt is created " +
-        "on first use (another name can be set as GoogleCloudSttBucketName in Settings.json). Uploaded audio is " +
+        "on first use (another name can be set in the storage bucket field). Uploaded audio is " +
         "deleted after each run.\n\n" +
         "Cost: about $0.003 per minute of audio, because dynamic batching is used by default. Google gives no " +
-        "latency guarantee for it, so set GoogleCloudSttDynamicBatching to false in Settings.json to transcribe " +
+        "latency guarantee for it, so turn dynamic batching off to transcribe " +
         "at the normal rate of about $0.016 per minute instead.\n\n" +
         "Region: 'us' or 'eu' for chirp_3, or a specific region for other models. " +
         "Model: chirp_3, chirp_2, long, latest_long... " +

--- a/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
+++ b/src/ui/Features/Video/SpeechToText/GoogleCloud/GoogleCloudSttService.cs
@@ -338,7 +338,7 @@ public class GoogleCloudSttService : ISttTranscriber
         }
 
         throw new HttpRequestException(
-            "No Google Cloud project could be determined. Either pick a service account key file, which carries its own project, or set GoogleCloudSttProjectId in Settings.json.");
+            "No Google Cloud project could be determined. Either pick a service account key file, which carries its own project, or fill in the project ID in the Google Cloud settings.");
     }
 
     internal static string ReadProjectId(string keyFile)

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -133,6 +133,9 @@ public partial class SpeechToTextViewModel : ObservableObject
     [ObservableProperty] private string? _googleCloudSttModel;
     [ObservableProperty] private string? _googleCloudSttLanguage;
     [ObservableProperty] private int _googleCloudSttTimeoutSeconds;
+    [ObservableProperty] private string? _googleCloudSttProjectId;
+    [ObservableProperty] private string? _googleCloudSttBucketName;
+    [ObservableProperty] private bool _googleCloudSttDynamicBatching;
 
     public Window? Window { get; set; }
 
@@ -387,6 +390,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         GoogleCloudSttModel = Se.Settings.Tools.GoogleCloudSttModel;
         GoogleCloudSttLanguage = Se.Settings.Tools.GoogleCloudSttLanguage;
         GoogleCloudSttTimeoutSeconds = Se.Settings.Tools.GoogleCloudSttTimeoutSeconds;
+        GoogleCloudSttProjectId = Se.Settings.Tools.GoogleCloudSttProjectId;
+        GoogleCloudSttBucketName = Se.Settings.Tools.GoogleCloudSttBucketName;
+        GoogleCloudSttDynamicBatching = Se.Settings.Tools.GoogleCloudSttDynamicBatching;
 
         var savedChoice = Se.Settings.Tools.AudioToText.WhisperChoice;
         var whisperCppEngine = Engines.OfType<WhisperCppEngine>().FirstOrDefault();
@@ -472,6 +478,9 @@ public partial class SpeechToTextViewModel : ObservableObject
         Se.Settings.Tools.GoogleCloudSttModel = GoogleCloudSttModel ?? "chirp_3";
         Se.Settings.Tools.GoogleCloudSttLanguage = GoogleCloudSttLanguage ?? string.Empty;
         Se.Settings.Tools.GoogleCloudSttTimeoutSeconds = GoogleCloudSttTimeoutSeconds;
+        Se.Settings.Tools.GoogleCloudSttProjectId = GoogleCloudSttProjectId?.Trim() ?? string.Empty;
+        Se.Settings.Tools.GoogleCloudSttBucketName = GoogleCloudSttBucketName?.Trim() ?? string.Empty;
+        Se.Settings.Tools.GoogleCloudSttDynamicBatching = GoogleCloudSttDynamicBatching;
 
         Se.SaveSettings();
     }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextWindow.cs
@@ -881,12 +881,19 @@ public class SpeechToTextWindow : Window
             [!NumericUpDown.ValueProperty] = new Binding(nameof(vm.GoogleCloudSttTimeoutSeconds)) { Mode = BindingMode.TwoWay }
         }.BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible));
 
+        var checkDynamicBatching = UiUtil.MakeCheckBox(vm, nameof(vm.GoogleCloudSttDynamicBatching))
+            .WithMarginTop(10)
+            .BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible));
+
         return new (Control, Control)[]
         {
             (MakeLabel(Se.Language.General.KeyFile), keyFilePanel),
+            (MakeLabel(Se.Language.General.GoogleCloudSttProjectId), MakeText(nameof(vm.GoogleCloudSttProjectId), 250).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
             (MakeLabel(Se.Language.General.Region), MakeText(nameof(vm.GoogleCloudSttRegion), 150).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
             (MakeLabel(Se.Language.General.Model), MakeText(nameof(vm.GoogleCloudSttModel), 250).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttLanguage), MakeText(nameof(vm.GoogleCloudSttLanguage), 150).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
+            (MakeLabel(Se.Language.General.GoogleCloudSttBucketName), MakeText(nameof(vm.GoogleCloudSttBucketName), 250).BindIsVisible(vm, nameof(vm.IsGoogleCloudSttVisible))),
+            (MakeLabel(Se.Language.General.GoogleCloudSttDynamicBatching), checkDynamicBatching),
             (MakeLabel(Se.Language.General.OpenAiCompatibleSttTimeout), numericTimeout),
         };
     }

--- a/src/ui/Logic/Config/Language/LanguageGeneral.cs
+++ b/src/ui/Logic/Config/Language/LanguageGeneral.cs
@@ -788,6 +788,9 @@ public class LanguageGeneral
     public string DashScopeSttRegion { get; set; }
     public string DashScopeSttEnableWords { get; set; }
     public string DashScopeSttRegionKeyHint { get; set; }
+    public string GoogleCloudSttProjectId { get; set; }
+    public string GoogleCloudSttBucketName { get; set; }
+    public string GoogleCloudSttDynamicBatching { get; set; }
     public string OnlineSttApiKeyMissing { get; set; }
     public string OpenAiCompatibleSttAutoTranscribeOnAudioSelection { get; set; }
     public string OpenAiCompatibleSttStream { get; set; }
@@ -1593,6 +1596,9 @@ public class LanguageGeneral
         OpenAiCompatibleSttModelRejectedHint = "The server rejected the model name. Not every OpenAI compatible endpoint takes a model - xAI's https://api.x.ai/v1/stt, for one, has no 'model' parameter at all. Try clearing the Model field.";
         DashScopeSttRegion = "Region";
         DashScopeSttEnableWords = "Word-level timestamps";
+        GoogleCloudSttProjectId = "Project ID (only for Application Default Credentials)";
+        GoogleCloudSttBucketName = "Storage bucket (empty = auto)";
+        GoogleCloudSttDynamicBatching = "Dynamic batching (about 5x cheaper, no latency guarantee)";
         DashScopeSttRegionKeyHint = "Note: Alibaba Cloud Model Studio API keys are region-specific - make sure the selected region matches the region where the API key was created (China vs. International).";
         OnlineSttApiKeyMissing = "An API key is required. Please enter your API key and try again.";
         OpenAiCompatibleSttAutoTranscribeOnAudioSelection = "Auto-transcribe new waveform selection via speech-to-text";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -183,6 +183,8 @@ public class LanguageSettings
     public string DownloadMpv { get; set; }
     public string DownloadVlc { get; set; }
     public string AllowSingleLetterShortcutsInTextbox { get; set; }
+    public string AllowTextNavigationShortcutsInTextbox { get; set; }
+    public string MpvAudioBufferSeconds { get; set; }
     public string SpellCheckEnglishTreatInApostropheAsIng { get; set; }
     public string GoToLineNumberSetsVideoPosition { get; set; }
     public string AdjustAllTimesRememberLineSelectionChoice { get; set; }
@@ -493,6 +495,8 @@ public class LanguageSettings
         DownloadMpv = "Download mpv";
         DownloadVlc = "Download VLC";
         AllowSingleLetterShortcutsInTextbox = "Allow single-letter shortcuts in text box";
+        AllowTextNavigationShortcutsInTextbox = "Allow shortcuts on text-navigation keys (Ctrl+Left/Right, Home/End) in text box";
+        MpvAudioBufferSeconds = "mpv audio buffer in seconds (0 = mpv default)";
         SpellCheckEnglishTreatInApostropheAsIng = "Spell check: Treat words ending in 'in'' as 'ing' (English only)";
         GoToLineNumberSetsVideoPosition = "Go-to-line-number also sets video position";
         AdjustAllTimesRememberLineSelectionChoice = "Adjust all times, remember line selection choice";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -184,7 +184,6 @@ public class LanguageSettings
     public string DownloadVlc { get; set; }
     public string AllowSingleLetterShortcutsInTextbox { get; set; }
     public string AllowTextNavigationShortcutsInTextbox { get; set; }
-    public string MpvAudioBufferSeconds { get; set; }
     public string SpellCheckEnglishTreatInApostropheAsIng { get; set; }
     public string GoToLineNumberSetsVideoPosition { get; set; }
     public string AdjustAllTimesRememberLineSelectionChoice { get; set; }
@@ -496,7 +495,6 @@ public class LanguageSettings
         DownloadVlc = "Download VLC";
         AllowSingleLetterShortcutsInTextbox = "Allow single-letter shortcuts in text box";
         AllowTextNavigationShortcutsInTextbox = "Allow shortcuts on text-navigation keys (Ctrl+Left/Right, Home/End) in text box";
-        MpvAudioBufferSeconds = "mpv audio buffer in seconds (0 = mpv default)";
         SpellCheckEnglishTreatInApostropheAsIng = "Spell check: Treat words ending in 'in'' as 'ing' (English only)";
         GoToLineNumberSetsVideoPosition = "Go-to-line-number also sets video position";
         AdjustAllTimesRememberLineSelectionChoice = "Adjust all times, remember line selection choice";

--- a/src/ui/Logic/Config/SeTools.cs
+++ b/src/ui/Logic/Config/SeTools.cs
@@ -178,7 +178,7 @@ public class SeTools
     /// 2.5 hour episode costs about $0.44 instead of $2.32. On by default: the saving is
     /// large, it is money the user spends without ever being asked, and it measured 13.6x
     /// realtime on a 140 minute episode. Google gives no latency guarantee for it, so set
-    /// this to false in Settings.json if a run needs to come back as fast as possible.
+    /// this off in the speech-to-text window if a run needs to come back as fast as possible.
     /// </summary>
     public bool GoogleCloudSttDynamicBatching { get; set; } = true;
 
@@ -188,7 +188,7 @@ public class SeTools
     /// <summary>
     /// Let shortcuts bound to the text-navigation chords (Ctrl+Left/Right, Home/End with or
     /// without Ctrl/Shift) fire while a text input has focus, instead of reserving those keys
-    /// for caret movement (#11357). Off by default; Settings.json only for now (#14654).
+    /// for caret movement (#11357). Off by default; Settings > Tools (#14654).
     /// </summary>
     public bool AllowTextNavigationShortcutsInTextbox { get; set; }
 


### PR DESCRIPTION
Several settings added during the 5.2.0 rc stage were only editable in Settings.json. This exposes them in the UI:

- **Settings > Tools:** "Allow shortcuts on text-navigation keys (Ctrl+Left/Right, Home/End) in text box" (#14654), placed under the single-letter shortcuts checkbox.
- **Speech to text > Google Cloud:** project ID (for Application Default Credentials), storage bucket name, and a "Dynamic batching" checkbox. The engine help text and the "no project" error now point at these fields instead of Settings.json.

`MpvAudioBufferSeconds` stays Settings.json-only on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)