### PR TITLE
Docs: bring the user documentation up to date with 5.2

### DIFF
--- a/docs/features/ai-review.md
+++ b/docs/features/ai-review.md
@@ -14,6 +14,8 @@ Proofread the subtitle text with a local (or remote) large language model - typo
 - **Ollama** — uses a running [Ollama](https://ollama.com) instance; type a model name or pick one from the server.
 - **OpenAI-compatible** — any endpoint that speaks the OpenAI chat API: LM Studio, KoboldCpp, vLLM, a llama.cpp server on another machine, or cloud APIs (OpenAI, Groq, OpenRouter, DeepSeek, Mistral, Gemini). Enter the URL, model name, and an API key if the service needs one.
 
+Next to the llama.cpp model list is a **Start server** / **Stop server** button. An idle `llama-server` keeps the model's VRAM until Subtitle Edit closes, so stop it here when you want the GPU back without leaving the window; the next review starts it again. Stopping a running review, or closing the window, also stops a server Subtitle Edit started.
+
 ### Using a cloud model
 
 If a local model is too slow on your machine, select the **OpenAI-compatible** engine and point it at a cloud provider. Only the URL, model name and API key differ:

--- a/docs/features/assisted-split.md
+++ b/docs/features/assisted-split.md
@@ -1,0 +1,90 @@
+# Assisted Split and Assisted Move
+
+Split the selected line at one of up to five ranked split points, or move words between the selected line and its neighbours - each suggestion is shown as a full preview of the resulting lines, and one click (or one key press) applies it.
+
+- **Menu:** Right-click a line in the subtitle grid → Assisted split... / Assisted move...
+- **Shortcut:** Configurable (no default) - "Assisted split" and "Assisted move" in the General category
+
+Both tools work on the selected line and open a window with numbered cards. Each card has a title saying what the suggestion does, followed by a preview box per resulting line with the text, the start and end time, the character count and the CPS. Click a card or press its number to apply it; Escape closes the window without changing anything.
+
+The previews are produced by running the real split or move on a copy of the lines, so what a card shows is exactly what you get. Both changes go into the undo history like any other edit.
+
+## Assisted Split
+
+<!-- Screenshot: Assisted split window with numbered split candidates (assisted-split.png, not yet taken) -->
+
+Where **Split line** cuts the selected line at the middle (or at the text cursor), assisted split shows the sensible cut points first.
+
+### How to Use
+
+1. Select a line and right-click → **Assisted split...**
+2. The window shows the original text at the top and the candidates below it
+3. Click a card, or press **1** to **5**
+4. The line is split; the new second half is selected and scrolled into view
+
+If nothing sensible is found (for example a line with fewer than four characters), the status bar says *No split suggestions for this line* and no window opens.
+
+### Split Points
+
+The candidates are ranked in this order, and at most five are shown:
+
+- **Split at dialog dash** - at a line break where the next line starts with a dash
+- **Split at end of sentence** - after `.`, `!`, `?` or `…` (closing quotes and brackets stay with the sentence). A full stop glued to a letter or digit, as in `1.5` or `nikse.dk`, does not count
+- **Split at line break** - at an existing line break that is not a dialog dash
+- **Split at comma** - at the comma nearest the middle of the text
+- **Split at space nearest the middle** - always offered as a fallback
+
+Split points never land inside a `<...>` or `{...}` tag, two candidates that give the same result are shown once, and a candidate that would leave a lone dash on a line is dropped.
+
+### What the Split Does
+
+Applying a card uses the same rules as **Split line**: the time codes are divided between the halves in proportion to their text, the continuation style and tag fix-up from the rules profile are applied, and an original subtitle (when one is open) is split at the same point.
+
+## Assisted Move
+
+<!-- Screenshot: Assisted move window with numbered move candidates (assisted-move.png, not yet taken) -->
+
+Moves words across the boundary between the selected line and the previous or next line, or between the two lines of the selected subtitle. The list is context aware: word moves across a boundary are only offered when the sentence actually continues across it, so words are never pushed into a line that starts a new sentence or a new dialog.
+
+### How to Use
+
+1. Select a line and right-click → **Assisted move...**
+2. Click a card, or press **1** to **6**
+3. The selected line and the affected neighbour are updated together
+
+If the sentence neither runs on into the next line nor continues from the previous one, and the line itself has no two-line move to offer, the status bar says *No move suggestions - the sentence does not continue into the previous/next subtitle*.
+
+### Suggestions
+
+When the selected line does not finish its sentence and the next line does not open a dialog:
+
+- **Move unfinished sentence to next subtitle** - the text after the last sentence end goes to the start of the next line
+- **Balance with next subtitle** - moves as many words as it takes for both lines to hold about the same amount of text
+- **Move last word to next subtitle**
+- **Fetch first word from next subtitle**
+- **Fetch rest of sentence from next subtitle** - the next line's text up to its first sentence end joins the end of the selected line
+
+When the previous line runs on into the selected one, the mirrored set is offered: **Move rest of sentence to previous subtitle**, **Balance with previous subtitle**, **Move first word to previous subtitle**, **Fetch last word from previous subtitle** and **Fetch unfinished sentence from previous subtitle**.
+
+For a two-line subtitle that is not a dialog, two moves inside the line are added: **Move last word from first line down (current subtitle)** and **Move first word from next line up (current subtitle)**.
+
+A sentence "continues" when the earlier text does not end with `.`, `!`, `?` or `…` (closing quotes ignored) and the later text does not start with a dash. A line ending in an ellipsis still continues when the next line starts with a lowercase letter.
+
+### Timing and Line Breaks
+
+- For moves across a boundary, the boundary moves with the text: the outer start and end and the gap between the two lines are kept, and the span is divided in proportion to the new text lengths (each side keeps at least 15% of it). Moves inside a subtitle leave the time codes alone
+- Both sides are re-broken with auto-break for the detected language. Dialog lines keep their per-speaker lines and are only re-broken when a line is over the single line max length
+- A move is dropped when it would leave a lone dash on a line, or push a side over two full lines - unless that side was already over the limit and does not grow
+
+## Notes
+
+- Neither tool is available for a read-only original reference line
+- The single-step moves are also available as text box shortcuts, see [Text Editor](text-editor.md); for splitting a whole file by rules, see [Split/Break Long Lines](split-break-long-lines.md)
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| 1-5 (split) / 1-6 (move) | Apply that candidate |
+| Escape | Close without changes |
+| F1 | Open help |

--- a/docs/features/audio-visualizer.md
+++ b/docs/features/audio-visualizer.md
@@ -72,6 +72,8 @@ The waveform toolbar (when visible) provides:
 - Horizontal and vertical zoom sliders, video position slider and editable position box
 - Playback speed, auto-select on play, center, video seek, audio track picker, and a **More** menu
 
+The **audio track** picker only appears when the video has more than one audio track. Picking a track switches the video player to it and reloads the waveform for that track: from the cache if it has been extracted before, otherwise it is extracted when **Auto-generate waveform when opening a video** is on (or on click when it is off). The same choice is available from **Video → Audio tracks**, and the track is carried into the [visual sync](visual-sync.md) and [point sync](point-sync.md) dialogs.
+
 Switching between waveform and spectrogram is done from the right-click menu, and grid lines are turned on in **Options → Settings → Waveform**; neither is a toolbar button. See [Waveform Toolbar](main-window.md#waveform-toolbar) for the full list.
 
 The toolbar can be toggled from **Video → More → Toggle waveform toolbar**. Subtitle Edit 5 also supports waveform toolbar customization, including button visibility/order and import/export of toolbar settings.
@@ -109,16 +111,34 @@ All the distances live in Options → Settings → Waveform, directly under the 
 
 ## Context Menu
 
-Right-click on the waveform for options including:
-- Add subtitle at position
-- Split subtitle
-- Merge subtitles
-- Delete subtitle
-- Go to subtitle
-- Toggle shot change, or toggle a [chapter](chapters.md) at the video position
-- Extract audio, or clone the voice heard in the selected subtitle into a TTS engine (**Clone voice to**)
-- Copy the selected subtitle (Ctrl+C) or paste lines from the clipboard at the waveform position (Ctrl+V)
-- Zoom controls
+Right-click on the waveform for a menu whose first part depends on what is under the pointer. The items appear in this order:
+
+With a **new selection** (a range marked with click+drag):
+- **Insert new selection** - insert a subtitle covering the range
+- **Paste clipboard text to new selection** - insert the range with the clipboard text as its text
+- **Speech to text for new selection...** - transcribe the range (only with a video loaded)
+
+Elsewhere (the set shown depends on whether the click is on empty waveform, on a subtitle, or on the selected subtitle):
+- **Insert subtitle at video position and focus text box**
+- **Paste from clipboard** - paste lines from the clipboard at the waveform position (Ctrl+V); shown on empty waveform when the clipboard has text
+- **Insert subtitle file at video position...** - insert a whole subtitle file anchored at the right-clicked position
+- **Delete subtitle at video position**, **Delete**
+- **Insert before** / **Insert after**
+- **Copy subtitle** (Ctrl+C) / **Copy (text only)**
+- **Split line** / **Split line at waveform head**
+- **Merge with line before** / **Merge with line after**
+
+Always available:
+- **Filter by layer** (ASSA only)
+- **Guess time codes...**
+- **Toggle shot change**, or **Toggle chapter at video position** (see [chapters](chapters.md))
+- **Seek silence...**
+- **Extract audio...**, or clone the voice heard in the selected subtitle into a TTS engine (**Clone voice to**)
+- **Speech to text selected lines...** - shown when a subtitle is under the pointer
+- **Show original subtitle** - with an original subtitle loaded, draws its cues as a translucent overlay on the waveform
+- **Show only waveform** / **Show only spectrogram** / **Show waveform and spectrogram** - when a spectrogram has been generated
+
+**Copy subtitle** and **Paste from clipboard** are the waveform's Ctrl+C / Ctrl+V; **Copy (text only)** and **Paste clipboard text to new selection** ship without a default key and can be assigned in **Options → Shortcuts** (waveform category).
 
 <!-- Screenshot: Waveform context menu -->
 ![Waveform Context Menu](../screenshots/waveform-context-menu.png)

--- a/docs/features/auto-translate.md
+++ b/docs/features/auto-translate.md
@@ -19,10 +19,10 @@ Automatically translate subtitles using various translation engines and AI servi
 
 ## Supported Engines
 
-- **Google Translate V1 API** — Free Google Translate
+- **Google Translate V1 API** — Free Google Translate. When Google answers with its "unusual traffic" block page, Subtitle Edit retries the request through a fallback endpoint (`clients5.google.com`) before giving up; a block is on Google's side and is usually lifted again after minutes to a few hours
 - **Google Translate V2 API** — Google Cloud Translation (requires API key)
 - **Bing Microsoft Translator** — Azure Cognitive Services (requires API key)
-- **DeepL V2 translate** — DeepL translation (requires API key). A **Formality** dropdown — Default, More formal, Less formal, More formal (fall back to default), Less formal (fall back to default) — appears for target languages that support it
+- **DeepL V2 translate** — DeepL translation (requires API key). Every language the DeepL API offers is listed, as source and as target (including the target-only regional variants such as fr-CA and de-CH). A **Formality** dropdown — Default, More formal, Less formal, More formal (fall back to default), Less formal (fall back to default) — appears for target languages that support it
 - **LibreTranslate** — Open-source, self-hosted translation
 - **MyMemory Translate** — Free translation memory
 - **ChatGPT** — OpenAI AI translation (requires API key)
@@ -112,6 +112,10 @@ The **llama.cpp advanced** and **Ollama advanced** engines translate in batches 
 ## Translation Review
 
 The translation grid shows the original text alongside the translated text. You can edit individual translations before accepting them.
+
+Engines keep the source's line breaks and often add their own, so a two-line source can come back as three short lines that no long-line tool would touch. After translating, a row with more lines than the *maximum number of lines* or a line longer than the single-line limit is un-broken and auto-broken again with the target language's rules. Rows that already fit are left alone, and lyrics (♪) and CJK targets are never re-broken.
+
+Switching engine to compare results keeps the source and target languages you picked, as long as the new engine offers them - only then does the default derived from the subtitle take over.
 
 ## Keyboard Shortcuts
 

--- a/docs/features/batch-convert.md
+++ b/docs/features/batch-convert.md
@@ -82,6 +82,20 @@ Supported OCR engines in Batch Convert:
 
 Subtitle Edit 5 can auto-detect language and pixels-are-space settings for nOcr/BinaryOcr in many batch workflows. This reduces the amount of manual setup needed when converting many image-based subtitle files with similar fonts.
 
+## Transport Stream Input
+
+A transport stream (`.ts`, `.m2ts`, `.mts`, or `.mpg`/`.mpeg` containing one) is listed as one item, and every subtitle track in it is converted: each DVB image track, every teletext page on every PID - one PID can carry several pages, e.g. 888 and 889 for a second language, and each page becomes its own output file - and ARIB STD-B24 caption tracks. Each output is named from the source file plus the file name ending template below, e.g. `movie.en.srt`; a track without a language code in the stream gets its PID or teletext page number instead, so two language-less tracks never collide.
+
+When a transport stream is in the list, a **Transport Stream settings...** button appears:
+
+- **Override original X position** - replace the DVB subtitle's own horizontal position with an alignment (left, center, right) and a left/right margin in percent of the screen width
+- **Override original Y position** - replace the vertical position with a bottom margin in percent of the screen height
+- **Override original video size** - scale the screen size, bitmaps and positions to the width and height you enter (**Get size from video...** reads them from a video file)
+- **File name ending** - text added before the extension for every extracted track, with placeholders for the two- or three-letter language code in lowercase or uppercase; the default is `.{two-letter-country-code}`. Leave it empty to use the regular language post fix instead
+- **Only teletext** - skip the DVB image tracks and convert only the teletext (and other text) tracks
+
+Position and video size only affect DVB image tracks exported to an image-based format.
+
 ## Speech to Text in Batch Mode
 
 Speech-to-text batch mode can transcribe multiple media files and save the results next to the source files. See [Speech to Text](speech-to-text.md) for engine setup and model details.

--- a/docs/features/binary-edit.md
+++ b/docs/features/binary-edit.md
@@ -11,10 +11,14 @@ Edit image-based subtitles — Blu-ray SUP, VobSub, DVB, BDN XML — directly, w
 ## Supported Files
 
 - Blu-ray SUP (`.sup`)
+- DVD sup (`.sup` with SP packets, e.g. demuxed with SubRip or Subtitle Processor)
 - VobSub (`.sub` + `.idx`)
-- Transport stream (`.ts`) with DVB subtitles
+- Transport stream (`.ts`, `.m2ts`, `.mts`, `.rec`) with DVB subtitles
 - Matroska (`.mkv`/`.mks`) with PGS, VobSub, or DVB tracks
-- BDN XML (`.xml`)
+- MP4/MOV (`.mp4`, `.m4v`, `.mov`, `.3gp`) with VobSub image tracks
+- XSUB/DivX subtitles in `.avi`/`.divx`
+- WebVTT with embedded base64 images (`.vtt`, `.webvtt`)
+- BDN XML, Final Cut Pro image xml, and SMPTE-TT/IMSC with base64 images (`.xml`, `.ttml`, `.dfxp`)
 
 ## Window Layout
 
@@ -32,10 +36,13 @@ From the Tools menu (all lines) or the right-click menu (selected lines):
 - **Alignment** / **Center horizontally** / **Top align** / **Bottom align** — Reposition using the margins from the window's Options → Settings
 - **Resize images...** — Scale the bitmaps by a percentage
 - **Crop images** — Trim transparent borders
+- **Video resolution...** - Re-target the subtitle to another screen resolution (a preset or a custom width and height): every bitmap and every X/Y position is scaled by the width and height ratios, so a 1080p file keeps its layout at 720p or PAL. Changing the screen size fields alone only re-labels the canvas
+- **Move captions...** - For letterboxed video: pick the letterbox ratio (1.66:1 to 2.40:1, or a custom bar height) and move the captions **Into the letterbox bars (outside the picture)** or **Inside the picture (out of the bars)**, keeping an **Offset from edge (px)**. Captions centred in the upper half of the screen go to the top edge, the rest to the bottom edge; the dialog shows how many captions will move. From the right-click menu it moves only the selected lines
 - **Adjust brightness...** / **Adjust alpha (transparency)...** / **Adjust color...** — Image corrections with live preview
 - **Adjust durations...** / **Apply duration limits...** — Same duration tools as for text subtitles
 - **Append subtitle...** — Append another image-based file, keeping its time codes or offsetting them
 - **Sort by start time**
+- **Remove fade in/out** - Authoring tools write a fade as a run of back-to-back captions that share one image and differ only in transparency; this collapses each run (gaps up to 50 ms) into a single caption spanning the whole time, using the most opaque image
 
 The right-click menu additionally offers **Insert before** / **Insert after** (a new line from an image file), **Toggle forced**, **Select forced/non-forced lines**, and **Show earlier/later...**.
 

--- a/docs/features/edit.md
+++ b/docs/features/edit.md
@@ -52,6 +52,8 @@ Find and replace text in the subtitle.
 - **Menu:** Edit → Replace
 - **Shortcut:** `Ctrl+H`
 
+The buttons have Alt accelerators, underlined while Alt is held: `Alt+F` **Find next**, `Alt+R` **Replace & find next**, `Alt+A` **Replace all**. As in Subtitle Edit 4, the bare letter (`F`, `R`, `A`) also works once the focus has left the text boxes, e.g. after clicking a button. The Find window has `Alt+F` **Find next** and `Alt+P` **Find previous** the same way. `Ctrl+Delete` removes the current search text from the search history.
+
 With an editable original subtitle loaded, a **Replace/search in** drop-down appears with three choices:
 
 - **Text and original text** - both columns (the default, and what Find always does)
@@ -108,6 +110,8 @@ Each rule has one of three match types, shown as an icon in the tree:
 | Regular expression | Full .NET regex syntax. Use `\n` to match a line break between two lines (`\r\n` and `\r` are accepted too and treated as `\n`). |
 
 Unlike Find and Replace, regular expression rules here are matched in multiline mode: `^` and `$` match at the start and the end of *every* line, so `^- ` strips the dash from both lines of a two-line subtitle. Put `(?-m)` in front of the pattern to anchor to the whole subtitle text instead. The replacement text follows the same rules as in Replace above - `$1` and `\n` work, other backslash escapes do not.
+
+> **Slow patterns:** the same five-second match timeout as in Find applies to each rule on each line. A rule that runs out of time is retired for the rest of the pass and flagged in the tree with "Regular expression gave up after 5 seconds - the rule is skipped, try a simpler pattern", so a catastrophically backtracking pattern shows up as an error rather than as a rule that silently matches nothing. The timeout is fixed; there is no setting for it.
 
 ### Managing categories
 

--- a/docs/features/file.md
+++ b/docs/features/file.md
@@ -27,6 +27,8 @@ Open an existing subtitle file.
 - **Menu:** File → Open
 - **Shortcut:** `Ctrl+O`
 
+The format is detected automatically. A file that no known format claims is tried with the generic importers - plain lines with time codes, CSV, JSON, spreadsheets, and a generic XML importer that finds the repeated element carrying time codes and text in an unknown XML dialect. If that still yields nothing, a `.txt` file goes straight to [Import plain text](import-plain-text.md), as SE 4 did; for other extensions the "unknown subtitle format" error has an **Import plain text** button that sends the file there instead - handy for unsynced lyrics or a script.
+
 ### Open (keep video)
 
 Open a subtitle file while keeping the currently loaded video.
@@ -52,6 +54,8 @@ Save the current subtitle to a new file or format.
 
 - **Menu:** File → Save as...
 - **Shortcut:** `Ctrl+Shift+S`
+
+Formats new in 5.2 in the format list include EBU-TT (Tech 3350), Csv Excel, Wistia json, DVD Junior SPC, Sonic DVD Producer, YouTube timed text srv3, DaVinci Resolve Marker EDL, Adobe Premiere Markers, Audacity labels and Final Cut Pro Xml Captions - see [Supported Formats](../reference/supported-formats.md).
 
 ## Save Forced Lines As
 
@@ -89,7 +93,7 @@ Import plain text and create subtitle lines from it, with optional forced-aligne
 
 See [Import Plain Text](import-plain-text.md) for details.
 
-### Import images
+### Images for OCR
 
 Import image files and create subtitle entries from them.
 
@@ -162,6 +166,17 @@ Export subtitles as images. The Export submenu lists: Blu-ray (sup), BDN/xml, BD
 **BDN/xml** writes 32-bit PNGs; **BDN/xml 8-bit** writes the same index.xml with 8-bit palette-indexed PNGs, which is what most Blu-ray authoring tools expect.
 
 The **IMSC 1.1 image profile** export writes a single self-contained TTML file with each subtitle embedded as a base64 PNG (`smpte:image` / `smpte:backgroundImage`), media timebase, and percentage-positioned regions — the standardized image-subtitle carriage for streaming and broadcast delivery.
+
+#### Text effects
+
+Tick **Text effect** (next to the bold and right-to-left check boxes) and press the settings button beside it to pick a **Preset** and tune it with **Strength**, **Letter spacing**, **Curve** and **Wave**. Every size in a preset scales with the font size, and presets use the window's font, outline and shadow colours where that is natural (the "signature" looks such as gold, chrome and fire bring their own palette). The presets, as listed in the settings window:
+
+- Shadow and outline: Soft shadow, Double outline, Hollow (outline only), Emboss, Comic book
+- Glow and 3D: Neon glow, 3D extrude, 3D glasses, Retro 80s
+- Gradients and materials: Gradient (gold), Chrome, Brushed steel, Ice, Fire, Lava, Marble, Wood
+- Patterns: Rainbow, Candy cane, Polka dots
+
+The same setting is used by Batch convert's image-based output, so the two cannot drift apart.
 
 #### ASSA override tags
 

--- a/docs/features/import-plain-text.md
+++ b/docs/features/import-plain-text.md
@@ -4,6 +4,7 @@ Turn a plain text file — or pasted text — into subtitle lines, with generate
 
 - **Menu:** File → Import → Plain text...
 - **Shortcut:** Configurable (no default)
+- **Also:** Opening a file Subtitle Edit cannot read lands here too - a plain `.txt` file goes to this window directly, and for other extensions the "unknown subtitle format" error offers an **Import plain text** button. See [File → Open](file.md#open)
 
 <!-- Screenshot: Import plain text window -->
 ![Import Plain Text](../screenshots/import-plain-text.png)

--- a/docs/features/list-errors.md
+++ b/docs/features/list-errors.md
@@ -1,0 +1,64 @@
+# List Errors
+
+List every line that breaks a rule - reading speed, duration, line length, overlaps and gaps - with one summary card per error type, and export the list to the clipboard, a text file, Excel or a web page.
+
+- **Menu:** Tools → List errors...
+- **Shortcut:** Ctrl+F8 (Cmd+F8 on macOS)
+
+<!-- Screenshot: List errors window with summary cards and the error table (list-errors.png, not yet taken) -->
+
+The checks are the same ones that color cells in the [subtitle grid](subtitle-grid.md): which checks run is set by the **Syntax coloring** switches in [Settings](settings.md#syntax-coloring), and their limits come from the active rules profile in **Settings → Rules**.
+
+## How to Use
+
+1. Open **Tools → List errors...**
+2. The header gives the verdict: *N error(s) in X of Y line(s)*, or *No errors found.*
+3. Click a summary card to show only that error type; **All** shows everything again
+4. Select a row and click **Go to** (or double-click it, or press Enter) to jump to that line in the grid
+
+A line with several errors appears once per error. The table has the columns **#**, **Error** (with the type's color dot), **Show**, **Hide**, **Detail** and **Text**; Home and End jump to the first and last row.
+
+## Error Types
+
+| Card | Detail column | Setting |
+|------|---------------|---------|
+| Too many lines | `3 > 2` | Color text if more than X lines / Max number of lines |
+| Reading speed | `27.3 > 25` | Color characters/sec if too high / Max chars/sec |
+| Too short | `600 < 1000` (ms) | Color duration if too short / Min duration |
+| Too long | `9000 > 8000` (ms) | Color duration if too long / Max duration |
+| Line too long | `48 > 43`, one row per line | Color text if too long / Single line max length |
+| Line too wide | `1140 > 1040` (pixels) | Color text if too wide / its pixel width |
+| Overlapping | `from previous: 120 ms` or `to next: ...` | Color time code overlap |
+| Gap too short | `to next: 40 < 83 ms` | Color if gap is too short / Min gap |
+
+Subtitles read from EBU STL or teletext are also checked against the teletext page width, regardless of the "too long" setting.
+
+## Export
+
+**Export...** (enabled while the table has rows) offers four targets:
+
+- **Copy to clipboard** - tab separated, so it pastes as columns into Excel or Sheets and as a readable block anywhere else. A *Copied to clipboard* note appears next to the buttons for a few seconds
+- **Text file (.txt)...**
+- **Excel file (.xlsx)...**
+- **Web page (.html)...** - the same summary cards and colors as the window, as a standalone page
+
+Every target exports the rows exactly as shown, so an active card filter is part of what is exported. The text and web page exports also carry the summary line and the subtitle file name. The suggested file name is the subtitle's name with `-errors` appended; after saving, the usual file-saved prompt offers to open the folder.
+
+## In Batch Convert
+
+[Batch convert](batch-convert.md) has its own **List errors** in the menu of the **Convert** split button. After a conversion it lists the errors of all converted files with an extra **File name** column and the same summary cards; its **Export...** writes a CSV file (file name, line number, text, error).
+
+## Tips
+
+- **F8** and **Shift+F8** (*GoTo next error* / *GoTo previous error*) walk through the error lines directly in the grid without opening this window
+- Reading speed, duration and gap errors are often fixed in one go by [Fix Common Errors](fix-common-errors.md), [Apply Duration Limits](apply-duration-limits.md) and [Apply Minimum Gap](apply-min-gap.md); line length by [Split/Break Long Lines](split-break-long-lines.md)
+- For Netflix delivery rules use [Check and Fix Netflix Errors](netflix-errors.md) instead
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Enter / double-click | Go to the selected line |
+| Home / End | First / last row |
+| Escape | Close |
+| F1 | Open help |

--- a/docs/features/main-window.md
+++ b/docs/features/main-window.md
@@ -18,15 +18,15 @@ The menu bar provides access to all features organized into categories:
 
 | Menu | Description |
 |------|-------------|
-| **File** | New, New window, Open, Save, Save as, Save forced lines as, Close translation, format properties, Import, Export, Compare, Statistics |
-| **Edit** | Undo, Redo, Find, Replace, Multiple Replace, Go to line number, right-to-left tools (fix RTL via Unicode control chars, remove Unicode control chars, reverse RTL start/end), Modify Selection |
-| **Tools** | Fix Common Errors, Batch Convert, Change Casing, Merge/Split, etc. |
+| **File** | New, New (keep video), New window, Open, Open (keep video), Open original, Edit original subtitle, Close original, Close translation, Reopen, Restore auto-backup, Save, Save as, Save forced lines as, format properties, Open containing folder, Compare, Statistics, Import, Export, Exit |
+| **Edit** | Undo, Redo, Show history for undo, Find, Find next, Replace, Multiple replace, Go to line number, Right-to-left mode and the RTL tools (fix RTL via Unicode control chars, remove Unicode control chars, reverse RTL start/end), Modify selection, Invert selection, Select all |
+| **Tools** | Adjust durations, AI review, Apply duration limits, Apply min. gap between subtitles, Batch convert, Beautify time codes, Bridge gaps, Change casing, Change formatting, Check and fix Netflix errors, Convert actors, Fix common errors, List errors, Make new empty translation from current subtitle, Merge continuation lines, Merge lines with same text, Merge lines with same time codes, Merge short lines, Merge two subtitles, Remove text for hearing impaired, Remove/replace Unicode characters, Renumber, Snap all times to frames, Sort subtitles, Split/rebalance long lines, and below a separator Join subtitles and Split subtitle |
 | **Plugins** | Run installed plugins; manage installed plugins (only shown when **Options → Settings → Appearance → Show Plugins menu** is on) |
-| **Spell check** | Spell checking, dictionaries, find double words / lines |
-| **Video** | Open/close video, Speech to Text, Text to Speech, Burn-In, etc. |
-| **Sync** | Adjust All Times, Visual Sync, Point Sync, Change Frame Rate/Speed |
-| **Translate** | Auto Translate, Copy/Paste Translate |
-| **Options** | Settings, Shortcuts, Word Lists, Language |
+| **Spell check** | Spell check, Find double words, Find double lines, Add name to names list, Get dictionaries |
+| **Video** | Open video, Open video from URL, Open recent video, Close video file, Open/remove second subtitle file, Audio tracks, Go to video position, Speech to text, Text to speech, OCR burned-in subtitle, Generate video with burned-in subtitles, Generate transparent video with subtitles, Generate blank video, Embed subtitles, Generate/import shot changes, List shot changes, Undock/Dock video controls, Toggle select subtitle while playing, and a **More** submenu (Chapters, Cut video, Find voices in video and clone, Re-encode video, Remux video, Set video offset, SMPTE timing, Toggle waveform toolbar) shown while a video is loaded |
+| **Synchronization** | Adjust all times, Visual sync, Point sync, Point sync via other subtitle, Change frame rate, Change speed |
+| **Translate** | Auto-translate, Auto-translate via copy-paste |
+| **Options** | Settings, Shortcuts, Word lists, Choose UI language |
 | **Help** | Check for updates, Help, About |
 | **ASSA tools** | Styles, Properties, Attachments, Drawing, Positioning, etc. (only visible when an ASSA/SSA subtitle is loaded) |
 

--- a/docs/features/ocr.md
+++ b/docs/features/ocr.md
@@ -30,6 +30,7 @@ Built-in trainable OCR engine.
 - Train character databases for specific fonts
 - Very accurate once trained
 - Best for consistent fonts (like DVD/Blu-ray subtitles)
+- **Train nOCR database...** - a database can also be trained from installed fonts instead of being taught during OCR. Open the nOCR database settings (the settings button next to the database list) and right-click anywhere in that dialog to reach it. Pick one or more fonts, a font size, the characters to train (or **Import characters from subtitle file...**), letter combinations that might end up in one image, whether to include bold and italic, and the number of line segments; **Start training** renders every character in every selected font and saves the result as a new `.nocr` database in the OCR folder, ready to pick from the database list
 
 ### Binary OCR
 Binary image comparison engine, listed as **Binary image compare** in the engine dropdown.
@@ -74,9 +75,9 @@ Cloud-based OCR using Mistral API.
 - Requires a Mistral API key
 
 ### Paddle OCR Standalone / Paddle OCR Python
-Local OCR engine.
+Local OCR engine, based on Paddle OCR 3.7 with the PP-OCRv6 recognition models.
 - Standalone (downloadable CPU/GPU builds) is available on Windows and Linux.
-- The Python variant works anywhere a Paddle OCR Python install is available.
+- The Python variant works anywhere a Paddle OCR Python install is available. It uses the same downloaded models, so it needs `paddleocr` 3.7 or newer - older versions do not know the PP-OCRv6 model names.
 
 ## Engine Setup Notes
 
@@ -96,6 +97,12 @@ Local OCR engine.
 5. Click **Start OCR**
 6. Review and correct any errors
 7. Click **OK** to import the text subtitles
+
+After **OK**, the matching video is opened as well (unless auto-opening the video is turned off in the settings): a container source (`.mkv`, `.mp4`, `.ts`) is opened as the video itself; for a stand-alone image subtitle (`.sup`, `.sub`/`.idx`, ...) a video passed together with the file (drag and drop, command line) is used first, then the video the subtitle was last opened with, then a video file with the same name next to the subtitle.
+
+## Language Auto-detection
+
+When the OCR window opens, the OCR language for every engine - and through it the spell check dictionary - is pre-selected from the source's declared language: the stream language in a VobSub `.idx`, the track language of a Matroska or MP4 subtitle track, or a language tag in the file name. Two file-name patterns are recognised: a bracketed ISO 639 code such as `movie_track3_[dut].sup` (the naming used by Subtitle Edit's own Matroska track export; the last valid code wins), and a trailing dot-separated tag such as `movie.nl.sub` or `movie.dut.forced.sub` - the `hi`, `sdh`, `cc` and `forced` markers are skipped, only the last two remaining tokens are considered, three-letter codes must be lowercase, and `hi` is read as hearing impaired rather than Hindi. A detected language wins over the last-used one; a source without language information keeps the previous selection.
 
 ## Options
 

--- a/docs/features/point-sync-via-other.md
+++ b/docs/features/point-sync-via-other.md
@@ -18,4 +18,8 @@ Synchronize a subtitle file using another subtitle file as reference.
 
 Both grids have a **Gap** column with the silence before each line; lines starting after 3+ seconds of silence are highlighted, as they often make reliable sync points. **Find text** above each grid searches that subtitle.
 
+The sync point list in the middle is kept in subtitle order, and a line has at most one sync point - setting one again for the same line re-points it. **Delete** in the list's right-click menu, or Delete/Backspace with the list focused, removes the selected point; **OK** and **Apply** need at least one point.
+
+**Set sync point via video...** opens the same window as [Point sync](point-sync.md#set-sync-point-window): the video with the subtitle drawn on it, playing the audio track selected in the main window, and a **Sync point time code** box that follows the video and can be edited by hand. Opened from here the window has no waveform pane.
+
 The window remembers its size and position between sessions.

--- a/docs/features/point-sync.md
+++ b/docs/features/point-sync.md
@@ -15,3 +15,19 @@ Synchronize subtitles using multiple reference points.
 4. Click **OK** to apply
 
 More sync points provide better accuracy for subtitles with non-linear drift. The window remembers its size and position between sessions.
+
+## Sync Points List
+
+- The list is kept in subtitle order, however the points were added
+- A line has at most one sync point: setting a sync point for a line that already has one **re-points** it instead of adding a second
+- **Delete** in the list's right-click menu, or the Delete/Backspace key with the list focused, removes the selected point; **OK** is only enabled while at least one point is left
+
+## Set Sync Point Window
+
+**Set sync point** opens a window with the video, the subtitle drawn on it like on the main window's video, and a waveform below when the main window has one - drag the handle between them to resize the waveform (the height is remembered).
+
+- **Sync point time code** box: follows the video position while it plays or seeks, and can be edited directly - while the box has the focus the video leaves it alone. With no video loaded the box is the sync point, seeded with the line's own start time
+- **One second back** / **One second forward**, **Play 2 secs & back**, **Go to sub pos** and **Find text** work as in Visual sync; without a video the nudge buttons move the time code box instead
+- The video uses the audio track selected in the main window; **Open video file...** loads a video when none is open (a video found next to the subtitle file is used automatically)
+- Click **Set sync point** to take the time code back to the list
+

--- a/docs/features/remove-unicode-characters.md
+++ b/docs/features/remove-unicode-characters.md
@@ -1,0 +1,51 @@
+# Remove/replace Unicode Characters
+
+Find every character outside Latin-1 (code point above 255) in the subtitle and remove or replace each one - the Subtitle Edit 4 "Remove Unicode characters" plugin, now built in.
+
+- **Menu:** Tools → Remove/replace Unicode characters...
+- **Shortcut:** None (menu only)
+
+<!-- Screenshot: Remove/replace Unicode characters window with the character table (remove-unicode-characters.png, not yet taken) -->
+
+Typical targets are typographic quotes and apostrophes, the `…` ellipsis, em and en dashes, music notes and emoji - characters that some players, encoders or delivery formats cannot show. Accented Latin-1 letters such as `é`, `ü` and `ñ` are below the limit and are not listed.
+
+## How to Use
+
+1. Open **Tools → Remove/replace Unicode characters...**; the whole subtitle is scanned and the status line says *Unicode characters found: N* (or *No Unicode characters found*)
+2. Tick **Apply** for the characters to change
+3. Leave **Replace with** empty to remove the character, or type the replacement (for example `...` for `…` or `"` for `“`)
+4. Click **OK** - the change is applied to every line, and can be undone like any other edit
+
+## The Table
+
+| Column | Content |
+|--------|---------|
+| Apply | Whether the row is applied on OK (all rows start ticked) |
+| Character | The character itself |
+| Unicode | Its code point, e.g. `U+2026` |
+| Count | How many times it occurs in the subtitle |
+| Replace with | Editable replacement text; empty means remove |
+| Lines | The line numbers it occurs in, e.g. `1, 5, 7` |
+
+Rows are sorted by code point. Characters are counted per rune, so an emoji made of a surrogate pair is one row, not two broken halves.
+
+- **Select all** ticks every row; **Invert selection** flips them
+- With one or more rows selected, **Space** toggles their Apply boxes (typing a space in a Replace with box still inserts a space)
+
+## Remembered Replacements
+
+Every non-empty **Replace with** is saved when you click OK and filled in again the next time the same character shows up, in any subtitle. Clearing a box and clicking OK forgets that mapping. Characters not present in the current subtitle keep their saved replacements untouched.
+
+## Notes
+
+- The tool works on the whole subtitle, not on the selection
+- It replaces plain text only; tags such as `<i>` are left alone, but a listed character inside a tag (for example in a font name) is replaced too
+- For the invisible right-to-left control characters use **Edit → Remove Unicode control chars (selected lines)** instead, see [Edit Menu](edit.md)
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Space | Toggle Apply for the selected rows |
+| Escape | Close without changes |
+| F1 | Open help |

--- a/docs/features/remux-video.md
+++ b/docs/features/remux-video.md
@@ -1,0 +1,58 @@
+# Remux Video
+
+Repackage the video with new audio tracks and optional soft subtitles into an MP4 or MKV file without re-encoding the video.
+
+- **Menu:** Video → More → Remux video...
+- **Shortcut:** None (menu only)
+
+<!-- Screenshot: Remux video window with the video, audio and subtitle sections (remux-video.png, not yet taken) -->
+
+Remuxing copies the streams into a new container, so it is quick and lossless. Use it to attach a dubbed or translated audio track (for example from [Text to Speech](text-to-speech.md)), to add subtitle tracks that can be switched on and off in the player, or to convert between MP4 and MKV. To draw the subtitle into the picture instead, see [Burn-In Subtitles](burn-in.md).
+
+The **More** submenu is shown while a video is loaded, and ffmpeg is required (you are offered to download it when it is missing).
+
+## How to Use
+
+1. Open **Video → More → Remux video...**
+2. **Input video** is filled with the loaded video, and its own audio is placed first in the audio list (with several audio tracks you are asked which one to use)
+3. **Add...** the audio files and, optionally, the subtitle files
+4. Pick the **Output format** and check the **Output file** name
+5. Click **Remux**; a progress bar shows how far ffmpeg has come
+6. When done, a file-saved prompt appears and **Open containing folder** and **Play** buttons show up next to **Done**
+
+**Cancel** while remuxing stops ffmpeg and deletes the partial output file. The window is not modal, so the main window stays usable while it is open; only one remux window can be open at a time.
+
+## Input Video
+
+Accepted formats: `.mp4`, `.mkv`, `.avi`, `.webm`, `.ts`. The first video stream is copied as-is.
+
+## Audio Files
+
+Accepted formats: `.mp3`, `.aac`, `.ac3`, `.wav`, `.mkv`, `.mka`, `.mp4`. At least one audio file is required.
+
+- Each file becomes one audio track, in list order - use **Move up** / **Move down** (Ctrl+Up / Ctrl+Down) to change the order, **Remove** (Delete) or **Clear** to drop entries
+- A file with several audio tracks asks which track to use when it is added; **Select audio track...** in the list's right-click menu changes it later
+- The video's own audio is included only while it is in the list - remove it to replace the original sound entirely
+- Each track gets a title (the file name, or the track name for multi-track files) and, when known, its language
+- For an `.mp4` output, `.wav` audio is encoded to AAC (192 kb/s); everything else is copied
+
+## Subtitle Files
+
+Accepted formats: `.srt`, `.ass`, `.ssa`, `.vtt`, `.sub`. These become soft subtitle tracks (selectable in the player, not burned in), one per file, titled after the file name. In an MKV the file is stored unchanged; in an MP4 it is converted to the MP4 text subtitle format (mov_text), which loses styling.
+
+## Output Format and File
+
+- **Output format** is `.mp4` or `.mkv`; the default follows the input video (MKV in, MKV out; anything else MP4)
+- **MKV is required**, and switched to automatically with a message, when there is more than one audio file, more than one subtitle file, or an `.ass`/`.ssa` subtitle (to keep its styles)
+- **Output file** defaults to the video name with `_remuxed` appended, next to the video; a number is added if that file exists. It cannot be one of the input files
+
+The window remembers its size and position.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| Ctrl+Up / Ctrl+Down | Move the selected audio or subtitle file up / down |
+| Delete | Remove the selected file from its list |
+| Escape | Close (not while remuxing) |
+| F1 | Open help |

--- a/docs/features/seconv.md
+++ b/docs/features/seconv.md
@@ -8,6 +8,7 @@ seconv movie.srt subrip --encoding:source --FixCommonErrors
 seconv movie.mkv subrip --track-number:3
 seconv movie.sup subrip --ocr-engine:tesseract --ocr-language:eng
 seconv movie.sub subrip --ocr-engine:binaryocr --ocr-db:Latin.db   # VobSub (.idx auto-detected)
+seconv movie.sup subrip --ocr-engine:llamacpp                      # llama.cpp vision model, auto-starts llama-server
 seconv movie.sub subrip --ocr-engine:tesseract --no-vobsub-isolate-colors  # OCR raw palette (isolation is on by default)
 seconv movie.sup subrip --time-codes-only
 seconv movie.avi subrip --ocr-engine:tesseract --ocr-language:eng   # XSUB (DivX) subtitles in an .avi

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -11,7 +11,7 @@ Configure application preferences, rules and profiles, appearance, video player,
 ## How to Use
 
 1. Open **Options → Settings...**
-2. Pick a section from the icons on the left
+2. Pick a section from the icons on the left, or type in the **Search for settings...** box at the top to jump to a setting by name
 3. Adjust settings as needed
 4. Click **OK** to save
 
@@ -31,18 +31,21 @@ The subtitle rules that drive error checking, the grid's warning colors, and too
 
 ## General
 
+- **Default new subtitle duration (ms)** - The duration a newly inserted subtitle gets, e.g. when inserting at the video position
+- **Time up/down increment (ms)** - The step of the start/end/duration up-down boxes in millisecond mode
 - **Prompt before delete**, **Lock time codes**, **Remember window position and size**
 - **Use frame mode (hh.mm.ss.ff)** — Show times as frames instead of milliseconds
 - **Limit number of lines in subtitle text box**
 - **Open last recent file on start**
 - **Auto-convert encoding to UTF-8 on open**, **Force CR+LF on save**, **Auto-trim white-space**
+- **Warn on save when lines exceed the format's limits (e.g. SCC 32 chars/line)**
 - **Remove blank lines when opening a subtitle** — Off by default
 - **Default encoding**
 - **Subtitle grid Enter-key / single-click / double-click action** — What each gesture does to the video position and focus
 - **Subtitle grid, center when selecting prev/next row**
 - **Save as behavior**, **Save as: append language code**, **Default save location** (with a custom folder)
 - **Auto-save** — Save the open file while editing
-- **Auto-backup** — Automatic backups at a set interval, with a restore dialog
+- **Auto-backup** — Automatic backups at a set interval, with a restore dialog, and **Auto-backup retention (days)** for how long they are kept
 
 ## Subtitle Formats
 
@@ -88,6 +91,7 @@ The subtitle rules that drive error checking, the grid's warning colors, and too
 ## Tools
 
 - **Allow single-letter shortcuts in text box**
+- **Allow shortcuts on text-navigation keys (Ctrl+Left/Right, Home/End) in text box** - Off by default, so the keys keep moving the caret even when a shortcut is bound to them
 - **Go-to-line-number also sets video position**
 - **Adjust all times, remember line selection choice**
 - **Merge lines: keep end time (allow overlap with next subtitle)**, and the variant that limits it to ASSA files
@@ -107,7 +111,8 @@ The subtitle rules that drive error checking, the grid's warning colors, and too
 - **Theme**, **icon theme**, **match icon color to dark theme foreground color**, **UI scale (%)**
 - **Dark theme foreground / background color**, **focused button background color**
 - **UI font**, and a separate font for the subtitle text box and grid
-- **Grid** — Show subtitle text as single line (with the separator to use), text fit, [show formatted text](subtitle-grid.md#formatting-display), live spell check, compact mode, alternating row colors (light and dark), grid lines, bookmark color
+- **Grid** — Show subtitle text as single line (with the separator to use), text fit, [show formatted text](subtitle-grid.md#formatting-display), live spell check, **Center text in subtitle grid** (centers the text column, as Subtitle Edit 4 could), compact mode, alternating row colors (light and dark), grid lines, bookmark color
+- **Spell check highlight color** - The color of the unknown word highlighted in the spell check and OCR unknown-word windows (red by default; pick a lighter color for the dark theme)
 - **Subtitle text box** — Bold text, color tags, live spell check, centered text, and which buttons are shown (auto-break, unbreak, italic, color, remove formatting, AI assistant), the up/down start/end/duration controls and their labels
 - **Show button hints** — Turns the tooltips on and off
 - **Show ASSA layer box**, **show horizontal line above toolbar**, **show Plugins menu**

--- a/docs/features/speech-to-text.md
+++ b/docs/features/speech-to-text.md
@@ -15,11 +15,12 @@ Subtitle Edit can automatically transcribe audio to text using Whisper-based and
 | Purfview Faster Whisper XXL | Windows, Linux | Fast local engine, often used with NVIDIA CUDA |
 | Whisper CTranslate2 | Windows, Linux (x64), macOS (Apple Silicon) | CPU / NVIDIA CUDA depending on installation; CUDA requires [CUDA 12.x](https://developer.nvidia.com/cuda-12-0-0-download-archive) |
 | Whisper Const-me | Windows | DirectX-based engine |
-| WhisperX | Windows (x64), Linux (x64), macOS (Apple Silicon) | Faster-Whisper with wav2vec2 word-level alignment, packaged as a standalone build (no Python install needed) |
+| WhisperX | Windows (x64), Linux (x64), macOS (Apple Silicon) | Faster-Whisper with wav2vec2 word-level alignment, packaged as a standalone build (no Python install needed). Progress and the decoded lines are shown live while it runs |
 | Whisper OpenAI | All | Python-based OpenAI Whisper workflow |
 | OpenAI Compatible Server | All | Connect to any OpenAI-compatible speech-to-text endpoint |
 | OpenRouter | All | Online. One API key routes to Whisper, gpt-4o-transcribe, Groq and Google Chirp |
 | Alibaba Qwen3-ASR | All | Online Qwen3-ASR via Alibaba Model Studio (DashScope) |
+| Google Cloud Speech-to-Text | All | Online Google Cloud Speech-to-Text v2 (Chirp models) with word-level timings. Needs a service account key file (JSON) - the v2 API does not accept API keys |
 | Qwen3 ASR CPP | Windows, Linux, macOS | Local Qwen3 ASR engine with downloadable GGUF models |
 | Crisp ASR | Windows, Linux, macOS | Single engine with selectable backends: Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral |
 
@@ -31,7 +32,8 @@ Engines and models are downloaded automatically on first use.
 - **Qwen3 ASR CPP** includes 0.6B and 1.7B model options, plus a forced-aligner model used for timing workflows.
 - **Crisp ASR** is exposed as one engine that wraps multiple backends (Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, Voxtral). Pick the backend from the Crisp ASR backend dropdown - see [Crisp ASR backends](#crisp-asr-backends) for what each one is good at.
 - A **Forced aligner** option is shown for Crisp ASR backends and exposes the built-in aligner, Canary CTC, Qwen3, and the wav2vec2 zoo (12 language-specific CTC aligners that run on top of any Crisp ASR backend).
-- Several newer engines support automatic language selection.
+- Automatic language detection: the Whisper engines (Whisper CPP, Purfview Faster Whisper XXL, CTranslate2, WhisperX, Const-me and OpenAI) and every Crisp ASR backend have an **Auto detect** entry at the top of the language list - except the Russian-only GigaAM and MOSS Diarize, which keep their fixed languages.
+- **Google Cloud Speech-to-Text** is Google's v2 API, which does not take API keys. In the Google Cloud console, create a project with billing, enable the Speech-to-Text API, create a service account with the *Cloud Speech Client* and *Storage Admin* roles, add a JSON key to it and pick that file as the **Key file**. If your organisation does not allow service account keys, leave the key file empty, run `gcloud auth application-default login` and fill in the **Project ID**. The other fields are **Region** (`us` or `eu` for chirp_3, or a specific region for other models), **Model** (`chirp_3`, `chirp_2`, `long`, `latest_long`...), a **Language** hint (leave it empty for automatic detection with the Chirp models), the Cloud Storage **bucket name** long audio is uploaded to (one named `<project>-subtitle-edit-stt` is created on first use, and uploads are deleted after each run), **Dynamic batching** (on by default - about a fifth of the price, but Google gives no latency guarantee) and a timeout.
 - Each engine can have separate advanced command-line parameters.
 
 ## Crisp ASR backends
@@ -44,7 +46,7 @@ The languages column counts what the backend dropdown offers (an *auto* entry is
 
 | Backend | Languages | Output | Model size range | Good for |
 |---------|-----------|------------|------------------|----------|
-| **Parakeet** | 13 (European + zh, ja, ko) | Native timings | 75 MB - 2.14 GB | The fast default. NVIDIA Parakeet TDT/RNN-T in 0.6B, 1.1B and a 110M tdt_ctc model - the smallest Crisp ASR model of all. Has a Japanese fine-tune |
+| **Parakeet** | 13 (European + zh, ja, ko) | Native timings | 75 MB - 2.14 GB | The fast default. NVIDIA Parakeet TDT and RNN-T in 0.6B (v2 and v3) and 1.1B, plus the hybrid TDT+CTC models: `parakeet-tdt_ctc-110m` (the smallest Crisp ASR model of all) and `parakeet-tdt_ctc-1.1b` in q4_k, q8_0 and unquantized - same decoding and native timestamps as `parakeet-tdt-1.1b`, with a CTC head available to the runtime. Has a Japanese fine-tune |
 | **Canary** | 25 (European) | Native timings | 705 MB - 1.97 GB | NVIDIA Canary 1B v2. Broad European coverage with its own timings; also usable as a CTC forced aligner for other backends |
 | **Cohere** | 14 | Native timings | 1.51 - 4.14 GB | Cohere Transcribe. Separate Arabic and Japanese fine-tunes. VAD is on by default (see the VAD section below) |
 | **GigaAM** | 1 (Russian) | Native timings; punctuation + casing on `e2e` only | 151 - 452 MB | Russian only, and very small. Use an `e2e` revision - those emit punctuation and capitalisation, the plain `ctc` / `rnnt` heads return bare lowercase text |
@@ -83,6 +85,7 @@ These models live under the **Crisp ASR** engine, not under the standalone Qwen3
 | Crisp ASR Qwen3 | `qwen3-asr-1.7b-ja-anime-q8_0.gguf` (or `-q4_k.gguf`) | Fine-tuned on anime / visual novel speech - the best starting point for anime audio |
 | Crisp ASR Cohere | `cohere-asr-ja-q8_0.gguf` (also q4_k / q6_k / f16) | Japanese fine-tune covering general and anime domains |
 | Crisp ASR Parakeet | `parakeet-tdt-0.6b-ja-q8_0.gguf` (also q4_k / unquantized) | Fast Japanese model |
+| Whisper CPP, Purfview Faster Whisper XXL, Whisper CTranslate2, WhisperX | `anime.ja` | anime-whisper, a kotoba-whisper fine-tune for anime / visual novel dialogue - a Whisper model, so it is under the Whisper engines rather than Crisp ASR |
 
 The general `qwen3-asr-1.7b` and Whisper `large-v3-turbo` models are also strong on Japanese if you prefer a single model for mixed content.
 
@@ -107,7 +110,7 @@ Each engine has its own set of models. Common model sizes:
 - **medium** — High accuracy
 - **large** / **large-v2** / **large-v3** — Best accuracy, slowest
 
-Models ending in `.en` are English-only and perform better for English audio.
+Models ending in `.en` are English-only and perform better for English audio. Models with another language suffix are fine-tunes for that language: the Swedish `.sv` and Norwegian `.nb` models, and `anime.ja` - [anime-whisper](https://huggingface.co/litagin/anime-whisper), a Japanese fine-tune for anime and visual novel dialogue, offered by Whisper CPP, Purfview Faster Whisper XXL, Whisper CTranslate2 and WhisperX.
 
 ## Batch Mode
 
@@ -136,6 +139,8 @@ VAD usually gives tighter timings, but on some material it drops quiet speech an
 
 To keep VAD and only change how it behaves, put `--vad` in the advanced parameters yourself (the **Enable VAD** button fills in the flag and the model path). An explicit `--vad` wins over `--chunk-seconds`, so the two can be combined.
 
+If a Crisp ASR run with VAD comes back with no lines at all - Silero can reject a short clip as non-speech - Subtitle Edit retries once with VAD suppressed before reporting an empty result.
+
 ## Post-Processing Settings
 
 Click the **Post-processing** button to configure:
@@ -147,8 +152,20 @@ Click the **Post-processing** button to configure:
 - Split long lines
 - Remove non-speech lines (lines that only describe sound, like "[Music]")
 - Remove repeated lines (lines that repeat the previous line word for word)
-- Show quality report after transcription
+- Show quality report after transcription (see below)
 - Change underline to color (useful for highlight spoken words)
+
+## Transcription Quality Report
+
+With **Show quality report after transcription** ticked (the default), a report window opens after a transcription that has something to flag - nothing opens for a clean result. It checks the finished subtitle against your general timing settings, so it agrees with what the main grid colors as errors:
+
+- **Too short** - display time below the minimum, or reading speed above the maximum
+- **Too long** - display time above the maximum, or a long span with almost no text (the typical hallucination: two or three words stretched over 10-30 seconds)
+- **Overlap** - a line that ends after the next one starts
+- **Non-speech** - lines that only describe sound, like `[Music]` or `(laughs)`
+- **Repeated** - the same text as the previous line (an engine loop)
+
+Summary cards at the top filter the table by category; each row shows the line number, time codes, a detail (duration, cps or overlap) and the text. Lines the post-processor already dropped - when **Remove non-speech lines** or **Remove repeated lines** is on - are listed as *removed*, so you can tell what was fixed from what is still there. **Export...** copies the report to the clipboard or saves it as text, an Excel file or a web page. *Do not show again* turns the report off; it is the same setting as the post-processing checkbox.
 
 ## Console Log
 

--- a/docs/features/statistics.md
+++ b/docs/features/statistics.md
@@ -11,7 +11,7 @@ View detailed statistics about the currently loaded subtitle file, including lin
 1. Open a subtitle file.
 2. Go to **File** → **Statistics...** to open the statistics dialog.
 3. Read the dashboard: totals at the top, timing/pacing ranges and checks in the middle, and the word/line lists at the bottom.
-4. Use **Export** to save the statistics to a text file.
+4. Use **Export** to save the statistics to a text file (suggested name: `<subtitle name>_statistics.txt`).
 
 ## Features
 
@@ -33,7 +33,7 @@ View detailed statistics about the currently loaded subtitle file, including lin
 - Each list has a **Copy to clipboard** button.
 
 ### Export
-- Save the full statistics report to a text file.
+- Save the full statistics report (totals, most used words and most used lines) to a `.txt` file; a confirmation with the file location is shown afterwards. Text is the only export format - use the **Copy to clipboard** buttons to take a list somewhere else.
 
 ## Keyboard Shortcuts
 

--- a/docs/features/subtitle-grid.md
+++ b/docs/features/subtitle-grid.md
@@ -7,7 +7,7 @@ The subtitle grid is the main area for viewing and managing all subtitle lines.
 
 ## Columns
 
-The grid has a fixed set of columns. Some are always visible; others can be toggled on or off via the column header context menu (see [Customizing Visible Columns](#customizing-visible-columns) below).
+The grid can show the columns below. A few are always visible; the others can be toggled on or off via the column header context menu, and the whole set can be reordered in the **Columns...** dialog (see [Customizing Visible Columns](#customizing-visible-columns) below).
 
 | Column | Always visible | Description |
 |--------|---------------|-------------|

--- a/docs/features/text-editor.md
+++ b/docs/features/text-editor.md
@@ -59,7 +59,19 @@ Besides cut/copy/paste, split and the formatting items above, the text box right
 - **Casing** — Toggle casing, Selection to UPPERCASE, Selection to lowercase, Selection to Sentence case, and Change casing... for the selected lines
 - **Insert Unicode symbol** — insert one of the configured symbols
 - **Google it** (with a selection) and **Search via** — the custom search slots set up in Options → Shortcuts
+- **Look up "..."** (macOS only) - opens the selected text, or with no selection the word under the pointer, in the system Dictionary app, as every macOS text field offers
 - **AI assistant** — see below
+
+## Drag and Drop
+
+Text can be dragged with the mouse, as in Subtitle Edit 4: select some text, then press on the selection and drag.
+
+- Dropped elsewhere in the **same** text box, the text is **moved**; hold **Ctrl** while dropping to copy it instead
+- Dropped into the **other** text box (for example from the original text into the working text), the text is **copied**
+- Text dragged from another application is dropped at the pointer too
+- A caret-shaped bar shows where the text will land while you drag; the dropped text stays selected afterwards, so it can be picked up again
+
+Spacing is tidied at the seams: a space is added where the dropped text would touch a word (none in front of punctuation or after a line break), and the space a word leaves behind when it is moved out is removed. A read-only original text box does not accept drops. A plain click inside the selection (without dragging) just places the caret, as usual.
 
 ## AI Assistant
 

--- a/docs/features/text-to-speech.md
+++ b/docs/features/text-to-speech.md
@@ -48,7 +48,7 @@ Lines that contain only sounds or music — `♪`, `[door slams]`, `(sighs)`, or
 
 ## Supported Engines
 
-- **Piper** — Local, open-source TTS (Windows and Linux)
+- **Piper** — Local, open-source TTS (Windows and Linux). Custom voice models are supported: any Piper voice is an `.onnx` model with an `.onnx.json` config beside it, and **Import voice...** in the voice settings dialog (the settings button next to **Test voice**) copies such a pair into the Piper folder (`TextToSpeech/Piper` in the data folder). It then appears in the voice list as *Custom - name*; a pair copied into the folder by hand is picked up the same way
 - **EdgeTts** — Microsoft Edge online voices
 - **AllTalk** — Local TTS server
 - **ElevenLabs** — Cloud-based, high-quality voices (requires API key)
@@ -132,6 +132,15 @@ The points that matter:
 - Each speech model also has its own license, which may add further limits on commercial use.
 
 Declining just means "not now" — nothing is changed, the clone is refused, and you are asked again the next time. The answer is remembered per terms version, so you are asked again if the terms change.
+
+### Renaming and Deleting Imported Voices
+
+Right-click the voice combo box for **Rename voice...** and **Delete voice...**. Both work on voices you imported or cloned - the engines list those straight from their `voices` folder, one reference recording per voice - and are disabled for engine presets, built-in speakers and the *Clone from video* entry.
+
+- **Rename voice...** moves the recording together with its sidecar files (the `.txt` transcript, engine JSON) and the cached prepared copy, so nothing is left behind as an orphan. Spaces are stored as underscores, which is what the engines show as spaces.
+- **Delete voice...** asks for confirmation, then removes the recording and its files from disk.
+
+Supported for every file-backed cloning voice: the CrispASR engines (Chatterbox, Confucius4-TTS, CosyVoice3, dots.tts, IndexTTS, MOSS-TTS, OmniVoice, Pocket TTS, Qwen3 TTS, VibeVoice, VoxCPM2, Zonos), the standalone OmniVoice TTS, and the audio.cpp engines (IndexTTS 2.5, Higgs Audio v3, Fish Audio S2 Pro, FireRedTTS3).
 
 ### Cloning a Voice Heard in the Video
 

--- a/docs/features/video-player.md
+++ b/docs/features/video-player.md
@@ -69,6 +69,8 @@ You can undock the video player into a separate window for multi-monitor setups:
 
 You can open a secondary subtitle on the video player and remove it again from the Video menu. This is useful when checking a translation against the original subtitle while previewing video playback.
 
+**Video → Open second subtitle file...** sits in the same spot as in Subtitle Edit 4, right after the open/close video items (it is shown while a video is loaded), and **Remove second subtitle file** appears below it while one is shown. Only one second subtitle is shown at a time: opening another file replaces the current one, and the file picker starts at the current second subtitle, so re-opening it is also the way to adjust its style without removing it first.
+
 ## Embedded Subtitles
 
 Use [Embedded Subtitles](embedded-subtitles.md) to add, remove, preview, and edit Matroska/WebM embedded subtitle tracks.
@@ -113,5 +115,11 @@ The Video menu also includes:
 
 Under **Video → More** (shown while a video is loaded):
 
-- **Set video offset...** - shift video playback relative to the subtitle timing.
+- **Chapters...** - edit, import, export and write the video's chapter marks, see [Chapters](chapters.md).
+- **Cut video...** - cut or merge segments of the video, see [Cut Video](cut-video.md).
+- **Find voices in video and clone...** - find the speakers in the video, clone each voice and set up the cast for dubbing, see [Text to Speech](text-to-speech.md#find-voices-in-video-and-clone).
+- **Re-encode video for better subtitling...** - see [Re-encode Video](re-encode-video.md).
+- **Remux video...** - repackage the video with new audio tracks and soft subtitles, see [Remux Video](remux-video.md).
+- **Set video offset...** - shift video playback relative to the subtitle timing. The dialog keeps a drop-down of recently used offsets next to the time code box (the last ten you applied; 1 hour and 10 hours are offered until you have applied your own) - picking one fills the box. While an offset is active the menu item reads **Update video offset from ...** instead.
 - **SMPTE timing (non-integer frame rate)** - toggle SMPTE-style timing display when available.
+- **Toggle waveform toolbar** - show or hide the toolbar above the waveform.

--- a/docs/features/visual-sync.md
+++ b/docs/features/visual-sync.md
@@ -9,7 +9,9 @@ Synchronize subtitles visually by matching two points in the video.
 
 ## How to Use
 
-The Visual sync window shows two video player panes ("Start scene" and "End scene"), each with its own audio visualizer and a combo box for picking a subtitle line.
+The Visual sync window shows two video player panes ("Start scene" and "End scene"), each with its own audio visualizer and a combo box for picking a subtitle line. The subtitle is drawn on both videos with the same look as on the main window's video, and both players use the audio track selected in the main window (**Video → Audio tracks** or the waveform toolbar picker); there is no separate track picker in the dialog.
+
+The waveform under each video only appears when the main window has a waveform to share. Drag the handle between the video and the waveform to resize the waveform - both panes follow, and the height is remembered between sessions.
 
 1. Open **Sync → Visual sync...**
 2. In the **Start scene** pane, pick a subtitle line near the beginning and play the video to the position where that line should start

--- a/docs/features/whats-new-in-se5.md
+++ b/docs/features/whats-new-in-se5.md
@@ -13,6 +13,8 @@ Subtitle Edit 5 is the Avalonia-based, cross-platform version of Subtitle Edit. 
 - **Update check settings** — pick the stable or beta channel, and get a passive notification at startup when a newer build is out.
 - **Proxy settings** — domain, system credentials and a bypass list, used by every download and online engine.
 - **Type-to-search in every combo box**, a default save location setting, and the subtitle file name in dialog title bars.
+- **New UI languages** - Central Kurdish and Azerbaijani joined in 5.2 (on top of the Arabic, Turkish, Persian, Traditional Chinese, Indonesian, Vietnamese, Greek and Thai added in 5.1), and every language file is synced with English.
+- **Toolbar settings redesigned** as a grid of icon toggles, so you see the button you are showing or hiding instead of a list of checkboxes.
 
 ## Editing and Grid
 
@@ -26,7 +28,12 @@ Subtitle Edit 5 is the Avalonia-based, cross-platform version of Subtitle Edit. 
 - **Edit original** — the original/reference column can be edited in place, and its non-matching lines are shown as reference rows in the grid.
 - **Hide tags** — a third grid formatting mode that hides override tags so tag-heavy ASSA lines read as plain text; *show formatting* now shows the text of tag-heavy lines too.
 - **Layout 10** puts the edit box under the waveform, like SE 4 and Aegisub.
-- New **Tools → Remove/replace Unicode characters** (the SE 4 plugin, built in), **Sentence case** in the casing options, and the SE 4 **Minimum gap frame rate calculator**.
+- New [**Tools → Remove/replace Unicode characters**](remove-unicode-characters.md) (the SE 4 plugin, built in), **Sentence case** in the casing options, and the SE 4 **Minimum gap frame rate calculator**.
+- **Assisted split** and **Assisted move** - ranked one-click suggestions for where to split a line, or which words to move to the previous/next subtitle, each with a full preview of the result; click an option or press its number (see [Assisted split](assisted-split.md)).
+- **Error list** - **Tools → List errors...** collects every error the grid flags into one window with summary cards per category, and exports the list to the clipboard, a text file, Excel or a web page; Batch convert has the same list for a whole run (see [Error list](list-errors.md)).
+- **Forced narrative lines** - a *Forced* grid column, *Toggle forced* for the selected lines, and **Save forced lines as...** to write only those lines to their own file.
+- **Columns... dialog** to reorder and hide the grid columns, and a **Statistics dashboard** with KPI tiles, meters, checks and a CPS histogram (see [Statistics](statistics.md)).
+- **Text boxes** - drag and drop text between them (e.g. from the original into the working text), configurable **Search via** shortcuts (the selected text takes the place of `{0}` in the URL), **Google it**, macOS **Look up**, and more **Surround with** slots.
 - **Multiple replace** grew up — import/export of selected rule categories, move rules up/down/to top/bottom, select all/none/invert in the preview, the whole rule shown while editing, remembered expanded categories, and a toolbar button.
 - **Merge lines: keep end time** (allow overlap with the next subtitle) as an option, and *Show selected lines earlier/later* in the grid context menu.
 - Auto-break settings under Settings → Tools, with a **do-not-break-after** list editor and a bottom-heavy percentage.
@@ -52,6 +59,11 @@ See [Spell Check](spell-check.md) for details.
 - **Burn-in** gains Apple VideoToolbox hardware encoders on macOS, `.webm`/`.ts` output, letter spacing, and lists only the encoders and containers the OS and codec actually support.
 - **Matroska track chooser** shows an image-subtitle preview, the number of forced cues, and can export VobSub directly.
 - *Go to sub position and pause* and *Go to video position…* shortcuts, and a toggle-subtitles shortcut for the video player.
+- **Video → More → Remux video...** puts a video and a separate audio (and subtitle) file into one container without re-encoding, picking the audio track when the source has several (see [Remux video](remux-video.md)).
+- **Guess start / Guess end** move the selected line's edge to where the speech actually starts or stops on the waveform, and the status bar tells you how far it moved.
+- **Per-track audio picker** - the video menu lists the file's audio tracks so the waveform and playback can follow a different one.
+- The **video position box** is editable, as in SE 4: type a time to jump there instead of scrubbing.
+- **Video offset** remembers the recently used offsets, and the Video menu gained **Open recent video** and **Go to video position...**.
 
 ## Sync
 
@@ -85,6 +97,11 @@ Beyond the classic engines, image-to-text now includes AI-based local and online
 - **Train nOCR** from SE 4 is back, and nOCR matching is faster thanks to a result cache.
 - **HunyuanOCR 1.5** joins the llama.cpp OCR model list, with install-status dots for engines and models and an engine download/update button in the settings.
 - **Save all images with HTML index** from the OCR window, and CrispEmbed's hardware build can be re-picked after the first install.
+- **Apple Vision OCR** on macOS - the system's built-in OCR, no download needed.
+- **Paddle OCR 3.7** with the PP-OCRv6 models, and **PP-OCRv6** and **DeepSeek-OCR-2** as CrispEmbed backends.
+- **LFM2.5-VL 3B** in the llama.cpp OCR model list, and custom vision models: drop a `.gguf` with its `mmproj` file into the llama.cpp models folder.
+- The OCR language is **auto-detected** from the file or track, and the matching video is opened after OCR.
+- **Video OCR** reads far more of the burned-in subtitles with better text and start times, can use the CrispEmbed engine, runs the OCR fix engine on the result, and colors spelling errors.
 
 See [OCR](ocr.md) and [Video OCR](video-ocr.md) for details.
 
@@ -93,12 +110,17 @@ See [OCR](ocr.md) and [Video OCR](video-ocr.md) for details.
 Speech recognition is no longer limited to classic Whisper workflows. Subtitle Edit 5 includes a broader set of local and downloadable engines:
 
 - Purfview Faster-Whisper XXL, CTranslate2, Whisper.cpp (with cuBLAS and Vulkan backends on Windows), OpenAI Whisper, OpenAI-compatible STT, and Const-me's Whisper.
+- **WhisperX** as a standalone build - Faster-Whisper with wav2vec2 word-level alignment, no Python install needed, and live progress while it runs.
+- **Google Cloud Speech-to-Text v2** (Chirp models, word timings) as an online engine; it takes a service account key file rather than an API key.
 - Qwen3 ASR with multiple GGUF model sizes.
-- Crisp ASR variants including GLM, Qwen3, Granite, Omni, Parakeet, Canary, Cohere, Fire Red, Mega, and Kyutai.
+- Crisp ASR as one engine with 16 backends: Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK and Voxtral.
 - Forced-aligner picker (built-in / Canary CTC / Qwen3 / 12 language-specific wav2vec2 aligners) for word-level timestamps.
 - Per-engine advanced parameters and batch transcription improvements.
-- Automatic language selection for several newer engines.
+- **Auto detect** language on the Whisper engines and on every Crisp ASR backend that covers more than one language.
 - **Voxtral** backend for Crisp ASR, a way to switch VAD off, and an automatic retry without VAD when a clip comes back empty.
+- **anime-whisper** (`anime.ja`), a Japanese fine-tune for anime and visual novel dialogue, in the Whisper CPP, Purfview, CTranslate2 and WhisperX model lists.
+- A **transcription quality report** after each run - too short, too long, overlapping, non-speech and repeated lines - with optional removal of non-speech and repeated lines in post-processing.
+- The MLX Whisper engine was removed.
 - Batch speech to text can include the language code in the output file names.
 
 See [Speech to Text](speech-to-text.md) for the current engine list and workflow.
@@ -115,7 +137,11 @@ Text to speech now includes more local and cloud engines:
 - Review audio clips, regenerate individual lines, keep regeneration history, and export generated clips with metadata.
 - **IndexTTS 2.5** — a local engine with emotion and speaking-rate control.
 - **Find voices in video and clone them all** — auto-cast every speaker from the video, or clone the voice of a single line from the video.
-- Chatterbox in 23 languages (plus F16 and Q4_K model variants), and the CosyVoice3 RL talker models.
+- Chatterbox V3 in 23 languages (plus F16 and Q4_K model variants), and the CosyVoice3 RL talker models.
+- More engines on the **audio.cpp** runtime: **Higgs Audio v3**, **Fish Audio S2 Pro** and **FireRedTTS3**, sharing one install with IndexTTS 2.5.
+- More engines on the CrispASR runtime: **dots.tts**, **Confucius4-TTS**, **Pocket TTS**, **VibeVoice**, **VoxCPM2**, **MOSS-TTS** and **Zonos** (with a language picker).
+- **Per-line cloning** - *Clone from video (voice of each line)* on Qwen3 TTS, the audio.cpp engines, VibeVoice, MOSS-TTS, CosyVoice3 and VoxCPM2 - with a one-time consent prompt before the first clone.
+- **Speaker-name detection** moves `NAME:` style speakers from an SDH text into the actor field, sound and music lines can be **left silent**, and **custom Piper voices** (an `.onnx` + `.onnx.json` pair) can be imported.
 
 See [Text to Speech](text-to-speech.md) for details.
 
@@ -126,8 +152,10 @@ Subtitle Edit 5 adds local, downloadable auto-translate engines that run entirel
 - **Server-managed llama.cpp** — Subtitle Edit downloads llama.cpp, manages a local `llama-server` process, and offers a curated TranslateGemma model picker, so no manual server setup is required. CPU, Vulkan, and CUDA builds are available, and the server can be started and stopped from the Auto-translate window.
 - **CrispASR MADLAD** — a local MADLAD-based translation engine with downloadable models (shown with size and install status), available in both the Auto-translate window and Batch Convert.
 - **OpenAI Compatible API** — a generic engine for any service exposing an OpenAI-compatible `chat/completions` endpoint (vLLM, KoboldCpp, a llama.cpp server on another machine, cloud providers, ...).
-- **MiLMMT-46** translation models in the llama.cpp engine, and a **llama.cpp advanced** engine with custom prompt, server parameters, a stall watchdog and a token cap.
+- **MiLMMT-46** translation models in the llama.cpp engine, and the **llama.cpp advanced** and **Ollama advanced** engines that translate in batches with surrounding context, a synopsis, a glossary and schema-forced output - also in Batch convert and `seconv`.
 - Completion-format prompts for LM Studio, KoboldCpp, Ollama and the other local engines, a reset-to-default button for the prompt, and the chosen languages are kept when the engine changes.
+- **DeepL** offers every language its API supports, and the free **Google Translate** retries through a fallback endpoint when Google blocks the usual one.
+- Translated rows that break the line profile (too many lines, or a line over the single-line limit) are **re-broken** for the target language, and the original text is no longer lost after translating.
 
 See [Auto-translate](auto-translate.md) for the full engine list and workflow.
 
@@ -139,6 +167,7 @@ See [Auto-translate](auto-translate.md) for the full engine list and workflow.
 - **Safe by design** — formatting tags (`<i>`, `{\an8}`, etc.) and line breaks are preserved; suggestions that touch tags are dropped, and large rewrites are flagged for a closer look and left unselected.
 - **Editable prompt** — the instructions sent to the model can be customized (with the subtitle language auto-detected and substituted in).
 - **Play current**, **Select none**, and a **Start/Stop server** button so the local model's VRAM can be released without leaving the window; the server is also stopped when a review is cancelled. AI review is in the grid's *Selected lines* context menu too.
+- Apply suggestions **in passes** (Apply keeps the window open, each pass is one undo step), a **delay between requests** for rate-limited cloud endpoints, and new models: Gemma 4 E2B, EuroLLM and Granite 4.1.
 
 See [AI Review](ai-review.md) for details.
 
@@ -151,6 +180,7 @@ See [AI Review](ai-review.md) for details.
 - **Optimized MKV parsing** — reading subtitle tracks from Matroska (`.mkv`) files is significantly faster, speeding up batch jobs that extract subtitles from many video containers.
 - **Beautify time codes**, **Convert colors to dialog**, **Snap time codes to frames**, and the **CrispEmbed** OCR and **llama.cpp advanced** translate engines as batch steps; the llama.cpp launch flags are yours to set.
 - **Add folder…**, a filtered file count, translation progress, and an option to **keep the source file's date/time** on converted files (also in `seconv`).
+- Every **teletext page per PID** is written as its own result from transport streams, and **Transport Stream** output settings for the batch queue.
 
 See [Batch Convert](batch-convert.md), [OCR](ocr.md), and [Command Line (seconv)](../reference/command-line.md).
 
@@ -174,6 +204,13 @@ See [Batch Convert](batch-convert.md), [OCR](ocr.md), and [Command Line (seconv)
 - New imports: Adobe Premiere Pro *Markers* panel CSV, and **XSUB** subtitles inside `.avi` files.
 - **D-Cinema interop** properties dialog, and the option to remove blank lines when opening a subtitle is back from SE 4.
 - Abbreviation lists for 30 more languages.
+- New formats: **EBU-TT** (Tech 3350), **Manzanita DVB teletext** (`.dvbttx`), **Csv Excel**, **CANVASs SSTG1** (`.sdb`), **Wistia json**, **DVD Junior SPC**, **Sonic DVD Producer** and **YouTube timed text srv3** (`.ytt`).
+- Read subtitles from **fragmented MP4** (DASH/CMAF), **ARIB STD-B24** captions from transport streams, and **SMPTE-TT bitmap** captions.
+- A **generic XML importer** for unknown formats, and **Import plain text** straight from the unknown-format prompt.
+- **EBU STL**: the video preview shows box, justification and double height as a teletext decoder would, and time codes are shown frame-based while the format is active.
+- **SCC**: colors are written as CEA-608 mid-row codes, a warning on save when a line exceeds 32 characters, and import timing applies each control code at its frame within the line.
+- **Ruby and emphasis** in Lambda Cap and Netflix IMSC 1.1 Japanese, and font colors in EBU-TT-D and IMSC Rosetta.
+- **Image export**: text effects (gradient, neon glow, 3D extrude), per-line ASSA colors and outlines, and inline font face and size.
 
 ## Command Line (seconv)
 
@@ -181,8 +218,9 @@ The `seconv` headless converter now lives in the main Subtitle Edit repository �
 
 - **Polished terminal UI** — colored output with progress per file, summary tables, and a `--json` mode for CI pipelines and scripting.
 - **Cross-platform** — runs on Windows, Linux, and macOS with only the .NET runtime; no display or GUI required, suitable for servers and Docker.
-- **Broader feature set** — additional time and cleanup operations, OCR engine selection (Tesseract / nOCR / Binary OCR / Ollama / PaddleOCR), container input from `.mkv` / `.mp4` / `.mcc`, `info` and `lint` subcommands for inspection, custom output templates, and POSIX-style flag names (legacy SE 4.x flags still work).
+- **Broader feature set** — additional time and cleanup operations, OCR engine selection (Tesseract / nOCR / Binary OCR / Ollama / llama.cpp / PaddleOCR), container input from `.mkv` / `.mp4` / `.mcc`, `info` and `lint` subcommands for inspection, custom output templates, and POSIX-style flag names (legacy SE 4.x flags still work).
 - `.avi`/XSUB input, rule selection for `--remove-formatting`, and keeping the source file's date/time on output.
+- `--help-json` for a machine-readable option list, `--ocr-prompt` and `--translate-prompt` for the LLM engines, `--override-position`, `--output-filename-append`, and batched Paddle OCR.
 
 See [Command Line (seconv)](../reference/command-line.md) for usage and examples.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Edit Menu](features/edit.md) — Find, Replace, Multiple Replace, History
 - [Source View](features/source-view.md) — Edit the raw subtitle source: syntax coloring, live parse check, find/replace, line commands
 - [Modify Selection](features/modify-selection.md) — Select lines by rules: text, hearing-impaired text, duration, CPS, gaps, styles, actors
+- [Assisted Split and Assisted Move](features/assisted-split.md) — Ranked one-click split points and word moves with full previews
 - [Subtitle Grid](features/subtitle-grid.md) — Working with the subtitle list/grid
 - [Text Editor](features/text-editor.md) — Editing subtitle text
 - [AI Assistant](features/ai-assistant.md) — AI help for the current line: fix errors, fit reading speed, change tone
@@ -29,6 +30,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [AI Review](features/ai-review.md) — Proofread with a local LLM (llama.cpp, Ollama, or any OpenAI-compatible endpoint)
 - [Fix Common Errors](features/fix-common-errors.md) — Automatic error detection and fixing
 - [Check and Fix Netflix Errors](features/netflix-errors.md) — Netflix quality checks, proposed fixes, and CSV reports
+- [List Errors](features/list-errors.md) — Every rule violation with summary cards; export to clipboard, text, Excel or web page
 - [Batch Convert](features/batch-convert.md) — Convert multiple subtitle files
 - [Beautify Time Codes](features/beautify-time-codes.md) — Snap cues to shot changes and frames using a configurable profile, with a live before/after preview
 - [Change Casing](features/change-casing.md) — Fix casing issues
@@ -49,6 +51,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Join Subtitles](features/join-subtitles.md) — Join multiple subtitle files
 - [Sort By](features/sort-by.md) — Sort subtitles by various criteria
 - [Remove Text for Hearing Impaired](features/remove-text-hi.md) — Remove HI annotations
+- [Remove/replace Unicode Characters](features/remove-unicode-characters.md) — Find, remove or replace characters outside Latin-1 (SE 4 plugin port)
 - [Command Line (seconv)](features/seconv.md) — Headless converter for scripts and bulk conversion (see also the [full reference](reference/command-line.md))
 
 ### Synchronization
@@ -73,6 +76,7 @@ Subtitle Edit is a free, open-source editor for video subtitles. This is the doc
 - [Blank Video](features/blank-video.md) — Generate a blank video
 - [Re-encode Video](features/re-encode-video.md) — Re-encode video files
 - [Cut Video](features/cut-video.md) — Cut video segments
+- [Remux Video](features/remux-video.md) — Repackage video with new audio tracks and soft subtitles, without re-encoding
 
 ### Translation
 - [Auto Translate](features/auto-translate.md) — Automatic subtitle translation

--- a/docs/reference/command-line.md
+++ b/docs/reference/command-line.md
@@ -8,7 +8,7 @@
 
 - **380+ subtitle formats** — text, binary, and image-based.
 - **Container input** — Matroska (`.mkv` / `.mks`), MP4, MCC, MXF, AVI (`.avi` / `.divx`), transport stream teletext, Blu-Ray `.sup`.
-- **OCR for image-based sources** via five engines (Tesseract subprocess, nOCR built-in, BinaryOCR built-in, Ollama HTTP, PaddleOCR subprocess).
+- **OCR for image-based sources** via six engines (Tesseract subprocess, nOCR built-in, BinaryOCR built-in, Ollama HTTP, llama.cpp HTTP with automatic server start, PaddleOCR subprocess).
 - **Auto-translate** via local LLMs (llama.cpp with automatic server start, Ollama, LM Studio) or self-hosted services (LibreTranslate, NLLB).
 - **Image-based output** — Blu-Ray sup, BDN-XML, DOST, FCP (Final Cut Pro + image), D-Cinema interop / SMPTE 2014, images-with-time-code.
 - **Operations pipeline** — offset, fps change, change-speed, renumber, adjust-duration, fix-common-errors, merge/split, balance, redo casing, RTL fixes, multiple-replace, custom-text format, plain text.
@@ -247,7 +247,7 @@ An AVI stream header carries no language, so a multi-stream `.avi` names its out
 | `binaryocr` *(alias: `binary`)* | In-process | Built-in BinaryOCR matcher (different accuracy profile, similar speed). Required: `--ocr-db:<path-to-Latin.db>`. |
 | `ollama` | HTTP | Local Ollama server with a vision-capable model (e.g. `llama3.2-vision`, `qwen2.5vl`). Configure via `--ollama-url` (default `http://localhost:11434/api/chat`) and `--ollama-model` (default `llama3.2-vision`). Pass `--ocr-language` as a human name like `English`. |
 | `llamacpp` *(aliases: `llama.cpp`, `llama`)* | HTTP | llama.cpp with a curated OCR vision model (best-first: GLM-OCR, LFM2.5-VL 3B, PaddleOCR-VL, HunyuanOCR 1.5, LightOnOCR). With no `--ocr-url`, seconv finds `llama-server` (SE data folder next to seconv, installed SE data folder, then `PATH`) and an OCR model — the first model in that order that is installed, unless `--ocr-model` names one — starts the server on a free loopback port, and stops it at exit. seconv never downloads engines/models — install them via the SE UI's OCR window (engine "llama.cpp") or point `--ocr-url` at a running server. Pass `--ocr-language` as a human name like `English`. |
-| `paddle` *(alias: `paddleocr`)* | Subprocess | Install via `pip install paddleocr` (3.7 or newer, for the PP-OCRv6 models); ensure the `paddleocr` binary is on `PATH`. Pass `--ocr-language` as a short code (`en`, `de`, …). |
+| `paddle` *(alias: `paddleocr`)* | Subprocess | Install via `pip install paddleocr` (3.7 or newer, for the PP-OCRv6 models); ensure the `paddleocr` binary is on `PATH`. Pass `--ocr-language` as a short code (`en`, `de`, …). Images are OCR'ed in batches: the prepared images of a file are written to a folder and one `paddleocr` process reads the whole folder, so the roughly twenty-second model load is paid once per file rather than once per image. |
 
 | Option | Description |
 |---|---|

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -126,7 +126,7 @@ wins over the menu activation.
 | Shortcut | Action |
 |----------|--------|
 | Ctrl+V | Paste lines from clipboard at waveform position |
-| Ctrl+C | Copy the selected subtitle to the clipboard |
+| Ctrl+C | Copy the selected subtitle to the clipboard ("Copy (text only)" has no default key) |
 | Shift++ | Vertical zoom in |
 | Shift+- | Vertical zoom out |
 
@@ -148,6 +148,20 @@ wins over the menu activation.
 | Ctrl+Alt+Shift+L | Save language file |
 
 > **Note:** Several actions (Bold, Underline, shot-change snapping/extending, green-zone in/out cues, "Guess start time from waveform" / "Guess end time from waveform", "Go to next empty line", "Waveform paste clipboard text to new selection", etc.) ship without a default key. Open **Options** → **Shortcuts** to assign them, or use **Import from SE 4.x** to bring over a familiar set.
+
+## Find and Replace Windows
+
+Button accelerators in the [Find and Replace](../features/edit.md#replace) windows. They are fixed, not part of **Options** → **Shortcuts**.
+
+| Shortcut | Action |
+|----------|--------|
+| Alt+F | Find next (both windows) |
+| Alt+P | Find previous (Find window) |
+| Alt+R | Replace & find next (Replace window) |
+| Alt+A | Replace all (Replace window) |
+| F / P / R / A | The same, without Alt, when the focus is not in a text box (e.g. after clicking a button) |
+| Ctrl+Delete | Remove the current search text from the search history |
+| Escape | Close the window |
 
 ## Fix Lists in Dialogs
 

--- a/docs/reference/supported-formats.md
+++ b/docs/reference/supported-formats.md
@@ -15,16 +15,23 @@ Subtitle Edit supports a wide range of subtitle formats for reading and writing.
 | Timed Text (TTML) | .ttml, .xml, .dfxp | |
 | iTunes Timed Text (iTT) | .itt | |
 | EBU STL | .stl | |
+| EBU-TT (Tech 3350) | .xml | |
 | Spruce STL | .stl | |
 | Scenarist Closed Captions (SCC) | .scc | |
 | DVD Studio Pro | .stl | |
 | Cavena 890 | .890 | |
 | CANVASs SSTG1 project (SSTG1Pro/Lite, import only) | .sdb | |
+| DVB Teletext (Manzanita; import - export via File → Export → DVB teletext (Manzanita)) | .dvbttx | |
+| DVD Junior SPC | .spc | |
+| Sonic DVD Producer | .txt | |
 | PAC | .pac | |
 | Cheetah | .cap | |
 | Avid DVD, Avid Caption, Avid Caption Drop Frame, Avid Loc Markers | .txt | |
 | Avid STL | .stl | |
 | JSON (various) | .json | |
+| Wistia json | .json | |
+| Csv Excel | .csv | |
+| YouTube timed text srv3 | .xml, .ytt, .srv3 | |
 | LRC (Lyrics) | .lrc | |
 | and many more... | | |
 
@@ -48,6 +55,7 @@ Formats used to move captions and markers between Subtitle Edit and video editor
 | Adobe Premiere Markers | .csv |
 | Adobe Premiere PrProj Xml | .xml |
 | Adobe Encore (tabs) | .txt |
+| Audacity / Tenacity labels | .txt |
 
 ## Spreadsheets
 
@@ -82,7 +90,7 @@ Import only — a spreadsheet with a header row naming start/end/text columns is
 |--------|--------------|
 | Matroska (MKV/MKS/WebM) | .mkv, .mks, .webm |
 | MP4 / MOV (text tracks, including fragmented MP4/DASH — wvtt, stpp, tx3g) | .mp4, .m4v, .m4s, .3gp, .mov |
-| Transport Stream (teletext, DVB-sub) | .ts, .m2ts, .mts |
+| Transport Stream (teletext, DVB-sub, ARIB STD-B24 captions) | .ts, .m2ts, .mts |
 | AVI (XSUB) | .avi, .divx |
 | MacCaption | .mcc |
 | MXF (timed-text essences) | .mxf |
@@ -99,3 +107,10 @@ Import only — a spreadsheet with a header row naming start/end/text columns is
 | Blu-ray Transport Stream | .m2ts |
 
 > **Note:** Subtitle Edit ships with parsers/writers for 380+ subtitle formats, including text, binary, and image-based ones. The format is auto-detected when you open a file.
+
+## Format Notes
+
+- **Scenarist Closed Captions (SCC):** font colors are written as CEA-608 mid-row codes (a mid-row code displays as a space, so it costs one cell). A line holds at most 32 characters and a caption at most 4 rows; with *Warn on save when lines exceed the format's limits* enabled (Options → Settings) a "Format limits exceeded" dialog lists the offending lines before the file is written. Import timing is frame-accurate: CEA-608 carries one byte pair per frame, so a display code takes effect at the line's time code plus its position in the line.
+- **EBU STL / DVB teletext:** the video preview draws the text the way a teletext decoder would, with the box behind the text and double-height rows. While EBU STL is the active format the time codes are shown frame-based (HH:MM:SS:FF) using the frame rate from the STL header; the display reverts when another format is chosen.
+- **Lambda Cap:** ruby (furigana), emphasis marks and tate-chu-yoko are decoded to the same markup as "Netflix IMSC 1.1 Japanese", so the video preview draws them instead of showing the control codes as text.
+- **EBU-TT-D / IMSC Rosetta:** `<font color>` tags are written as referential styles. Rosetta allows only its eight fixed foreground styles, so a color is snapped to the nearest of black, red, yellow, green, cyan, blue, magenta and white; EBU-TT-D uses the same eight teletext colors and reads them back by name, so a round trip keeps `<font color="yellow">`.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -64,6 +64,7 @@ All listed files exist on disk. Filenames are stable and may be linked from `../
 - `sort-by.png` — Sort by window
 - `renumber.png` — Renumber window
 - `remove-text-hi.png` — Remove text for hearing impaired window
+- `ai-review.png` - AI review window
 
 ## Synchronization
 
@@ -160,9 +161,9 @@ Used by `../reference/assa-override-tags.md` to illustrate individual override t
 
 ## Counts
 
-- Top-level screenshots: **95**
+- Top-level screenshots: **96**
 - ASSA override-tag examples (`assa/`): **35**
-- Total: **130**
+- Total: **131**
 
 ## How the dialog screenshots are made
 

--- a/docs/third-party-components.md
+++ b/docs/third-party-components.md
@@ -34,9 +34,13 @@ Subtitle Edit stores these components in its **Data Folder**.
 | **Tesseract** | `tesseract.exe`, `tessdata/` folder | `[Data Folder]/Tesseract` |
 | **Whisper CPP** | `whisper-cli.exe`, `Models/` folder | `[Data Folder]/SpeechToText/Cpp` |
 | **Purfview Faster-Whisper XXL** | `faster-whisper-xxl.exe`, `_models/` folder | `[Data Folder]/SpeechToText/Purfview-Faster-Whisper-XXL` |
+| **WhisperX** | standalone build (no Python); models in the Hugging Face cache | `[Data Folder]/SpeechToText/WhisperX` |
 | **Crisp ASR** | `crispasr.exe`, `models/` folder | `[Data Folder]/CrispASR` |
 | **Qwen3 ASR CPP** | `qwen3-asr-cli.exe`, `models/` folder | `[Data Folder]/Qwen3ASR` |
 | **PaddleOCR** | `paddleocr.exe`, `models/` folder | `[Data Folder]/OCR/PaddleOCR3-7` |
+| **CrispEmbed** | OCR runtime, GGUF models in `models/` | `[Data Folder]/OCR/CrispEmbed` |
+| **llama.cpp** | `llama-server.exe`, GGUF models in `models/` (translate, AI review, OCR) | `[Data Folder]/llama.cpp` |
+| **audio.cpp** | `audiocpp_server.exe`, `BUILD-INFO.txt`, GGUF models in `models/` | `[Data Folder]/audio.cpp` |
 | **Qwen3 TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Qwen3TtsCrispAsr` (voices only) |
 | **Chatterbox TTS (CrispASR)** | shares `crispasr.exe` + `models/` from `[Data Folder]/CrispASR`; reference voices in `voices/` | `[Data Folder]/TextToSpeech/Chatterbox` (voices only) |
 | **OmniVoice TTS** | `omnivoice-tts.exe`, `omnivoice-codec.exe`, `models/`, `voices/` | `[Data Folder]/TextToSpeech/OmniVoice` |
@@ -108,12 +112,21 @@ Used for GPU-accelerated AI-based speech recognition.
 *   **Files:** Download the Standalone Archive, extract contents so `faster-whisper-xxl.exe` is in the folder root.
 *   **Models:** Place model directories (e.g., `faster-whisper-medium`) inside the `_models` folder.
 
+### WhisperX (Speech-to-Text)
+Faster-Whisper with wav2vec2 word-level alignment, shipped as a standalone build so no Python install is needed.
+
+*   **Download:** Built by Subtitle Edit's own workflow and published in [SubtitleEdit/support-files releases](https://github.com/SubtitleEdit/support-files/releases); the Speech to text window downloads it for you. Windows x64, Linux x64 and macOS Apple Silicon.
+*   **Destination:** `[Data Folder]/SpeechToText/WhisperX`
+*   **Models:** The Whisper model list is shared with Purfview Faster-Whisper XXL; WhisperX itself keeps the downloaded weights in the Hugging Face cache rather than in the Data Folder.
+
 ### SE5 Speech-to-Text Engines
 Subtitle Edit 5 can download additional ASR engines directly from the **Speech to text** window.
 
 *   **Crisp ASR:** Stored in `[Data Folder]/CrispASR`. Models go into its `models` folder. Crisp ASR backends include Parakeet, Canary, Cohere, Fire Red, Fun-ASR Nano, GigaAM, GLM, Granite, Qwen3, Mega, MOSS Diarize, Omni, Kyutai, SenseVoice, ARK, and Voxtral.
     *   The speech-to-text dialog also offers a **Forced aligner** combo for word-level timestamps. Built-in (where the backend supports it), Canary CTC, Qwen3, and 12 language-specific wav2vec2 aligners (the WhisperX aligner zoo): `en`, `de`, `fr`, `es`, `it`, `ja`, `zh`, `nl`, `pt`, `ar`, `uk`, `cs`. The default is the built-in aligner when the backend supports it, otherwise Qwen3 or Canary CTC depending on the backend; pick a wav2vec2 entry manually to use one of those.
 *   **Qwen3 ASR CPP:** Stored in `[Data Folder]/Qwen3ASR`. Models go into `[Data Folder]/Qwen3ASR/models`. (Parakeet is no longer a standalone engine; it is a Crisp ASR backend.)
+*   **llama.cpp:** Stored in `[Data Folder]/llama.cpp` with the GGUF models in its `models` folder. One install serves the llama.cpp auto-translate engines, AI review, the AI assistant and the llama.cpp OCR vision models; a `.gguf` you download yourself and drop into `models` is listed as *(custom)*.
+*   **CrispEmbed:** The local OCR runtime, stored in `[Data Folder]/OCR/CrispEmbed` with its GGUF models in `models`.
 
 Use [Speech to Text](features/speech-to-text.md) for the current engine list and workflow.
 
@@ -134,8 +147,17 @@ Subtitle Edit 5 can download local TTS servers and models from the **Text to spe
 *   **Chatterbox TTS (CrispASR):** Reference voices are stored in `[Data Folder]/TextToSpeech/Chatterbox/voices`. The Base / Turbo model GGUFs (T3 + S3Gen) are downloaded into the shared `[Data Folder]/CrispASR/models` cache alongside the Crisp ASR speech-to-text models, not under `TextToSpeech/Chatterbox/models` — installing Crisp ASR first is therefore recommended. Older installs that still have model files under the legacy `TextToSpeech/Chatterbox/models` folder are migrated automatically the first time the engine is used.
 *   **OmniVoice TTS:** Stored in `[Data Folder]/TextToSpeech/OmniVoice`. Brings its own `omnivoice-tts` and `omnivoice-codec` binaries. Supports 646 languages and voice cloning on CPU. `models/` and `voices/` subfolders.
 *   **Kokoro TTS:** Stored in `[Data Folder]/TextToSpeech/KokoroTtsCpp`. Models go into the `models` folder.
+*   **Piper:** Stored in `[Data Folder]/TextToSpeech/Piper`. A custom voice is an `.onnx` model with its `.onnx.json` beside it in that folder (imported from the voice settings dialog or copied in by hand).
 
-These are examples, not the full set — many more local engines are downloadable from the Text to speech window (IndexTTS, CosyVoice3, dots.tts, VoxCPM2, MOSS-TTS, Zonos, VibeVoice, Confucius4-TTS, Pocket TTS, Higgs Audio, Fish Audio, and more), following the same layout: CrispASR-based engines share the `[Data Folder]/CrispASR` cache, and the rest live under `[Data Folder]/TextToSpeech/<engine>`.
+### audio.cpp (Text-to-Speech runtime)
+The runtime behind **IndexTTS 2.5**, **Higgs Audio v3**, **Fish Audio S2 Pro** and **FireRedTTS3**. One install serves all four engines, and each of them prompts for it on first use.
+
+*   **Download:** Built by Subtitle Edit's own workflow from upstream audio.cpp and published in [SubtitleEdit/support-files releases](https://github.com/SubtitleEdit/support-files/releases) (upstream only ships Windows builds). CPU, CUDA and Vulkan builds for Windows and Linux x64, and a Metal build for macOS Apple Silicon.
+*   **Destination:** `[Data Folder]/audio.cpp` - `audiocpp_server.exe` (`audiocpp_server` on Linux/macOS) plus a `BUILD-INFO.txt` listing the model families the build was compiled with. Subtitle Edit reads that file and offers an update when an engine needs a family the installed build lacks, so keep it next to the binary if you install by hand.
+*   **Models:** GGUF weights come straight from Hugging Face (`audio-cpp/audio.cpp-gguf`) and go into `[Data Folder]/audio.cpp/models/<family>-GGUF`: `IndexTTS2.5-GGUF`, `Higgs-Audio-v3-TTS-4B-GGUF`, `Fish-Audio-S2-Pro-GGUF` and `FireRedTTS3-Base-GGUF`. IndexTTS 2.5, Higgs Audio v3 and Fish Audio S2 Pro show a licence window before the first download.
+*   **Voices:** Reference recordings are kept per engine under `[Data Folder]/TextToSpeech/IndexTts25AudioCpp`, `HiggsTtsAudioCpp`, `FishTtsAudioCpp` and `FireRedTts3AudioCpp`.
+
+These are examples, not the full set — many more local engines are downloadable from the Text to speech window (IndexTTS, CosyVoice3, dots.tts, VoxCPM2, MOSS-TTS, Zonos, VibeVoice, Confucius4-TTS, Pocket TTS, and more), following the same layout: CrispASR-based engines share the `[Data Folder]/CrispASR` cache, the audio.cpp engines share `[Data Folder]/audio.cpp`, and the rest live under `[Data Folder]/TextToSpeech/<engine>`.
 
 Use [Text to Speech](features/text-to-speech.md) for the full engine list and engine-specific options.
 
@@ -196,7 +218,7 @@ Used for GPU-accelerated AI-based speech recognition.
 
 ### SE5 Speech-to-Text, OCR, and TTS Engines
 
-The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, PaddleOCR, and the local TTS engines because the required files differ by build and model.
+The same data-folder layout is used on Linux. Prefer the in-app downloaders for Crisp ASR, Qwen3 ASR, WhisperX, PaddleOCR, CrispEmbed, llama.cpp, audio.cpp and the local TTS engines because the required files differ by build and model.
 
 ---
 

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -58,7 +58,7 @@ Near the top of the JSON file, update these fields:
 ```json
 {
   "title": "Subtitle Edit",
-  "version": "v5.2.0-beta32",
+  "version": "v5.2.0",
   "translatedBy": "Your Name (or email / homepage)",
   "cultureName": "de-DE",
   ...

--- a/src/ui/Features/Main/AssistedMove/AssistedMoveViewModel.cs
+++ b/src/ui/Features/Main/AssistedMove/AssistedMoveViewModel.cs
@@ -2,6 +2,7 @@
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Main.AssistedMove;
@@ -42,6 +43,13 @@ public partial class AssistedMoveViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+            return;
+        }
+
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assisted-split", "assisted-move");
             return;
         }
 

--- a/src/ui/Features/Main/AssistedSplit/AssistedSplitViewModel.cs
+++ b/src/ui/Features/Main/AssistedSplit/AssistedSplitViewModel.cs
@@ -2,6 +2,7 @@
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 
 namespace Nikse.SubtitleEdit.Features.Main.AssistedSplit;
@@ -42,6 +43,13 @@ public partial class AssistedSplitViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+            return;
+        }
+
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assisted-split");
             return;
         }
 

--- a/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
+++ b/src/ui/Features/Shared/ErrorList/ErrorListViewModel.cs
@@ -158,6 +158,11 @@ public partial class ErrorListViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/list-errors");
+        }
     }
 
     /// <summary>

--- a/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersViewModel.cs
+++ b/src/ui/Features/Tools/RemoveUnicodeCharacters/RemoveUnicodeCharactersViewModel.cs
@@ -174,5 +174,10 @@ public partial class RemoveUnicodeCharactersViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/remove-unicode-characters");
+        }
     }
 }

--- a/src/ui/Features/Video/RemuxVideo/RemuxVideoViewModel.cs
+++ b/src/ui/Features/Video/RemuxVideo/RemuxVideoViewModel.cs
@@ -1027,5 +1027,10 @@ public partial class RemuxVideoViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/remux-video");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Audit of `docs/` against the 5.2.0 changelog and the current code, with every gap fixed.

**New pages** (also added to `docs/index.md`, help key wired in the windows):
- `features/assisted-split.md` - Assisted split and Assisted move
- `features/list-errors.md` - Tools > List errors, summary cards, exports, batch variant
- `features/remove-unicode-characters.md` - the SE 4 plugin port
- `features/remux-video.md` - Video > More > Remux video

**Updated pages**
- What's New: all 5.2 areas (editing, video, STT, TTS, translate, AI review, OCR, formats, batch/seconv)
- Main window menu table and the Video > More submenu list (were stale)
- Speech to text: Google Cloud STT v2, anime-whisper, transcription quality report, Parakeet models, Auto detect rule, retry without VAD
- Text to speech: custom Piper voices, Rename/Delete voice context menu
- Auto-translate: Google fallback endpoint, DeepL full language list, re-break of translated rows, languages kept on engine change
- AI review: Start/Stop server button
- OCR: Paddle 3.7 / PP-OCRv6, language auto-detect, open video after OCR, Train nOCR
- File: image export text effects, unknown-format importer, Save As format additions
- Supported formats: 5.2 formats and a Format notes section (SCC, EBU STL, Lambda Cap, EBU-TT-D/Rosetta colors)
- Batch convert: transport stream settings and teletext page per PID
- Image-based edit: new inputs, Video resolution, Move captions, Remove fade in/out
- Sync dialogs, waveform context menu, text editor drag-and-drop and macOS Look up, Replace accelerators, settings additions, seconv engine count, third-party components (WhisperX, audio.cpp), keyboard shortcut reference
- `translating.md` version example, `screenshots/README.md` entry for `ai-review.png`

**Code** (5 files, 5-8 lines each): F1/help shortcut in the Assisted split, Assisted move, Error list, Remove Unicode characters and Remux video view models, pointing at the new pages.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` - 0 errors
- [x] Every `features/*.md` is linked from `index.md`; every `ShowHelp` target has a page; all relative links and image references resolve
- [ ] Screenshots for the four new pages are still placeholders (`<!-- not yet taken -->`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
