### PR TITLE
Bring back the SE4 EBU STL "Box" toggle

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1201,6 +1201,16 @@ public static partial class InitListViewAndEditBox
         boldMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsSubtitleGridDataMenuVisible)));
         flyout.Items.Add(boldMenuItem);
 
+        // EBU STL only (teletext boxing) - hidden for every other format, as in SE4.
+        var boxMenuItem = new MenuItem
+        {
+            Header = Se.Language.General.Box,
+            Command = vm.ToggleLinesBoxCommand,
+            DataContext = vm,
+        };
+        boxMenuItem.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsBoxMenuItemVisible)));
+        flyout.Items.Add(boxMenuItem);
+
         var colorMenuItem = new MenuItem
         {
             Header = Se.Language.General.ColorDotDotDot,
@@ -1820,6 +1830,12 @@ public static partial class InitListViewAndEditBox
         var menuItemTextBoxUnderline = new MenuItem { Header = Se.Language.General.Underline };
         menuItemTextBoxUnderline.Command = vm.TextBoxUnderlineCommand;
         flyoutTextBox.Items.Add(menuItemTextBoxUnderline);
+
+        // EBU STL only (teletext boxing) - hidden for every other format, as in SE4.
+        var menuItemTextBoxBox = new MenuItem { Header = Se.Language.General.Box, DataContext = vm };
+        menuItemTextBoxBox.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.IsFormatEbu)));
+        menuItemTextBoxBox.Command = vm.TextBoxBoxCommand;
+        flyoutTextBox.Items.Add(menuItemTextBoxBox);
 
         var menuItemTextBoxFontName = new MenuItem { Header = Se.Language.General.FontNameDotDotDot };
         menuItemTextBoxFontName.Command = vm.TextBoxFontNameCommand;

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -253,7 +253,7 @@ public partial class MainViewModel :
 
     [ObservableProperty] private bool _isWaveformToolbarVisible;
     [ObservableProperty] private bool _isSubtitleGridFlyoutHeaderVisible;
-    [ObservableProperty] private bool _isSubtitleGridDataMenuVisible;
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(IsBoxMenuItemVisible))] private bool _isSubtitleGridDataMenuVisible;
     [ObservableProperty] private bool _isMergeWithNextOrPreviousVisible;
     [ObservableProperty] private bool _isInsertLineNoSelectionVisible;
     [ObservableProperty] private bool _isInsertSubtitleFileAfterLineVisible;
@@ -376,7 +376,14 @@ public partial class MainViewModel :
     /// teletext dialog, the "TT" column and the alignment preview are all gated on this.
     /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsBoxMenuItemVisible))]
     private bool _isFormatEbu;
+
+    /// <summary>
+    /// The grid context menu "Box" toggle - only EBU STL carries the teletext boxing codes that
+    /// the &lt;box&gt; tag maps to, so the item is hidden for every other format (SE4 parity).
+    /// </summary>
+    public bool IsBoxMenuItemVisible => IsSubtitleGridDataMenuVisible && IsFormatEbu;
 
     /// <summary>
     /// True while the toolbar format is one of the teletext formats - EBU STL or DVB teletext
@@ -15008,6 +15015,35 @@ public partial class MainViewModel :
     }
 
     [RelayCommand]
