### PR TITLE
Wire the help shortcut in 110 more dialogs

### DIFF
--- a/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaTagHistoryViewModel.cs
+++ b/src/ui/Features/Assa/AssaApplyCustomOverrideTags/AssaTagHistoryViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -63,6 +64,11 @@ public partial class AssaTagHistoryViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-override-tags");
         }
         else if (e.Key == Key.Enter)
         {

--- a/src/ui/Features/Assa/AssaSingleStyleViewModel.cs
+++ b/src/ui/Features/Assa/AssaSingleStyleViewModel.cs
@@ -67,6 +67,11 @@ public partial class AssaSingleStyleViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-styles");
+        }
     }
 
     internal void BorderTypeChanged(object? sender, SelectionChangedEventArgs e)

--- a/src/ui/Features/Assa/AssaStylePickerViewModel.cs
+++ b/src/ui/Features/Assa/AssaStylePickerViewModel.cs
@@ -72,5 +72,10 @@ public partial class AssaStylePickerViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-styles");
+        }
     }
 }

--- a/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
+++ b/src/ui/Features/Assa/FontCollector/FontCollectorViewModel.cs
@@ -728,5 +728,10 @@ public partial class FontCollectorViewModel : ObservableObject
             e.Handled = true;
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/assa-attachments", "font-attachments");
+        }
     }
 }

--- a/src/ui/Features/Edit/MultipleReplace/CategoryPickerViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/CategoryPickerViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
@@ -128,6 +129,13 @@ public partial class CategoryPickerViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+            return;
+        }
+
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/edit", "multiple-replace");
             return;
         }
 

--- a/src/ui/Features/Edit/MultipleReplace/EditCategoryViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/EditCategoryViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
@@ -44,6 +45,11 @@ public partial class EditCategoryViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/edit", "multiple-replace");
         }
     }
 }

--- a/src/ui/Features/Edit/MultipleReplace/EditRuleViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/EditRuleViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
@@ -68,6 +69,11 @@ public partial class EditRuleViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/edit", "multiple-replace");
         }
         else if (e.Key == Key.Enter || e.Key == Key.Return)
         {

--- a/src/ui/Features/Edit/MultipleReplace/FindRuleViewModel.cs
+++ b/src/ui/Features/Edit/MultipleReplace/FindRuleViewModel.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Edit.MultipleReplace;
 
@@ -84,6 +85,11 @@ public partial class FindRuleViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/edit", "multiple-replace");
         }
         else if (e.Key == Key.Enter)
         {

--- a/src/ui/Features/Edit/ShowHistory/ShowHistoryViewModel.cs
+++ b/src/ui/Features/Edit/ShowHistory/ShowHistoryViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.UndoRedo;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -58,6 +59,11 @@ public partial class ShowHistoryViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/edit", "show-history");
         }
     }
 }

--- a/src/ui/Features/Files/ExportCavena890/ExportCavena890ViewModel.cs
+++ b/src/ui/Features/Files/ExportCavena890/ExportCavena890ViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportCavena890;
 
@@ -60,6 +61,11 @@ public partial class ExportCavena890ViewModel : ObservableObject
         {
             e.Handled = true;
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-to-cavena-890");
         }
     }
 }

--- a/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/EditCustomTextFormatViewModel.cs
@@ -169,6 +169,11 @@ public partial class EditCustomTextFormatViewModel : ObservableObject, IClosingC
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-custom-text-format");
+        }
     }
 
     /// <param name="title">The window caption.</param>

--- a/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
+++ b/src/ui/Features/Files/ExportCustomTextFormat/ExportCustomTextFormatViewModel.cs
@@ -200,6 +200,11 @@ public partial class ExportCustomTextFormatViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-custom-text-format");
+        }
     }
 
     internal void OnCustomFormatGridDoubleTapped(object? sender, TappedEventArgs e)

--- a/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextViewModel.cs
+++ b/src/ui/Features/Files/ExportDvbTeletext/ExportDvbTeletextViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -72,6 +73,11 @@ public partial class ExportDvbTeletextViewModel : ObservableObject
         {
             e.Handled = true;
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export");
         }
     }
 }

--- a/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
+++ b/src/ui/Features/Files/ExportEbuStl/ExportEbuStlViewModel.cs
@@ -792,5 +792,10 @@ new("2F", "French - hearing impaired (VF-MAL)"),
             e.Handled = true;
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-to-ebu-stl");
+        }
     }
 }

--- a/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ExportImageBasedViewModel.cs
@@ -1054,6 +1054,11 @@ public partial class ExportImageBasedViewModel : ObservableObject, IClosingClean
             e.Handled = true;
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-image-based");
+        }
         else if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl)
         {
             _isCtrlDown = true;

--- a/src/ui/Features/Files/ExportImageBased/ImageBasedProfileViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/ImageBasedProfileViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -133,6 +134,11 @@ public partial class ImageBasedProfileViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-image-based");
         }
     }
 

