### PR TITLE
Only apply the teletext line width in the grid when the EBU STL header says teletext

### DIFF
--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -947,6 +947,29 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                    header.Substring(3, 3) == "STL";
         }
 
+        /// <summary>
+        /// True when <paramref name="header"/> is an STL header whose display standard code is
+        /// teletext (level 1 or 2). Open subtitling (code 0) has no teletext page, so the 40 cell
+        /// row and its control-code overhead do not apply to it.
+        /// </summary>
+        public static bool IsTeletextHeader(string header)
+        {
+            if (!IsStlHeader(header))
+            {
+                return false;
+            }
+
+            try
+            {
+                var displayStandardCode = ReadHeader(GetEncoding(header.Substring(0, 3)).GetBytes(header)).DisplayStandardCode;
+                return displayStandardCode == "1" || displayStandardCode == "2";
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         public bool Save(string fileName, Subtitle subtitle)
         {
             return Save(fileName, subtitle, false);

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -5066,6 +5066,10 @@ public partial class MainViewModel :
         // sit there unseen until the next keystroke.
         _mpvPreviewDirty = true;
 
+        // The dialog stores the header on the subtitle, and switching it between open subtitling
+        // and teletext changes which line width the grid flags.
+        UpdateTeletextLineLength();
+
         return true;
     }
 
@@ -22654,6 +22658,11 @@ public partial class MainViewModel :
             SetSubtitleFormat(SubtitleFormats.FirstOrDefault(p => p.Name == loadedFormatName) ??
                               SelectedSubtitleFormat);
 
+            // Opening one STL after another leaves the format untouched, so the format-changed
+            // handler never runs - but the new header may be open subtitling where the old one
+            // was teletext, or the other way round.
+            UpdateTeletextLineLength();
+
             // The STL header declares the frame rate the timecodes were authored in, so the
             // HH:MM:SS:FF display (forced on for EBU STL) shows the file's own frame numbers.
             // Skipped when the header's disk format code is unreadable - the frame rate would
@@ -32501,6 +32510,36 @@ public partial class MainViewModel :
         _updateAudioVisualizer = true;
     }
 
+    /// <summary>
+    /// A teletext page is narrower than the general line-length limit, so for the teletext formats
+    /// an over-wide row counts as a text error (red Text cell, error list, next-error). EBU STL is
+    /// only teletext when its header says so: an open subtitling STL (the export dialog's default)
+    /// has no 40 cell page, and its rows are checked against the general maximum instead - the
+    /// same split the EBU save options dialog makes. Without a header the writer invents one, which
+    /// is teletext exactly when the subtitle carries colours (see the header fallback in Ebu.Save).
+    /// </summary>
+    private void UpdateTeletextLineLength()
+    {
+        var useTeletextLineLength = SelectedSubtitleFormat is DvbTeletext;
+        if (SelectedSubtitleFormat is Ebu)
+        {
+            useTeletextLineLength = Ebu.IsStlHeader(_subtitle.Header)
+                ? Ebu.IsTeletextHeader(_subtitle.Header)
+                : Subtitles.Any(row => row.Text.Contains("<font color", StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (SubtitleLineViewModel.UseTeletextLineLength == useTeletextLineLength)
+        {
+            return;
+        }
+
+        SubtitleLineViewModel.UseTeletextLineLength = useTeletextLineLength;
+        foreach (var row in Subtitles)
+        {
+            row.RefreshAfterSettingsChanged();
+        }
+    }
+
     internal void ComboBoxSubtitleFormatChanged(object? sender, SelectionChangedEventArgs e)
     {
         if (!_changingFormatProgrammatically)
@@ -32515,17 +32554,7 @@ public partial class MainViewModel :
         IsFormatWebVtt = SelectedSubtitleFormat is WebVTT or WebVTTFileWithLineNumber;
         IsFormatEbu = SelectedSubtitleFormat is Ebu;
         IsFormatTeletext = SelectedSubtitleFormat is Ebu or DvbTeletext;
-
-        // A teletext page is narrower than the general line-length limit, so for the teletext
-        // formats an over-wide row counts as a text error (red Text cell, error list, next-error).
-        if (SubtitleLineViewModel.UseTeletextLineLength != IsFormatTeletext)
-        {
-            SubtitleLineViewModel.UseTeletextLineLength = IsFormatTeletext;
-            foreach (var row in Subtitles)
-            {
-                row.RefreshAfterSettingsChanged();
-            }
-        }
+        UpdateTeletextLineLength();
 
         UpdateTemporaryFrameMode();
 

--- a/src/ui/Features/Main/SubtitleLineViewModel.cs
+++ b/src/ui/Features/Main/SubtitleLineViewModel.cs
@@ -168,8 +168,9 @@ public partial class SubtitleLineViewModel : ObservableObject
     }
 
     /// <summary>
-    /// True while an EBU STL subtitle is open, so a row wider than a teletext page counts as a
-    /// "text too long" error. Set from MainViewModel when the format changes.
+    /// True while a teletext subtitle is open (DVB teletext, or EBU STL whose header says teletext
+    /// rather than open subtitling), so a row wider than a teletext page counts as a "text too long"
+    /// error. Set from MainViewModel when the format, the file or the EBU header changes.
     /// </summary>
     public static bool UseTeletextLineLength { get; set; }
 

--- a/tests/libse/SubtitleFormats/EbuTest.cs
+++ b/tests/libse/SubtitleFormats/EbuTest.cs
@@ -49,6 +49,20 @@ public class EbuTest
         Assert.False(Ebu.IsStlHeader("STL25".PadRight(1024)));
     }
 
+    // The main grid flags rows wider than a teletext page (37 cells) only for teletext STL. An open
+    // subtitling STL has no page, so its rows are checked against the general maximum (Ingo's
+    // 42-character project showed 37-character errors the EBU save dialog did not).
+    [Fact]
+    public void IsTeletextHeader_TrueOnlyForTeletextDisplayStandard()
+    {
+        Assert.False(Ebu.IsTeletextHeader(null));
+        Assert.False(Ebu.IsTeletextHeader("WEBVTT"));
+        Assert.False(Ebu.IsTeletextHeader(new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = "0" }.ToString()));
+        Assert.False(Ebu.IsTeletextHeader(new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = " " }.ToString()));
+        Assert.True(Ebu.IsTeletextHeader(new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = "1" }.ToString()));
+        Assert.True(Ebu.IsTeletextHeader(new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = "2" }.ToString()));
+    }
+
     // Regression for #11910: EBU STL Save produced a 14-byte invalid file ("Not supported!")
     // because the binary format went through the text save path. The binary writer must emit a real
     // EBU file (1024-byte GSI header + TTI blocks) that reads back.


### PR DESCRIPTION
## Summary
- The main grid flagged any row over 37 characters as "text too long" whenever the format was EBU STL, regardless of the header's display standard. For an open subtitling STL (the export dialog's default) there is no teletext page, so a user working with a 42-character limit saw grid errors that the EBU save options dialog, which already checks the display standard, did not report.
- The gate now follows the header: DVB teletext always; EBU STL only when the stored header is teletext level 1 or 2; with no header yet, only when the subtitle carries colours (the case where `Ebu.Save` invents a teletext header).
- It is refreshed on format change, after a file load (opening one STL after another leaves the format unchanged, so the format-changed handler never ran) and after the EBU save options dialog stores a new header.

## Test plan
- [x] New `IsTeletextHeader_TrueOnlyForTeletextDisplayStandard` in `tests/libse/SubtitleFormats/EbuTest.cs`
- [x] `SubtitleLineViewModelHasErrorsTests` still pass
- [ ] Manual: open an open-subtitling STL with 40-character rows and a 42 limit, no red text cells; open a teletext STL, rows over 37 are flagged

Reported by Ingo (SubtitleService) by mail on 2026-09-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