+    private void ToggleLinesBox()
+    {
+        ToggleBox();
+    }
+
+    [RelayCommand]
+    private void ToggleLinesBoxOrSelectedText()
+    {
+        if (!IsFormatEbu)
+        {
+            return;
+        }
+
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        if (selectedItems.Count == 1 && EditTextBox.SelectedText.Length > 0)
+        {
+            TextBoxBox();
+            return;
+        }
+
+        ToggleBox();
+    }
+
+    [RelayCommand]
     private async Task ShowAlignmentPicker()
     {
         var selected = SelectedSubtitle;
@@ -18151,6 +18187,20 @@ public partial class MainViewModel :
     {
         var tb = EditTextBox;
         ToggleTextBoxTag(tb, "u");
+        _updateAudioVisualizer = true;
+    }
+
+    [RelayCommand]
+    private void TextBoxBox()
+    {
+        // EBU STL only: <box> is the teletext boxing code pair (0x84/0x85), meaningless elsewhere.
+        if (!IsFormatEbu)
+        {
+            return;
+        }
+
+        var tb = EditTextBox;
+        TextBoxTagToggler.ToggleTag(tb, "box", isAssa: false);
         _updateAudioVisualizer = true;
     }
 
@@ -27735,6 +27785,35 @@ public partial class MainViewModel :
                 {
                     item.Text = $"<u>{item.Text}</u>";
                 }
+            }
+        }
+    }
+
+    // SE 4 parity: the EBU STL "Box" toggle (teletext boxing, written as 0x84/0x85 by the STL
+    // writer). Plain HTML-style tag only - there is no ASSA equivalent, and the callers gate on
+    // the EBU STL format.
+    private void ToggleBox()
+    {
+        if (!IsFormatEbu)
+        {
+            return;
+        }
+
+        var selectedItems = _selectedSubtitles?.ToList() ?? [];
+        if (selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var makeBox = !selectedItems[0].Text.Contains("<box>", StringComparison.OrdinalIgnoreCase);
+        foreach (var item in selectedItems)
+        {
+            item.Text = item.Text
+                .Replace("<box>", string.Empty).Replace("</box>", string.Empty)
+                .Replace("<BOX>", string.Empty).Replace("</BOX>", string.Empty);
+            if (makeBox && !string.IsNullOrEmpty(item.Text))
+            {
+                item.Text = $"<box>{item.Text}</box>";
             }
         }
     }

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -184,6 +184,7 @@ public static class Se4ShortcutsImporter
         ["MainListViewItalic"] = nameof(MainViewModel.ToggleLinesItalicOrSelectedTextCommand),
         ["MainListViewBold"] = nameof(MainViewModel.ToggleLinesBoldOrSelectedTextCommand),
         ["MainListViewUnderline"] = nameof(MainViewModel.ToggleLinesUnderlineOrSelectedTextCommand),
+        ["MainListViewBox"] = nameof(MainViewModel.ToggleLinesBoxOrSelectedTextCommand),
         ["MainListViewAlignment"] = nameof(MainViewModel.ShowAlignmentPickerCommand),
         ["MainListViewAlignmentN1"] = nameof(MainViewModel.DoAlignmentAn1Command),
         ["MainListViewAlignmentN2"] = nameof(MainViewModel.DoAlignmentAn2Command),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -36,6 +36,7 @@ public class LanguageSettingsShortcuts
     public string GeneralToggleItalic { get; set; }
     public string GeneralToggleBold { get; set; }
     public string GeneralToggleUnderline { get; set; }
+    public string GeneralToggleBox { get; set; }
 
     public string FileOpen { get; set; }
     public string FileOpenKeepVideo { get; set; }
@@ -175,6 +176,7 @@ public class LanguageSettingsShortcuts
     public string TextBoxItalic { get; set; }
     public string TextBoxBold { get; set; }
     public string TextBoxUnderline { get; set; }
+    public string TextBoxBox { get; set; }
     public string ResetWaveformZoomAndSpeed { get; set; }
     public string TogglePlaybackSpeed { get; set; }
     public string PlaybackSpeedSlower { get; set; }
@@ -311,6 +313,7 @@ public class LanguageSettingsShortcuts
         GeneralToggleItalic = "Toggle italic";
         GeneralToggleBold = "Toggle bold";
         GeneralToggleUnderline = "Toggle underline";
+        GeneralToggleBox = "Toggle box (EBU STL)";
 
         FileOpen = "Open";
         FileOpenKeepVideo = "Open (keep video)";
@@ -455,6 +458,7 @@ public class LanguageSettingsShortcuts
         TextBoxItalic = "Text box italic";
         TextBoxBold = "Text box bold";
         TextBoxUnderline = "Text box underline";
+        TextBoxBox = "Text box box (EBU STL)";
         ResetWaveformZoomAndSpeed = "Reset waveform zoom and playback speed (play rate)";
         TogglePlaybackSpeed = "Toggle playback speed (play rate)";
         PlaybackSpeedSlower = "Playback speed slower (play rate)";

--- a/src/ui/Logic/ISplitManager.cs
+++ b/src/ui/Logic/ISplitManager.cs
@@ -330,6 +330,7 @@ public class SplitManager : ISplitManager
         ("<b>", "</b>"),
         ("<i>", "</i>"),
         ("<u>", "</u>"),
+        ("<box>", "</box>"), // EBU STL teletext boxing
     ];
 
     private static readonly string[] CompoundHtmlOpenPrefixes = ["<font", "<color"];