--- a/src/ui/Features/Files/ExportImageBased/TextEffectViewModel.cs
+++ b/src/ui/Features/Files/ExportImageBased/TextEffectViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.UiLogic.Export;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -149,6 +150,11 @@ public partial class TextEffectViewModel : ObservableObject
         {
             e.Handled = true;
             Cancel();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "text-effects");
         }
     }
 }

--- a/src/ui/Features/Files/ExportPac/ExportPacViewModel.cs
+++ b/src/ui/Features/Files/ExportPac/ExportPacViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.ExportPac;
 
@@ -74,6 +75,11 @@ public partial class ExportPacViewModel : ObservableObject
         {
             e.Handled = true;
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-to-pac");
         }
     }
 }

--- a/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
+++ b/src/ui/Features/Files/ExportPlainText/ExportPlainTextViewModel.cs
@@ -323,6 +323,11 @@ public partial class ExportPlainTextViewModel : ObservableObject, IClosingCleanu
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "export-as-plain-text");
+        }
     }
 
     internal void Initialize(List<SubtitleLineViewModel> subtitles, string? subtitleFileName, string? videoFileName)

--- a/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/DcinemaInteropProperties/DCinemaInteropPropertiesViewModel.cs
@@ -350,6 +350,11 @@ public partial class DCinemaInteropPropertiesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
+        }
     }
 
     public void Initialize(Subtitle subtitle, SubtitleFormat format)

--- a/src/ui/Features/Files/FormatProperties/DcinemaSmpteProperties/DCinemaSmptePropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/DcinemaSmpteProperties/DCinemaSmptePropertiesViewModel.cs
@@ -444,6 +444,11 @@ public partial class DCinemaSmptePropertiesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
+        }
     }
 
     internal void Initialize(SubtitleFormat format)

--- a/src/ui/Features/Files/FormatProperties/ItunesTimedTextProperties/ItunesTimedTextPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/ItunesTimedTextProperties/ItunesTimedTextPropertiesViewModel.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.ItunesTimedTextProperties;
 
@@ -452,6 +453,11 @@ public partial class ItunesTimedTextPropertiesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
         }
     }
 }

--- a/src/ui/Features/Files/FormatProperties/RosettaProperties/RosettaPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/RosettaProperties/RosettaPropertiesViewModel.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -761,6 +762,11 @@ public partial class RosettaPropertiesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
         }
     }
 }

--- a/src/ui/Features/Files/FormatProperties/TimedText10Properties/TimedText10PropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/TimedText10Properties/TimedText10PropertiesViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedText10Properties;
 
@@ -431,6 +432,11 @@ public partial class TimedText10PropertiesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
         }
     }
 }

--- a/src/ui/Features/Files/FormatProperties/TimedTextImsc11Properties/TimedTextImsc11PropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/TimedTextImsc11Properties/TimedTextImsc11PropertiesViewModel.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.TimedTextImsc11Properties;
 
@@ -359,6 +360,11 @@ public partial class TimedTextImsc11PropertiesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
         }
     }
 }

--- a/src/ui/Features/Files/FormatProperties/TmpegEncXmlProperties/TmpegEncXmlPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/TmpegEncXmlProperties/TmpegEncXmlPropertiesViewModel.cs
@@ -66,5 +66,10 @@ public partial class TmpegEncXmlPropertiesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "format-properties");
+        }
     }
 }

--- a/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesViewModel.cs
+++ b/src/ui/Features/Files/FormatProperties/WebVttProperties/WebVttPropertiesViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Files.FormatProperties.WebVttProperties;
 
@@ -96,6 +97,11 @@ public partial class WebVttPropertiesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/webvtt-styles");
         }
     }
 }

--- a/src/ui/Features/Files/ImportImages/ImportImagesViewModel.cs
+++ b/src/ui/Features/Files/ImportImages/ImportImagesViewModel.cs
@@ -7,6 +7,7 @@ using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -139,6 +140,11 @@ public partial class ImportImagesViewModel : ObservableObject
         if (e.Key == Key.Escape)
         {
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "images-for-ocr");
         }
     }
 

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
@@ -181,6 +181,11 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/file", "restore-auto-backup");
+        }
     }
 
     /// <summary>

--- a/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
+++ b/src/ui/Features/Help/CheckForUpdates/CheckForUpdatesViewModel.cs
@@ -83,5 +83,10 @@ public partial class CheckForUpdatesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "updates");
+        }
     }
 }

--- a/src/ui/Features/Main/GridColumns/GridColumnsViewModel.cs
+++ b/src/ui/Features/Main/GridColumns/GridColumnsViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -138,6 +139,11 @@ public partial class GridColumnsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/subtitle-grid", "customizing-visible-columns");
         }
     }
 }

