### PR TITLE
Add "Rename voice..." context menu to the TTS voice combo box

### DIFF
--- a/src/ui/Features/Video/TextToSpeech/Engines/VoiceFileRename.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoiceFileRename.cs
@@ -1,0 +1,137 @@
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// Renames a user-imported cloning voice on disk. Every clone engine lists its voices straight
+/// from its voices folder - one reference WAV per voice, named after the file with underscores
+/// shown as spaces - so a rename is a file move: the WAV, any sidecar beside it with the same base
+/// name (the <c>.txt</c> transcript, engine JSON, ...) and the cached
+/// <see cref="CloneReferenceTail"/> copy, which is keyed by file name and would otherwise be left
+/// behind as an orphan.
+/// </summary>
+public static class VoiceFileRename
+{
+    /// <summary>
+    /// The reference recording <paramref name="voice"/> clones from, or null when the voice is
+    /// not a renamable file-backed clone: an engine preset, the "Default" speaker, the per-line
+    /// clone marker, or a reference staged for a single line of one run.
+    /// </summary>
+    public static string? GetReferenceFilePath(Voice voice)
+    {
+        var filePath = voice.EngineVoice switch
+        {
+            ChatterboxVoice v => v.FilePath,
+            Confucius4TtsVoice v => v.FilePath,
+            CosyVoice3Voice v => v.FilePath,
+            DotsTtsVoice v => v.FilePath,
+            F5TtsVoice v => v.FilePath,
+            IndexTtsVoice v => v.FilePath,
+            MossTtsVoice v => v.FilePath,
+            OmniVoice v => v.FilePath,
+            OmniVoiceCrispAsrVoice v => v.FilePath,
+            PocketTtsVoice v => v.FilePath,
+            Qwen3TtsVoice v => v.FilePath,
+            VibeVoice v => v.FilePath,
+            VoxCPM2Voice v => v.FilePath,
+            ZonosTtsVoice v => v.FilePath,
+            _ => string.Empty,
+        };
+
+        if (string.IsNullOrEmpty(filePath) || PerLineReferenceStaging.IsStaged(filePath))
+        {
+            return null;
+        }
+
+        return filePath;
+    }
+
+    public static bool CanRename(Voice? voice) =>
+        voice != null && GetReferenceFilePath(voice) is { } path && File.Exists(path);
+
+    /// <summary>
+    /// Moves the voice's files to <paramref name="newName"/>. Returns the new reference file
+    /// name, or null with <paramref name="error"/> set when nothing was changed.
+    /// </summary>
+    public static string? Rename(Voice voice, string newName, out string error)
+    {
+        error = string.Empty;
+        var oldFileName = GetReferenceFilePath(voice);
+        if (oldFileName == null || !File.Exists(oldFileName))
+        {
+            error = "Voice file not found";
+            return null;
+        }
+
+        newName = newName.Trim();
+        if (string.IsNullOrEmpty(newName))
+        {
+            error = "Name is empty";
+            return null;
+        }
+
+        // The engines show '_' as ' ', so store spaces as underscores to round-trip the name.
+        var newBaseName = newName.Replace(' ', '_');
+        if (newBaseName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 || newBaseName.Contains("..") ||
+            newBaseName.StartsWith(PerLineReferenceStaging.Prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            error = "Name contains invalid characters";
+            return null;
+        }
+
+        var folder = Path.GetDirectoryName(oldFileName) ?? string.Empty;
+        var oldBaseName = Path.GetFileNameWithoutExtension(oldFileName);
+        var extension = Path.GetExtension(oldFileName);
+        var newFileName = Path.Combine(folder, newBaseName + extension);
+        if (string.Equals(oldBaseName, newBaseName, StringComparison.Ordinal))
+        {
+            return oldFileName;
+        }
+
+        var sameFileDifferentCase = string.Equals(oldBaseName, newBaseName, StringComparison.OrdinalIgnoreCase);
+        if (!sameFileDifferentCase && File.Exists(newFileName))
+        {
+            error = $"A voice named '{newName}' already exists";
+            return null;
+        }
+
+        try
+        {
+            // Sidecars first (a rename that fails half-way is still a usable voice); WAV last.
+            foreach (var sidecar in Directory.GetFiles(folder, oldBaseName + ".*"))
+            {
+                if (string.Equals(sidecar, oldFileName, StringComparison.OrdinalIgnoreCase) ||
+                    !string.Equals(Path.GetFileNameWithoutExtension(sidecar), oldBaseName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var target = Path.Combine(folder, newBaseName + Path.GetExtension(sidecar));
+                File.Move(sidecar, target, overwrite: sameFileDifferentCase);
+            }
+
+            File.Move(oldFileName, newFileName, overwrite: sameFileDifferentCase);
+
+            // The prepared copy is keyed on the reference's file name; the next synthesis makes
+            // a fresh one under the new name, so the old one would only be an orphan.
+            var prepared = CloneReferenceTail.GetPreparedFileName(oldFileName);
+            foreach (var stale in new[] { prepared, prepared + ".stamp" }.Where(File.Exists))
+            {
+                File.Delete(stale);
+            }
+
+            Se.WriteToolsLog($"TTS voice renamed: '{oldFileName}' -> '{newFileName}'");
+            return newFileName;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Renaming TTS voice '{oldFileName}' to '{newFileName}' failed");
+            error = ex.Message;
+            return null;
+        }
+    }
+}

--- a/src/ui/Features/Video/TextToSpeech/Engines/VoiceFileRename.cs
+++ b/src/ui/Features/Video/TextToSpeech/Engines/VoiceFileRename.cs
@@ -54,6 +54,50 @@ public static class VoiceFileRename
         voice != null && GetReferenceFilePath(voice) is { } path && File.Exists(path);
 
     /// <summary>
+    /// Deletes the voice's reference WAV, its sidecars and the cached prepared copy. Returns
+    /// false with <paramref name="error"/> set when the voice is not a file-backed clone or the
+    /// delete failed.
+    /// </summary>
+    public static bool Delete(Voice voice, out string error)
+    {
+        error = string.Empty;
+        var fileName = GetReferenceFilePath(voice);
+        if (fileName == null || !File.Exists(fileName))
+        {
+            error = "Voice file not found";
+            return false;
+        }
+
+        try
+        {
+            var folder = Path.GetDirectoryName(fileName) ?? string.Empty;
+            var baseName = Path.GetFileNameWithoutExtension(fileName);
+            foreach (var file in Directory.GetFiles(folder, baseName + ".*"))
+            {
+                if (string.Equals(Path.GetFileNameWithoutExtension(file), baseName, StringComparison.OrdinalIgnoreCase))
+                {
+                    File.Delete(file);
+                }
+            }
+
+            var prepared = CloneReferenceTail.GetPreparedFileName(fileName);
+            foreach (var stale in new[] { prepared, prepared + ".stamp" }.Where(File.Exists))
+            {
+                File.Delete(stale);
+            }
+
+            Se.WriteToolsLog($"TTS voice deleted: '{fileName}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Se.LogError(ex, $"Deleting TTS voice '{fileName}' failed");
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Moves the voice's files to <paramref name="newName"/>. Returns the new reference file
     /// name, or null with <paramref name="error"/> set when nothing was changed.
     /// </summary>

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -1996,6 +1996,67 @@ public partial class TextToSpeechViewModel : ObservableObject
         IsVoiceCountVisible = Voices.Count > 0;
     }
 
+    /// <summary>Whether the voice combo's "Rename voice..." applies to the current pick.</summary>
+    public bool CanRenameSelectedVoice() => VoiceFileRename.CanRename(SelectedVoice);
+
+    [RelayCommand]
+    private async Task RenameVoice()
+    {
+        var engine = SelectedEngine;
+        var voice = SelectedVoice;
+        if (Window == null || engine == null || voice == null || !VoiceFileRename.CanRename(voice))
+        {
+            return;
+        }
+
+        var result = await _windowService.ShowDialogAsync<PromptTextBoxWindow, PromptTextBoxViewModel>(Window, vm =>
+        {
+            vm.Initialize(Se.Language.Video.TextToSpeech.RenameVoiceTitle, voice.Name, 400, 30, returnSubmits: true);
+        });
+
+        if (!result.OkPressed || string.IsNullOrWhiteSpace(result.Text) || result.Text.Trim() == voice.Name)
+        {
+            return;
+        }
+
+        var oldName = voice.Name;
+        var newFileName = VoiceFileRename.Rename(voice, result.Text, out var error);
+        if (newFileName == null)
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.Video.TextToSpeech.RenameVoiceTitle,
+                string.Format(Se.Language.Video.TextToSpeech.VoiceXCouldNotBeRenamedX, oldName, error),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        // The engines derive the shown name from the file name, so re-read the folder and
+        // re-point everything that referenced the old name: the pick itself and any cast row.
+        var newName = Path.GetFileNameWithoutExtension(newFileName).Replace('_', ' ');
+        foreach (var mapping in _actorVoiceMappings)
+        {
+            if (mapping.VoiceName == oldName &&
+                (string.IsNullOrEmpty(mapping.EngineName) || string.Equals(mapping.EngineName, engine.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                mapping.VoiceName = newName;
+            }
+        }
+
+        if (Se.Settings.Video.TextToSpeech.Voice == oldName)
+        {
+            Se.Settings.Video.TextToSpeech.Voice = newName;
+        }
+
+        await RefreshVoices(engine);
+        var renamed = Voices.FirstOrDefault(v => v.Name == newName);
+        if (renamed != null)
+        {
+            SelectedVoice = renamed;
+        }
+    }
+
     [RelayCommand]
     private async Task ShowEncodingSettings()
     {

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechViewModel.cs
@@ -2058,6 +2058,57 @@ public partial class TextToSpeechViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task DeleteVoice()
+    {
+        var engine = SelectedEngine;
+        var voice = SelectedVoice;
+        if (Window == null || engine == null || voice == null || !VoiceFileRename.CanRename(voice))
+        {
+            return;
+        }
+
+        var answer = await MessageBox.Show(
+            Window,
+            Se.Language.Video.TextToSpeech.DeleteVoiceTitle,
+            string.Format(Se.Language.Video.TextToSpeech.DeleteVoiceXQuestion, voice.Name),
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question);
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        if (!VoiceFileRename.Delete(voice, out var error))
+        {
+            await MessageBox.Show(
+                Window,
+                Se.Language.Video.TextToSpeech.DeleteVoiceTitle,
+                string.Format(Se.Language.Video.TextToSpeech.VoiceXCouldNotBeDeletedX, voice.Name, error),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        // Cast rows that pointed at the deleted voice fall back to the global voice rather than
+        // silently landing on whichever voice the engine lists first.
+        foreach (var mapping in _actorVoiceMappings)
+        {
+            if (mapping.VoiceName == voice.Name &&
+                (string.IsNullOrEmpty(mapping.EngineName) || string.Equals(mapping.EngineName, engine.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                mapping.VoiceName = string.Empty;
+            }
+        }
+
+        if (Se.Settings.Video.TextToSpeech.Voice == voice.Name)
+        {
+            Se.Settings.Video.TextToSpeech.Voice = string.Empty;
+        }
+
+        await RefreshVoices(engine);
+    }
+
+    [RelayCommand]
     private async Task ShowEncodingSettings()
     {
         await _windowService.ShowDialogAsync<EncodingSettingsWindow, EncodingSettingsViewModel>(Window!, vm => { });

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -362,8 +362,18 @@ public class TextToSpeechWindow : Window
             Header = Se.Language.Video.TextToSpeech.RenameVoiceDotDotDot,
             Command = vm.RenameVoiceCommand,
         };
-        var voiceFlyout = new MenuFlyout { Items = { menuItemRenameVoice } };
-        voiceFlyout.Opening += (_, _) => menuItemRenameVoice.IsEnabled = vm.CanRenameSelectedVoice();
+        var menuItemDeleteVoice = new Avalonia.Controls.MenuItem
+        {
+            Header = Se.Language.Video.TextToSpeech.DeleteVoiceDotDotDot,
+            Command = vm.DeleteVoiceCommand,
+        };
+        var voiceFlyout = new MenuFlyout { Items = { menuItemRenameVoice, menuItemDeleteVoice } };
+        voiceFlyout.Opening += (_, _) =>
+        {
+            var isFileVoice = vm.CanRenameSelectedVoice();
+            menuItemRenameVoice.IsEnabled = isFileVoice;
+            menuItemDeleteVoice.IsEnabled = isFileVoice;
+        };
         comboBoxVoices.ContextFlyout = voiceFlyout;
         UiUtil.AttachMacContextFlyoutHandler(comboBoxVoices);
 

--- a/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/TextToSpeechWindow.cs
@@ -355,6 +355,18 @@ public class TextToSpeechWindow : Window
             return textBlock;
         }, true);
 
+        // Right-click: rename a user-imported clone voice (the file the engine lists it from).
+        // Presets and built-in speakers have no file, so the item is disabled for those.
+        var menuItemRenameVoice = new Avalonia.Controls.MenuItem
+        {
+            Header = Se.Language.Video.TextToSpeech.RenameVoiceDotDotDot,
+            Command = vm.RenameVoiceCommand,
+        };
+        var voiceFlyout = new MenuFlyout { Items = { menuItemRenameVoice } };
+        voiceFlyout.Opening += (_, _) => menuItemRenameVoice.IsEnabled = vm.CanRenameSelectedVoice();
+        comboBoxVoices.ContextFlyout = voiceFlyout;
+        UiUtil.AttachMacContextFlyoutHandler(comboBoxVoices);
+
         var panelVoice = new StackPanel
         {
             Orientation = Orientation.Horizontal,

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -36,6 +36,9 @@ public class LanguageTextToSpeech
     public string AddingAudioToVideoFileDotDotDot { get; set; }
     public string PreparingMergeDotDotDot { get; set; }
     public string ImportVoiceDotDotDot { get; set; }
+    public string RenameVoiceDotDotDot { get; set; }
+    public string RenameVoiceTitle { get; set; }
+    public string VoiceXCouldNotBeRenamedX { get; set; }
     public string VoiceImportSuccessTitle { get; set; }
     public string VoiceXImported { get; set; }
     public string VoiceXCouldNotBeImported { get; set; }
@@ -201,6 +204,9 @@ public class LanguageTextToSpeech
         AddingAudioToVideoFileDotDotDot = "Adding audio to video file...";
         PreparingMergeDotDotDot = "Preparing merge...";
         ImportVoiceDotDotDot = "Import voice...";
+        RenameVoiceDotDotDot = "Rename voice...";
+        RenameVoiceTitle = "Rename voice";
+        VoiceXCouldNotBeRenamedX = "Voice '{0}' could not be renamed: {1}";
         VoiceImportSuccessTitle = "Voice imported";
         VoiceXImported = "Voice '{0}' imported successfully";
         VoiceXCouldNotBeImported = "Voice '{0}' could not be imported - see the log for details";

--- a/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageTextToSpeech.cs
@@ -39,6 +39,10 @@ public class LanguageTextToSpeech
     public string RenameVoiceDotDotDot { get; set; }
     public string RenameVoiceTitle { get; set; }
     public string VoiceXCouldNotBeRenamedX { get; set; }
+    public string DeleteVoiceDotDotDot { get; set; }
+    public string DeleteVoiceTitle { get; set; }
+    public string DeleteVoiceXQuestion { get; set; }
+    public string VoiceXCouldNotBeDeletedX { get; set; }
     public string VoiceImportSuccessTitle { get; set; }
     public string VoiceXImported { get; set; }
     public string VoiceXCouldNotBeImported { get; set; }
@@ -207,6 +211,10 @@ public class LanguageTextToSpeech
         RenameVoiceDotDotDot = "Rename voice...";
         RenameVoiceTitle = "Rename voice";
         VoiceXCouldNotBeRenamedX = "Voice '{0}' could not be renamed: {1}";
+        DeleteVoiceDotDotDot = "Delete voice...";
+        DeleteVoiceTitle = "Delete voice";
+        DeleteVoiceXQuestion = "Delete voice '{0}'?\n\nThe reference recording and its files are removed from disk.";
+        VoiceXCouldNotBeDeletedX = "Voice '{0}' could not be deleted: {1}";
         VoiceImportSuccessTitle = "Voice imported";
         VoiceXImported = "Voice '{0}' imported successfully";
         VoiceXCouldNotBeImported = "Voice '{0}' could not be imported - see the log for details";

--- a/tests/UI/Features/Video/TextToSpeech/Engines/VoiceFileRenameTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/VoiceFileRenameTests.cs
@@ -1,0 +1,100 @@
+﻿using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
+using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Voices;
+
+namespace UITests.Features.Video.TextToSpeech.Engines;
+
+/// <summary>
+/// "Rename voice..." on the TTS voice combo: the clone engines list voices straight from their
+/// voices folder, so a rename has to move the reference WAV, keep its sidecars with it, and drop
+/// the cached prepared copy that is keyed by the old file name.
+/// </summary>
+public class VoiceFileRenameTests : IDisposable
+{
+    private readonly string _folder = Path.Combine(Path.GetTempPath(), "se-voice-rename-" + Guid.NewGuid().ToString("N"));
+
+    public VoiceFileRenameTests()
+    {
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_folder, recursive: true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    private Voice MakeVoice(string baseName)
+    {
+        var wav = Path.Combine(_folder, baseName + ".wav");
+        File.WriteAllBytes(wav, new byte[64]);
+        return new Voice(new Qwen3TtsVoice(baseName.Replace('_', ' '), wav));
+    }
+
+    [Fact]
+    public void Rename_MovesWavSidecarsAndDropsPreparedCopy()
+    {
+        var voice = MakeVoice("Old_Name");
+        File.WriteAllText(Path.Combine(_folder, "Old_Name.txt"), "transcript");
+        var prepared = CloneReferenceTail.GetPreparedFileName(Path.Combine(_folder, "Old_Name.wav"));
+        Directory.CreateDirectory(Path.GetDirectoryName(prepared)!);
+        File.WriteAllBytes(prepared, new byte[8]);
+        File.WriteAllText(prepared + ".stamp", "v1");
+
+        var result = VoiceFileRename.Rename(voice, "New Name", out var error);
+
+        Assert.Equal(string.Empty, error);
+        Assert.Equal(Path.Combine(_folder, "New_Name.wav"), result);
+        Assert.True(File.Exists(Path.Combine(_folder, "New_Name.wav")));
+        Assert.Equal("transcript", File.ReadAllText(Path.Combine(_folder, "New_Name.txt")));
+        Assert.False(File.Exists(Path.Combine(_folder, "Old_Name.wav")));
+        Assert.False(File.Exists(Path.Combine(_folder, "Old_Name.txt")));
+        Assert.False(File.Exists(prepared));
+        Assert.False(File.Exists(prepared + ".stamp"));
+    }
+
+    [Fact]
+    public void Rename_RefusesExistingNameAndLeavesFilesAlone()
+    {
+        var voice = MakeVoice("A");
+        MakeVoice("B");
+
+        var result = VoiceFileRename.Rename(voice, "B", out var error);
+
+        Assert.Null(result);
+        Assert.NotEqual(string.Empty, error);
+        Assert.True(File.Exists(Path.Combine(_folder, "A.wav")));
+        Assert.True(File.Exists(Path.Combine(_folder, "B.wav")));
+    }
+
+    [Fact]
+    public void Rename_RefusesEmptyAndInvalidNames()
+    {
+        var voice = MakeVoice("A");
+
+        Assert.Null(VoiceFileRename.Rename(voice, "   ", out _));
+        Assert.Null(VoiceFileRename.Rename(voice, "bad/name", out _));
+        Assert.Null(VoiceFileRename.Rename(voice, PerLineReferenceStaging.Prefix + "x", out _));
+        Assert.True(File.Exists(Path.Combine(_folder, "A.wav")));
+    }
+
+    [Fact]
+    public void CanRename_IsFalseForPresetsDefaultAndPerLineMarker()
+    {
+        Assert.False(VoiceFileRename.CanRename(null));
+        Assert.False(VoiceFileRename.CanRename(new Voice(new Qwen3TtsVoice("Default", string.Empty))));
+        Assert.False(VoiceFileRename.CanRename(new Voice(new CosyVoice3Voice("Preset", "preset"))));
+        Assert.False(VoiceFileRename.CanRename(new Voice(new PerLineCloneVoice())));
+
+        var staged = Path.Combine(_folder, PerLineReferenceStaging.Prefix + "clip.wav");
+        File.WriteAllBytes(staged, new byte[8]);
+        Assert.False(VoiceFileRename.CanRename(new Voice(new Qwen3TtsVoice("clip", staged))));
+
+        Assert.True(VoiceFileRename.CanRename(MakeVoice("Real")));
+    }
+}

--- a/tests/UI/Features/Video/TextToSpeech/Engines/VoiceFileRenameTests.cs
+++ b/tests/UI/Features/Video/TextToSpeech/Engines/VoiceFileRenameTests.cs
@@ -84,6 +84,32 @@ public class VoiceFileRenameTests : IDisposable
     }
 
     [Fact]
+    public void Delete_RemovesWavSidecarsAndPreparedCopy()
+    {
+        var voice = MakeVoice("Gone");
+        File.WriteAllText(Path.Combine(_folder, "Gone.txt"), "transcript");
+        var prepared = CloneReferenceTail.GetPreparedFileName(Path.Combine(_folder, "Gone.wav"));
+        Directory.CreateDirectory(Path.GetDirectoryName(prepared)!);
+        File.WriteAllBytes(prepared, new byte[8]);
+        MakeVoice("Kept");
+
+        Assert.True(VoiceFileRename.Delete(voice, out var error));
+
+        Assert.Equal(string.Empty, error);
+        Assert.False(File.Exists(Path.Combine(_folder, "Gone.wav")));
+        Assert.False(File.Exists(Path.Combine(_folder, "Gone.txt")));
+        Assert.False(File.Exists(prepared));
+        Assert.True(File.Exists(Path.Combine(_folder, "Kept.wav")));
+    }
+
+    [Fact]
+    public void Delete_RefusesNonFileVoices()
+    {
+        Assert.False(VoiceFileRename.Delete(new Voice(new Qwen3TtsVoice("Default", string.Empty)), out var error));
+        Assert.NotEqual(string.Empty, error);
+    }
+
+    [Fact]
     public void CanRename_IsFalseForPresetsDefaultAndPerLineMarker()
     {
         Assert.False(VoiceFileRename.CanRename(null));


### PR DESCRIPTION
## Summary
- Right-clicking the voice combo box in the Text to speech window now offers **Rename voice...** for user-imported clone voices.
- The item is disabled for engine presets, the "Default" speaker, the per-line "Clone from video" marker, and staged per-line references.
- Renaming moves the reference WAV plus its sidecars (e.g. the `.txt` transcript), drops the cached prepared-tail copy (keyed by file name), re-points cast rows and the saved voice setting, then re-reads the engine's voice list and reselects the renamed voice.
- Spaces are stored as underscores to round-trip the name the engines display. Empty names, invalid file-name characters, the staged-reference prefix, and existing names are refused with a message.

## Test plan
- [x] `VoiceFileRenameTests` (4 new tests) pass
- [ ] Import a voice for a clone engine (e.g. Qwen3 TTS.cpp), right-click the voice combo, rename it, and confirm the combo, cast dialog, and voices folder all show the new name
- [ ] Confirm the menu item is disabled on a preset / "Default" voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)