@@ -345,7 +346,7 @@ public class SplitManager : ISplitManager
         var closingToAppend = new List<string>();
         var openingToPrepend = new List<string>();
 
-        // Handle simple HTML tags: <b>, <i>, <u>
+        // Handle simple HTML tags: <b>, <i>, <u>, <box>
         foreach (var (open, close) in SimpleHtmlTags)
         {
             var openCount = CountOccurrences(text1, open);

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -269,6 +269,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.ToggleLinesItalicOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleItalic },
         { nameof(MainViewModel.ToggleLinesBoldOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleBold },
         { nameof(MainViewModel.ToggleLinesUnderlineOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleUnderline },
+        { nameof(MainViewModel.ToggleLinesBoxOrSelectedTextCommand), Se.Language.Options.Shortcuts.GeneralToggleBox },
 
         { nameof(MainViewModel.PlayCommand), Se.Language.General.Play },
         { nameof(MainViewModel.PlayNextCommand), Se.Language.General.PlayNext },
@@ -319,6 +320,7 @@ public static class ShortcutsMain
         { nameof(MainViewModel.TextBoxItalicCommand), Se.Language.Options.Shortcuts.TextBoxItalic },
         { nameof(MainViewModel.TextBoxBoldCommand), Se.Language.Options.Shortcuts.TextBoxBold },
         { nameof(MainViewModel.TextBoxUnderlineCommand), Se.Language.Options.Shortcuts.TextBoxUnderline },
+        { nameof(MainViewModel.TextBoxBoxCommand), Se.Language.Options.Shortcuts.TextBoxBox },
 
         { nameof(MainViewModel.VideoOneFrameBackCommand), Se.Language.General.VideoOneFrameBack },
         { nameof(MainViewModel.VideoOneFrameForwardCommand),  Se.Language.General.VideoOneFrameForward },
@@ -655,6 +657,7 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.ToggleLinesItalicOrSelectedTextCommand, nameof(vm.ToggleLinesItalicOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.ToggleLinesBoldOrSelectedTextCommand, nameof(vm.ToggleLinesBoldOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
         AddShortcut(shortcuts, vm.ToggleLinesUnderlineOrSelectedTextCommand, nameof(vm.ToggleLinesUnderlineOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
+        AddShortcut(shortcuts, vm.ToggleLinesBoxOrSelectedTextCommand, nameof(vm.ToggleLinesBoxOrSelectedTextCommand), ShortcutCategory.SubtitleGridAndTextBox);
 
         AddShortcut(shortcuts, vm.PlayCommand, nameof(vm.PlayCommand), ShortcutCategory.General, ShortcutGroup.Video);
         AddShortcut(shortcuts, vm.PlayNextCommand, nameof(vm.PlayNextCommand), ShortcutCategory.General, ShortcutGroup.Video);

--- a/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
+++ b/tests/UI/Features/Main/Se4GuessStartAndUnderlineTests.cs
@@ -96,6 +96,43 @@ public class Se4GuessStartAndUnderlineTests : IDisposable
     }
 
     /// <summary>
+    /// SE4's "Box" toggle (teletext boxing, the EBU STL 0x84/0x85 codes): wraps and unwraps the
+    /// selected lines in &lt;box&gt; - but only while the toolbar format is EBU STL. In any other
+    /// format the command is a no-op and the grid menu item stays hidden.
+    /// </summary>
+    [AvaloniaFact]
+    public void ToggleBoxWrapsSelectedLinesOnlyForEbuStl()
+    {
+        var (_, vm) = CreateMainViewModel();
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("Hello", 1000, 3000), null!) { Number = 1 });
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("World", 4000, 6000), null!) { Number = 2 });
+        Dispatcher.UIThread.RunJobs();
+
+        Select(vm, vm.Subtitles[0], vm.Subtitles[1]);
+
+        // Default format (SubRip): nothing happens, item hidden.
+        Assert.False(vm.IsFormatEbu);
+        vm.ToggleLinesBoxOrSelectedTextCommand.Execute(null);
+        Assert.Equal("Hello", vm.Subtitles[0].Text);
+        Assert.Equal("World", vm.Subtitles[1].Text);
+        Assert.False(vm.IsBoxMenuItemVisible);
+
+        vm.SelectedSubtitleFormat = vm.SubtitleFormats.First(f => f is Nikse.SubtitleEdit.Core.SubtitleFormats.Ebu);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.IsFormatEbu);
+        Select(vm, vm.Subtitles[0], vm.Subtitles[1]);
+
+        vm.ToggleLinesBoxOrSelectedTextCommand.Execute(null);
+        Assert.Equal("<box>Hello</box>", vm.Subtitles[0].Text);
+        Assert.Equal("<box>World</box>", vm.Subtitles[1].Text);
+
+        // Second press removes it again - the first selected line decides for the whole selection.
+        vm.ToggleLinesBoxOrSelectedTextCommand.Execute(null);
+        Assert.Equal("Hello", vm.Subtitles[0].Text);
+        Assert.Equal("World", vm.Subtitles[1].Text);
+    }
+
+    /// <summary>
     /// A cue that starts inside the silence in front of the speech: "guess start" moves the start
     /// cue up to just before the speech begins instead of leaving the dead air in the line.
     /// </summary>