--- a/src/ui/Features/Main/Layout/LayoutWindow.cs
+++ b/src/ui/Features/Main/Layout/LayoutWindow.cs
@@ -117,6 +117,13 @@ public class LayoutWindow : Window
             return;
         }
 
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/main-window", "layouts");
+            return;
+        }
+
         if (e.Key == Key.Enter)
         {
             e.Handled = true;

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrDbEditViewModel.cs
@@ -167,6 +167,11 @@ public partial class BinaryOcrDbEditViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "binary-ocr");
+        }
     }
 
     internal void Initialize(string imageCompareName)

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrInspectViewModel.cs
@@ -499,6 +499,11 @@ public partial class BinaryOcrInspectViewModel : ObservableObject
             e.Handled = true;
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "binary-ocr");
+        }
         else if (e.Key == Key.Left)
         {
             e.Handled = true;

--- a/src/ui/Features/Ocr/BinaryOcr/BinaryOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/BinaryOcr/BinaryOcrSettingsViewModel.cs
@@ -113,5 +113,10 @@ public partial class BinaryOcrSettingsViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "binary-ocr");
+        }
     }
 }

--- a/src/ui/Features/Ocr/CrispEmbedSettings/CrispEmbedSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/CrispEmbedSettings/CrispEmbedSettingsViewModel.cs
@@ -181,5 +181,10 @@ public partial class CrispEmbedSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "crispembed");
+        }
     }
 }

--- a/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
+++ b/src/ui/Features/Ocr/FallbackDatabase/OcrFallbackDatabaseViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -58,6 +59,11 @@ public partial class OcrFallbackDatabaseViewModel : ObservableObject
         {
             e.Handled = true;
             Ok();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "options");
         }
     }
 }

--- a/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/LlamaCppOcrSettingsViewModel.cs
@@ -170,5 +170,10 @@ public partial class LlamaCppOcrSettingsViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "llamacpp");
+        }
     }
 }

--- a/src/ui/Features/Ocr/NOcr/NOcrDbEditViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrDbEditViewModel.cs
@@ -191,6 +191,11 @@ public partial class NOcrDbEditViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "nocr-nikse-ocr");
+        }
         else if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl)
         {
             _isControlDown = true;

--- a/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrInspectViewModel.cs
@@ -648,6 +648,11 @@ public partial class NOcrInspectViewModel : ObservableObject
                 Cancel();
             }
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "nocr-nikse-ocr");
+        }
         else if (e.Key == Key.Left)
         {
             e.Handled = true;

--- a/src/ui/Features/Ocr/NOcr/NOcrSettingsViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrSettingsViewModel.cs
@@ -110,5 +110,10 @@ public partial class NOcrSettingsViewModel : ObservableObject
         {
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "nocr-nikse-ocr");
+        }
     }
 }

--- a/src/ui/Features/Ocr/NOcr/NOcrTrainViewModel.cs
+++ b/src/ui/Features/Ocr/NOcr/NOcrTrainViewModel.cs
@@ -237,6 +237,11 @@ public partial class NOcrTrainViewModel : ObservableObject
             e.Handled = true;
             Done();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "nocr-nikse-ocr");
+        }
     }
 
     internal void OnClosing()

--- a/src/ui/Features/Ocr/PreProcessingViewModel.cs
+++ b/src/ui/Features/Ocr/PreProcessingViewModel.cs
@@ -133,6 +133,11 @@ public partial class PreProcessingViewModel : ObservableObject, IClosingCleanup
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "pre-processing");
+        }
     }
 
     internal void RequestPreviewUpdate()

--- a/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
+++ b/src/ui/Features/Ocr/PromptUnknownWordViewModel.cs
@@ -276,6 +276,11 @@ public partial class PromptUnknownWordViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "unknown-words");
+        }
     }
 
     internal void Onloaded(object? sender, RoutedEventArgs e)

--- a/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserViewModel.cs
+++ b/src/ui/Features/Ocr/VobSubColorChooser/VobSubColorChooserViewModel.cs
@@ -212,5 +212,10 @@ public partial class VobSubColorChooserViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ocr", "options");
+        }
     }
 }

--- a/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListViewModel.cs
+++ b/src/ui/Features/Options/DoNotBreakAfterList/DoNotBreakAfterListViewModel.cs
@@ -294,5 +294,10 @@ public partial class DoNotBreakAfterListViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "tools");
+        }
     }
 }

--- a/src/ui/Features/Options/Language/LanguageViewModel.cs
+++ b/src/ui/Features/Options/Language/LanguageViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -47,6 +48,11 @@ public partial class LanguageViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "general");
         }
     }
 

--- a/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
+++ b/src/ui/Features/Options/Settings/CustomContinuationStyleViewModel.cs
@@ -309,6 +309,11 @@ public partial class CustomContinuationStyleViewModel : ObservableObject, IClosi
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "rules");
+        }
     }
 
     internal void StyleChanged()

