### PR TITLE
Preview open-subtitling EBU STL on the same row count the writer uses

### DIFF
--- a/src/libse/Common/SubtitlePositionToAssa.cs
+++ b/src/libse/Common/SubtitlePositionToAssa.cs
@@ -248,17 +248,11 @@ namespace Nikse.SubtitleEdit.Core.Common
         {
             try
             {
+                // The same rule the writer lays the lines out with - an open subtitling header
+                // whose MNR is "02" used to give a 2 row page here, which parked every line in
+                // the vertical middle of the preview while the saved file had it at the bottom.
                 var ebuHeader = Ebu.ReadHeader(Ebu.GetEncoding(header.Substring(0, 3)).GetBytes(header));
-                if (ebuHeader.DisplayStandardCode == "1" || ebuHeader.DisplayStandardCode == "2") // teletext
-                {
-                    return 23;
-                }
-
-                if (int.TryParse(ebuHeader.MaximumNumberOfDisplayableRows, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rows) &&
-                    rows > 1)
-                {
-                    return rows;
-                }
+                return Ebu.GetDisplayRowCount(ebuHeader);
             }
             catch
             {

--- a/src/libse/SubtitleFormats/Ebu.cs
+++ b/src/libse/SubtitleFormats/Ebu.cs
@@ -947,6 +947,33 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
                    header.Substring(3, 3) == "STL";
         }
 
+        /// <summary>
+        /// The number of rows the vertical position (VP) of a text block counts against. Teletext
+        /// always has a 23 row page, whatever the header's MNR says. Open subtitling files often
+        /// carry the number of rows a subtitle may occupy (02) rather than a page height, and
+        /// laying lines out against a 2 row page would put them mid-screen - so that case gets a
+        /// 15 row page. Shared by the writer and the video preview so both place a line the same.
+        /// </summary>
+        public static int GetDisplayRowCount(EbuGeneralSubtitleInformation header)
+        {
+            if (header.DisplayStandardCode == "1" || header.DisplayStandardCode == "2") // teletext
+            {
+                return 23;
+            }
+
+            if (header.DisplayStandardCode == "0" && header.MaximumNumberOfDisplayableRows == "02") // open subtitling
+            {
+                return 15;
+            }
+
+            if (int.TryParse(header.MaximumNumberOfDisplayableRows, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rows) && rows > 1)
+            {
+                return rows;
+            }
+
+            return 23;
+        }
+
         public bool Save(string fileName, Subtitle subtitle)
         {
             return Save(fileName, subtitle, false);
@@ -1054,21 +1081,7 @@ namespace Nikse.SubtitleEdit.Core.SubtitleFormats
             foreach (var p in subtitle.Paragraphs)
             {
                 var tti = new EbuTextTimingInformation();
-
-                if (!int.TryParse(header.MaximumNumberOfDisplayableRows, out var rows))
-                {
-                    rows = 23;
-                }
-
-                if (header.DisplayStandardCode == "1" || header.DisplayStandardCode == "2") // teletext
-                {
-                    rows = 23;
-                }
-                else if (header.DisplayStandardCode == "0" && header.MaximumNumberOfDisplayableRows == "02") // open subtitling
-                {
-                    rows = 15;
-                }
-
+                var rows = GetDisplayRowCount(header);
                 var text = p.Text.Trim(Utilities.NewLineChars);
 
                 var teletextPosition = 0;

--- a/tests/libse/Common/SubtitlePositionToAssaTest.cs
+++ b/tests/libse/Common/SubtitlePositionToAssaTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 
@@ -193,6 +194,26 @@ public class SubtitlePositionToAssaTest
         var p = subtitle.Paragraphs[0];
         Assert.StartsWith(@"{\an2}", p.Text, StringComparison.Ordinal);
         Assert.Equal("13", p.MarginV); // one row of 23 left below the two lines (rows 20 and 22)
+    }
+
+    [Fact]
+    public void EbuOpenSubtitlingWithTwoRowHeaderPreviewsAtTheBottomLikeTheWriter()
+    {
+        // Open subtitling STL files from other tools commonly carry "02" as the maximum number of
+        // displayable rows - the rows a subtitle may occupy, not a page height. The writer lays
+        // such a file out on a 15 row page; the preview used a 2 row page and centered every line.
+        var header = new Ebu.EbuGeneralSubtitleInformation { DisplayStandardCode = "0", MaximumNumberOfDisplayableRows = "02" }.ToString();
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hi there!", 1000, 3000));
+        subtitle.Paragraphs.Add(new Paragraph("Line one" + Environment.NewLine + "Line two", 4000, 6000));
+
+        Assert.True(SubtitlePositionToAssa.ApplyPositions(subtitle, header));
+
+        foreach (var p in subtitle.Paragraphs)
+        {
+            Assert.StartsWith(@"{\an2}", p.Text, StringComparison.Ordinal);
+            Assert.Equal("38", p.MarginV); // rows 13 (and 11+13) of 15, two rows left below - as Ebu.Save writes it
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- The mpv/VLC preview took the EBU STL page height from the header's maximum number of displayable rows. Open subtitling files from other tools commonly carry `02` there (the rows a subtitle may occupy, not a page height), so the preview laid lines out on a 2-row page and every subtitle sat in the vertical middle of the video. `Ebu.Save` already treats that header as a 15-row page and writes the lines at the bottom, so only the preview was wrong.
- The rule now lives in `Ebu.GetDisplayRowCount` and both the writer and `SubtitlePositionToAssa` use it. Teletext stays 23 rows; open subtitling with MNR `02` is 15 rows; any other parseable MNR above 1 is used as is; otherwise 23. The writer previously accepted `00`/`01` as a page height too, which produced row 0; those now fall back to 23 like the preview always did.

## Test plan
- [x] New `EbuOpenSubtitlingWithTwoRowHeaderPreviewsAtTheBottomLikeTheWriter` in `tests/libse/Common/SubtitlePositionToAssaTest.cs`
- [x] Full libse suite passes (2007 tests)
- [ ] Manual: open an open-subtitling STL with MNR 02, subtitles preview at the bottom instead of centered

Reported by Ingo (SubtitleService) by mail on 2026-09-11. Companion to #14781 (grid line width), kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