--- a/tests/UI/Logic/SplitManagerTests.cs
+++ b/tests/UI/Logic/SplitManagerTests.cs
@@ -293,6 +293,20 @@ public class SplitManagerTests : IDisposable
     }
 
     [Fact]
+    public void Split_EbuBoxTagOpenInFirstLine_ClosedAndReopenedInSecondLine()
+    {
+        Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;
+        var manager = new SplitManager();
+        var subtitle = MakeSubtitle($"<box>First line{Environment.NewLine}Second line</box>", 1, 3);
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { subtitle };
+
+        manager.Split(subtitles, subtitle, languageCode: "en");
+
+        Assert.Contains("</box>", subtitles[0].Text, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith("<box>", subtitles[1].Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Split_UnderlineTagOpenInFirstLine_ClosedAndReopenedInSecondLine()
     {
         Se.Settings.General.MinimumBetweenLines.Milliseconds = 0;


### PR DESCRIPTION
## Summary

The `<box>` tag (teletext boxing, EBU STL 0x84/0x85) still round-tripped through the EBU reader/writer and the boxed preview, but SE5 had no way to add it. SE4's "Box" items in the grid and text box context menus, its `MainListViewBox` shortcut and the split re-close helper never made it over.

- Grid context menu: "Box" after Bold, visible only while the format is EBU STL.
- Text box context menu: "Box" after Underline, same gate.
- Shortcuts: "Toggle box (EBU STL)" (grid + text box) and "Text box box (EBU STL)". SE4 `MainListViewBox` imports onto the new grid command. Both commands are no-ops outside EBU STL.
- SplitManager keeps `<box>` balanced across a split like `<i>`/`<b>`/`<u>`.

## Test plan

- [x] New headless test: toggle is a no-op and the menu item hidden in SubRip, wraps/unwraps in EBU STL.
- [x] New SplitManager test: `<box>` closed on line 1 and reopened on line 2 after a split.
- [x] UI test project: split, shortcut, language and SE4 importer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)