--- a/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateViewModel.cs
+++ b/src/ui/Features/Options/Settings/MinGapCalculate/MinGapCalculateViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -118,6 +119,11 @@ public partial class MinGapCalculateViewModel : ObservableObject
         {
             e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "rules");
         }
     }
 }

--- a/src/ui/Features/Options/Settings/ProfilesViewModel.cs
+++ b/src/ui/Features/Options/Settings/ProfilesViewModel.cs
@@ -274,5 +274,10 @@ public partial class ProfilesViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "rules");
+        }
     }
 }

--- a/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsImportExport/SettingsImportExportViewModel.cs
@@ -319,6 +319,11 @@ public partial class SettingsImportExportViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings");
+        }
     }
 
     private async Task ExportSettings()

--- a/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SyntaxColorTooWideSettings/SyntaxColorTooWideSettingsViewModel.cs
@@ -209,5 +209,10 @@ public partial class SyntaxColorTooWideSettingsViewModel : ObservableObject, ICl
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/settings", "syntax-coloring");
+        }
     }
 }

--- a/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
+++ b/src/ui/Features/Options/Settings/WaveformThemes/WaveformThemesWindow.cs
@@ -131,6 +131,11 @@ public class WaveformThemesWindow : Window
             {
                 vm.CancelCommand.Execute(null);
             }
+            else if (UiUtil.IsHelp(e))
+            {
+                e.Handled = true;
+                UiUtil.ShowHelp("features/audio-visualizer", "waveform-themes");
+            }
         };
     }
 

--- a/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsViewModel.cs
+++ b/src/ui/Features/Options/Settings/WaveformToolbarItems/WaveformToolbarItemsViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -186,6 +187,11 @@ public partial class WaveformToolbarItemsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/audio-visualizer", "toolbar");
         }
     }
 }

--- a/src/ui/Features/Options/Shortcuts/CustomSearch/CustomSearchViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/CustomSearch/CustomSearchViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Options.Shortcuts.CustomSearch;
 
@@ -48,6 +49,11 @@ public partial class CustomSearchViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
             return;
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/shortcuts");
         }
     }
 }

--- a/src/ui/Features/Options/Shortcuts/SurroundWith/SurroundWithViewModel.cs
+++ b/src/ui/Features/Options/Shortcuts/SurroundWith/SurroundWithViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Options.Shortcuts.SurroundWith;
 
@@ -46,6 +47,11 @@ public partial class SurroundWithViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
             return;
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/shortcuts");
         }
     }
 }

--- a/src/ui/Features/Shared/MediaInfoView/MediaInfoViewViewModel.cs
+++ b/src/ui/Features/Shared/MediaInfoView/MediaInfoViewViewModel.cs
@@ -227,6 +227,11 @@ public partial class MediaInfoViewViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/video-player", "video-info");
+        }
     }
 
     internal void OnKeyDownHandler(object? sender, KeyEventArgs e)

--- a/src/ui/Features/Shared/Undocked/AudioVisualizerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/AudioVisualizerUndockedViewModel.cs
@@ -60,6 +60,13 @@ public partial class AudioVisualizerUndockedViewModel : ObservableObject
     {
         var videoPlayer = MainViewModel?.GetVideoPlayerControl();
 
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/main-window", "undocking");
+            return;
+        }
+
         MainViewModel?.OnKeyDownHandler(sender, e);
         if (e.Handled)
         {

--- a/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
+++ b/src/ui/Features/Shared/Undocked/VideoPlayerUndockedViewModel.cs
@@ -98,6 +98,13 @@ public partial class VideoPlayerUndockedViewModel : ObservableObject
             return;
         }
 
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/main-window", "undocking");
+            return;
+        }
+
         MainViewModel?.OnKeyDownHandler(sender, e);
         if (e.Handled)
         {

--- a/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesViewModel.cs
+++ b/src/ui/Features/Shared/WaveformGuessTimeCodes/WaveformGuessTimeCodesViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Shared.WaveformGuessTimeCodes;
 
@@ -100,6 +101,11 @@ public partial class WaveformGuessTimeCodesViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/audio-visualizer");
         }
     }
 }

--- a/src/ui/Features/Shared/WaveformSeekSilence/WaveformSeekSilenceViewModel.cs
+++ b/src/ui/Features/Shared/WaveformSeekSilence/WaveformSeekSilenceViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Shared.WaveformSeekSilence;
 
@@ -78,6 +79,11 @@ public partial class WaveformSeekSilenceViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/audio-visualizer");
         }
     }
 

--- a/src/ui/Features/SpellCheck/EditWholeText/EditWholeTextViewModel.cs
+++ b/src/ui/Features/SpellCheck/EditWholeText/EditWholeTextViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck.EditWholeText;
 
@@ -48,6 +49,11 @@ public partial class EditWholeTextViewModel : ObservableObject
         {
             e.Handled = true;
             Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/spell-check");
         }
     }
 }

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -437,5 +437,10 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
             e.Handled = true;
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/spell-check", "dictionaries");
+        }
     }
 }

--- a/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
+++ b/src/ui/Features/Sync/PointSync/SetSyncPoint/SetSyncPointViewModel.cs
@@ -562,6 +562,11 @@ public partial class SetSyncPointViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/point-sync", "set-sync-point-window");
+        }
 
         if (e.Key == Key.Space || (e.Key == Key.P && e.KeyModifiers.HasFlag(KeyModifiers.Control)))
         {

--- a/src/ui/Features/Tools/AiReview/AiReviewPromptViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewPromptViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Tools.AiReview;
 
@@ -54,6 +55,11 @@ public partial class AiReviewPromptViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/ai-review");
         }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertAssaViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertAssaViewModel.cs
@@ -239,6 +239,11 @@ public partial class BatchConvertAssaViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/batch-convert", "available-functions");
+        }
     }
 
     internal void Loaded()

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertFixCommonErrorsSettingsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Tools.BatchConvert;
 
@@ -62,6 +63,11 @@ public partial class BatchConvertFixCommonErrorsSettingsViewModel : ObservableOb
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/batch-convert", "available-functions");
         }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertSettingsViewModel.cs
@@ -419,6 +419,11 @@ public partial class BatchConvertSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/batch-convert", "settings");
+        }
     }
 
     internal void OnOcrEngineChanged()

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertTsSettingsViewModel.cs
@@ -6,6 +6,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.UiLogic.BatchConvert;
 using Nikse.SubtitleEdit.UiLogic.Media;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -171,6 +172,11 @@ public partial class BatchConvertTsSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/batch-convert", "transport-stream-input");
         }
     }
 }

--- a/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchErrorList/BatchErrorListViewModel.cs
@@ -124,6 +124,11 @@ public partial class BatchErrorListViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/list-errors", "in-batch-convert");
+        }
     }
 
     internal void Initialize(List<BatchConvertItem> batchItems)

--- a/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileViewModel.cs
+++ b/src/ui/Features/Tools/BeautifyTimeCodes/Profile/BeautifyTimeCodesProfileViewModel.cs
@@ -233,6 +233,11 @@ public partial class BeautifyTimeCodesProfileViewModel : ObservableObject
             e.Handled = true;
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/beautify-time-codes", "profile-editor");
+        }
     }
 
     // GapMs property used by NumericUpDown bindings — derived from frame count

--- a/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
+++ b/src/ui/Features/Tools/ChangeCasing/FixNamesViewModel.cs
@@ -280,6 +280,11 @@ public partial class FixNamesViewModel : ObservableObject, IClosingCleanup
             e.Handled = true;
             CancelCommand.Execute(null);
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/change-casing", "fix-names");
+        }
     }
 
     internal async void OnLoaded(RoutedEventArgs e)

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsLogViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsLogViewModel.cs
@@ -77,5 +77,10 @@ public partial class FixCommonErrorsLogViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/fix-common-errors");
+        }
     }
 }

--- a/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileViewModel.cs
+++ b/src/ui/Features/Tools/FixCommonErrors/FixCommonErrorsProfileViewModel.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Nikse.SubtitleEdit.Features.Shared;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Tools.FixCommonErrors;
 
@@ -159,6 +160,11 @@ public partial class FixCommonErrorsProfileViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/fix-common-errors", "profiles");
         }
     }
 

--- a/src/ui/Features/Tools/RemoveTextForHearingImpaired/InterjectionsViewModel.cs
+++ b/src/ui/Features/Tools/RemoveTextForHearingImpaired/InterjectionsViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Linq;
 
@@ -74,6 +75,11 @@ public partial class InterjectionsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/remove-text-hi", "interjections");
         }
     }
 

--- a/src/ui/Features/Translate/TranslateSettingsViewModel.cs
+++ b/src/ui/Features/Translate/TranslateSettingsViewModel.cs
@@ -315,6 +315,11 @@ public partial class TranslateSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/auto-translate", "engine-configuration");
+        }
     }
 
     internal void Onloaded(object? sender, RoutedEventArgs e)

--- a/src/ui/Features/Video/BurnIn/BurnInEffectViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInEffectViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls.VideoPlayer;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -81,6 +82,11 @@ public partial class BurnInEffectViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/burn-in", "effect-and-logo");
         }
     }
 

--- a/src/ui/Features/Video/BurnIn/BurnInLogoViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInLogoViewModel.cs
@@ -223,6 +223,11 @@ public partial class BurnInLogoViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/burn-in", "effect-and-logo");
+        }
     }
 
     internal async void OnLoaded()

--- a/src/ui/Features/Video/BurnIn/BurnInResolutionPickerViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInResolutionPickerViewModel.cs
@@ -2,6 +2,7 @@
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -45,6 +46,11 @@ public partial class BurnInResolutionPickerViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/burn-in", "video-settings");
         }
     }
 

--- a/src/ui/Features/Video/BurnIn/BurnInSettingsViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInSettingsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.BurnIn;
@@ -82,6 +83,11 @@ public partial class BurnInSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/burn-in", "video-settings");
         }
     }
 }

--- a/src/ui/Features/Video/Chapters/ChaptersViewModel.cs
+++ b/src/ui/Features/Video/Chapters/ChaptersViewModel.cs
@@ -517,6 +517,11 @@ public partial class ChaptersViewModel : ObservableObject
             e.Handled = true;
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/chapters");
+        }
     }
 
     internal void GridKeyDown(KeyEventArgs e)

--- a/src/ui/Features/Video/Chapters/WriteChaptersToVideoViewModel.cs
+++ b/src/ui/Features/Video/Chapters/WriteChaptersToVideoViewModel.cs
@@ -226,6 +226,11 @@ public partial class WriteChaptersToVideoViewModel : ObservableObject, IClosingC
             e.Handled = true;
             Cancel();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/chapters", "write-to-video");
+        }
     }
 
     public void OnClosingCleanup()

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EditEmbeddedTrackViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EditEmbeddedTrackViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Video.EmbeddedSubtitlesEdit;
 
@@ -55,6 +56,11 @@ public partial class EditEmbeddedTrackViewModel : ObservableObject
         {
             e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/embedded-subtitles", "remove-or-edit-existing-tracks");
         }
     }
 

--- a/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewViewModel.cs
+++ b/src/ui/Features/Video/EmbeddedSubtitlesEdit/EmbedTrackPreviewViewModel.cs
@@ -85,6 +85,11 @@ public partial class EmbedTrackPreviewViewModel : ObservableObject
             Cancel();
             e.Handled = true;
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/embedded-subtitles");
+        }
     }
 
     private bool InitTrack()

--- a/src/ui/Features/Video/GoToVideoPosition/GoToVideoPositionViewModel.cs
+++ b/src/ui/Features/Video/GoToVideoPosition/GoToVideoPositionViewModel.cs
@@ -7,6 +7,7 @@ using Avalonia.VisualTree;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Controls;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Video.GoToVideoPosition;
 
@@ -48,6 +49,11 @@ public partial class GoToVideoPositionViewModel : ObservableObject
         {
             e.Handled = true; // the OK button is IsDefault and would run OK again on the same Enter
             Ok();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/video-player", "go-to-video-position");
         }
     }
 

--- a/src/ui/Features/Video/OpenFromUrl/OpenFromUrlViewModel.cs
+++ b/src/ui/Features/Video/OpenFromUrl/OpenFromUrlViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Video.OpenFromUrl;
 
@@ -78,6 +79,11 @@ public partial class OpenFromUrlViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/video-player", "opening-video");
         }
     }
 }

--- a/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
+++ b/src/ui/Features/Video/OpenSecondarySubtitle/OpenSecondarySubtitleViewModel.cs
@@ -204,6 +204,11 @@ public partial class OpenSecondarySubtitleViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/video-player", "secondary-subtitles");
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/ShotChanges/ShotChangeListViewModel.cs
+++ b/src/ui/Features/Video/ShotChanges/ShotChangeListViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -97,6 +98,11 @@ public partial class ShotChangeListViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/shot-changes");
         }
     }
 

--- a/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/EngineSettings/SpeechToTextEngineSettingsViewModel.cs
@@ -15,6 +15,7 @@ using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Download;
 using Nikse.SubtitleEdit.Logic.Media;
 using Nikse.SubtitleEdit.UiLogic;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Video.SpeechToText.EngineSettings;
 
@@ -349,6 +350,11 @@ public partial class SpeechToTextEngineSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/speech-to-text", "se5-engine-notes");
         }
     }
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextAdvancedViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Video.SpeechToText.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -355,6 +356,11 @@ public partial class SpeechToTextAdvancedViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/speech-to-text", "advanced-settings");
         }
     }
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextPostProcessingViewModel.cs
@@ -49,5 +49,10 @@ public partial class SpeechToTextPostProcessingViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/speech-to-text", "post-processing-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextQualityReportViewModel.cs
@@ -381,5 +381,10 @@ public partial class SpeechToTextQualityReportViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/speech-to-text", "transcription-quality-report");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceMappingViewModel.cs
@@ -600,6 +600,11 @@ public partial class ActorVoiceMappingViewModel : ObservableObject
             e.Handled = true;
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "set-up-cast-one-voice-per-speaker");
+        }
     }
 
     internal void OnClosing(WindowClosingEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ActorVoices/ActorVoiceRowSettingsViewModel.cs
@@ -114,6 +114,11 @@ public partial class ActorVoiceRowSettingsViewModel : ObservableObject
             e.Handled = true;
             Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "set-up-cast-one-voice-per-speaker");
+        }
     }
 
     internal void OnClosing(WindowClosingEventArgs e)

--- a/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/AdvancedTtsSettings/AdvancedTtsSettingsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Threading.Tasks;
 
@@ -100,6 +101,11 @@ public partial class AdvancedTtsSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/AudioCppTtsSettings/AudioCppTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/AudioCppTtsSettings/AudioCppTtsSettingsViewModel.cs
@@ -293,5 +293,10 @@ public partial class AudioCppTtsSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/AutoCast/AutoCastSpeakersViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/AutoCast/AutoCastSpeakersViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -105,6 +106,11 @@ public partial class AutoCastSpeakersViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "find-voices-in-video-and-clone");
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ChatterboxTtsSettings/ChatterboxTtsSettingsViewModel.cs
@@ -234,5 +234,10 @@ public partial class ChatterboxTtsSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "chatterbox-tts-crispasr");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Confucius4TtsCrispAsrSettings/Confucius4TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Confucius4TtsCrispAsrSettings/Confucius4TtsCrispAsrSettingsViewModel.cs
@@ -262,5 +262,10 @@ public partial class Confucius4TtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/CosyVoice3CrispAsrSettings/CosyVoice3CrispAsrSettingsViewModel.cs
@@ -271,5 +271,10 @@ public partial class CosyVoice3CrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DetectSpeakers/DetectSpeakersViewModel.cs
@@ -8,6 +8,8 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.DetectSpeakers;
 
 public partial class DetectSpeakersViewModel : SelectLinesViewModelBase<DetectSpeakersRow>
 {
+    protected override string HelpAnchor => "find-voices-in-video-and-clone";
+
     [ObservableProperty] private bool _stickySpeakers;
 
     /// <summary>The tags the user confirmed - these names become actors and leave the spoken text.</summary>

--- a/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/DotsTtsCrispAsrSettings/DotsTtsCrispAsrSettingsViewModel.cs
@@ -265,5 +265,10 @@ public partial class DotsTtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ElevenLabsSettings/ElevenLabsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ElevenLabsSettings/ElevenLabsSettingsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.ElevenLabsSettings;
 
@@ -141,6 +142,11 @@ public partial class ElevenLabsSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "elevenlabs-pauses-and-pacing");
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/EncodingSettings/EncodingSettingsViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -70,6 +71,11 @@ public partial class EncodingSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "exporting-clips");
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/F5TtsCrispAsrSettings/F5TtsCrispAsrSettingsViewModel.cs
@@ -221,5 +221,10 @@ public partial class F5TtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTts25AudioCppSettings/IndexTts25AudioCppSettingsViewModel.cs
@@ -281,5 +281,10 @@ public partial class IndexTts25AudioCppSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/IndexTtsCrispAsrSettings/IndexTtsCrispAsrSettingsViewModel.cs
@@ -265,5 +265,10 @@ public partial class IndexTtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/KokoroTtsSettings/KokoroTtsSettingsViewModel.cs
@@ -180,5 +180,10 @@ public partial class KokoroTtsSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "kokoro-tts");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/MossTtsCrispAsrSettings/MossTtsCrispAsrSettingsViewModel.cs
@@ -248,5 +248,10 @@ public partial class MossTtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceCrispAsrSettings/OmniVoiceCrispAsrSettingsViewModel.cs
@@ -239,5 +239,10 @@ public partial class OmniVoiceCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "omnivoice-tts");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/OmniVoiceSettings/OmniVoiceSettingsViewModel.cs
@@ -264,5 +264,10 @@ public partial class OmniVoiceSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "omnivoice-tts");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/PiperSettings/PiperSettingsViewModel.cs
@@ -183,5 +183,10 @@ public partial class PiperSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/PocketTtsCrispAsrSettings/PocketTtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/PocketTtsCrispAsrSettings/PocketTtsCrispAsrSettingsViewModel.cs
@@ -270,5 +270,10 @@ public partial class PocketTtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsCrispAsrSettings/Qwen3TtsCrispAsrSettingsViewModel.cs
@@ -250,5 +250,10 @@ public partial class Qwen3TtsCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "qwen3-tts-crispasr");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/Qwen3TtsSettings/Qwen3TtsSettingsViewModel.cs
@@ -255,5 +255,10 @@ public partial class Qwen3TtsSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/ReviewSpeechHistory/ReviewSpeechHistoryViewModel.cs
@@ -192,6 +192,11 @@ public partial class ReviewSpeechHistoryViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "regeneration-history");
+        }
     }
 
     internal void Initialize(ReviewRow line)

--- a/src/ui/Features/Video/TextToSpeech/SelectLinesViewModelBase.cs
+++ b/src/ui/Features/Video/TextToSpeech/SelectLinesViewModelBase.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Logic;
 using System.Collections.ObjectModel;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech;
@@ -17,6 +18,9 @@ public abstract partial class SelectLinesViewModelBase<TRow> : ObservableObject 
 
     public Window? Window { get; set; }
     public bool OkPressed { get; private set; }
+
+    /// <summary>Section of docs/features/text-to-speech.md the help key opens for this dialog.</summary>
+    protected abstract string HelpAnchor { get; }
 
     protected SelectLinesViewModelBase()
     {
@@ -65,6 +69,11 @@ public abstract partial class SelectLinesViewModelBase<TRow> : ObservableObject 
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", HelpAnchor);
         }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLinesViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/SkipNoiseLines/SkipNoiseLinesViewModel.cs
@@ -7,6 +7,8 @@ namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.SkipNoiseLines;
 
 public class SkipNoiseLinesViewModel : SelectLinesViewModelBase<SkipNoiseLineRow>
 {
+    protected override string HelpAnchor => "skip-sound-and-music-lines";
+
     /// <summary>The lines the user confirmed should stay silent - no speech is generated for them.</summary>
     public List<Paragraph> SelectedParagraphs { get; private set; }
 

--- a/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VibeVoiceCrispAsrSettings/VibeVoiceCrispAsrSettingsViewModel.cs
@@ -256,5 +256,10 @@ public partial class VibeVoiceCrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TextToSpeech/VoiceCloneConsent/VoiceCloneConsentViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceCloneConsent/VoiceCloneConsentViewModel.cs
@@ -1,8 +1,10 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Video.TextToSpeech.Engines;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic;
 using System.Diagnostics;
 
 namespace Nikse.SubtitleEdit.Features.Video.TextToSpeech.VoiceCloneConsent;
@@ -64,6 +66,15 @@ public partial class VoiceCloneConsentViewModel : ObservableObject
         Se.SaveSettings();
         OkPressed = false;
         Window?.Close();
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "voice-cloning");
+        }
     }
 
     [RelayCommand]

--- a/src/ui/Features/Video/TextToSpeech/VoiceCloneConsent/VoiceCloneConsentWindow.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceCloneConsent/VoiceCloneConsentWindow.cs
@@ -28,6 +28,7 @@ public class VoiceCloneConsentWindow : Window
         DataContext = vm;
 
         Content = BuildContent(vm);
+        KeyDown += (_, e) => vm.OnKeyDown(e);
     }
 
     private static Border BuildContent(VoiceCloneConsentViewModel vm)

--- a/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoiceSettings/VoiceSettingsViewModel.cs
@@ -544,6 +544,11 @@ public partial class VoiceSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 
     internal void Initialize(ITtsEngine engine)

--- a/src/ui/Features/Video/TextToSpeech/VoxCPM2CrispAsrSettings/VoxCPM2CrispAsrSettingsViewModel.cs
+++ b/src/ui/Features/Video/TextToSpeech/VoxCPM2CrispAsrSettings/VoxCPM2CrispAsrSettingsViewModel.cs
@@ -230,5 +230,10 @@ public partial class VoxCPM2CrispAsrSettingsViewModel : ObservableObject
             e.Handled = true;
             Window?.Close();
         }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/text-to-speech", "engine-settings");
+        }
     }
 }

--- a/src/ui/Features/Video/TransparentSubtitles/TransparentSettingsViewModel.cs
+++ b/src/ui/Features/Video/TransparentSubtitles/TransparentSettingsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Nikse.SubtitleEdit.Features.Shared;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
+using Nikse.SubtitleEdit.Logic;
 using System.Threading.Tasks;
 
 namespace Nikse.SubtitleEdit.Features.Video.TransparentSubtitles;
@@ -84,6 +85,11 @@ public partial class TransparentSettingsViewModel : ObservableObject
         {
             e.Handled = true;
             Window?.Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/transparent-subtitles");
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #14773. F1 (or the configured help shortcut) now opens the matching docs page and section from every dialog that has one. Of 294 window classes, 89 were wired before; this adds 110. The remaining ones are pickers, prompts, download/progress and licence dialogs.

Same pattern as the existing dialogs: an `UiUtil.IsHelp(e)` branch in the window's key handler calling `UiUtil.ShowHelp("features/<page>", "<anchor>")`. Every target was checked against `docs/features/*.md`: all pages exist and every anchor matches a heading (kramdown id rules).

Structural additions beyond the one-branch pattern:
- `VoiceCloneConsentViewModel` had no key handler, so one was added and subscribed in the window.
- `SelectLinesViewModelBase` (Detect speakers, Skip noise lines) gets an abstract `HelpAnchor` so the shared handler can open the right section.

No Escape/Enter behavior changed.

## Test plan
- [x] `dotnet build src/ui/UI.csproj` - 0 errors
- [x] Script check: every `ShowHelp` page and anchor in the diff resolves to a docs heading
- [ ] Spot-check F1 in a few dialogs (chapters, export image-based, TTS engine settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
