### PR TITLE
Add Voikko (libvoikko) backend for Finnish spell checking

### DIFF
--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -27,6 +27,8 @@ public class SpellChecker : ISpellChecker, IDoSpell
     private static readonly HashSet<string> AllowedTokens = new() { "&", "—", "–", "…" };
 
     private WordList? _hunspellWeCantSpell;
+    // Finnish via libvoikko when the "fi_FI.voikko" pseudo dictionary is selected; null otherwise.
+    private VoikkoSpellChecker? _voikko;
     protected SpellCheckWordLists? WordLists;
     // Case-insensitive so per-word membership tests need no ToUpperInvariant allocation -
     // IsWordCorrect runs per word per grid cell repaint with live spell check on.
@@ -58,6 +60,18 @@ public class SpellChecker : ISpellChecker, IDoSpell
             {
                 DictionaryFileName = dic,
                 Name = name,
+            });
+        }
+
+        // Finnish via Voikko is listed as a pseudo dictionary (a marker file rather than a .dic) so
+        // every dictionary picker gets it for free. Only listed when libvoikko can actually be loaded.
+        var voikkoMarker = VoikkoSpellChecker.GetMarkerFile(dictionaryFolder);
+        if (File.Exists(voikkoMarker) && VoikkoSpellChecker.IsAvailable(dictionaryFolder))
+        {
+            list.Add(new SpellCheckDictionaryDisplay
+            {
+                DictionaryFileName = voikkoMarker,
+                Name = "Finnish (Voikko) [fi_FI]",
             });
         }
 
@@ -115,8 +129,24 @@ public class SpellChecker : ISpellChecker, IDoSpell
             return false;
         }
 
-        var affixFile = Path.ChangeExtension(dictionaryFile, ".aff");
-        _hunspellWeCantSpell = WordList.CreateFromFiles(dictionaryFile, affixFile);
+        _voikko?.Dispose();
+        _voikko = null;
+        _hunspellWeCantSpell = null;
+        if (IsVoikkoDictionary(dictionaryFile))
+        {
+            var dictionaryFolder = Path.GetDirectoryName(Path.GetDirectoryName(dictionaryFile)) ?? string.Empty;
+            _voikko = VoikkoSpellChecker.TryCreate(dictionaryFolder, out var error);
+            if (_voikko == null)
+            {
+                SpellCheckConfig.LogError("Voikko: " + error);
+                return false;
+            }
+        }
+        else
+        {
+            var affixFile = Path.ChangeExtension(dictionaryFile, ".aff");
+            _hunspellWeCantSpell = WordList.CreateFromFiles(dictionaryFile, affixFile);
+        }
 
         if (string.IsNullOrEmpty(twoLetterLanguageCode))
         {
@@ -156,6 +186,11 @@ public class SpellChecker : ISpellChecker, IDoSpell
         if (WordSpellChecker != null)
         {
             return WordSpellChecker.GetSuggestions(word);
+        }
+
+        if (_voikko != null)
+        {
+            return _voikko.Suggest(word);
         }
 
         if (_hunspellWeCantSpell == null)
@@ -273,7 +308,7 @@ public class SpellChecker : ISpellChecker, IDoSpell
                 return true;
             }
         }
-        else if (_hunspellWeCantSpell != null && _hunspellWeCantSpell.Check(word))
+        else if (CheckWithDictionary(word))
         {
             return true;
         }
@@ -377,7 +412,22 @@ public class SpellChecker : ISpellChecker, IDoSpell
             return WordSpellChecker.DoSpell(word);
         }
 
+        return CheckWithDictionary(word);
+    }
+
+    private bool CheckWithDictionary(string word)
+    {
+        if (_voikko != null)
+        {
+            return _voikko.Spell(word);
+        }
+
         return _hunspellWeCantSpell != null && _hunspellWeCantSpell.Check(word);
+    }
+
+    public static bool IsVoikkoDictionary(string dictionaryFile)
+    {
+        return dictionaryFile.EndsWith(".voikko", StringComparison.OrdinalIgnoreCase);
     }
 
     protected static bool IsPartOfHtmlOrAssaTag(SpellCheckWord spellCheckWord, string text)

--- a/src/libuilogic/SpellCheck/VoikkoSpellChecker.cs
+++ b/src/libuilogic/SpellCheck/VoikkoSpellChecker.cs
@@ -1,0 +1,284 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+/// <summary>
+/// Finnish spell checking via libvoikko (https://voikko.puimula.org). Finnish morphology (15 cases,
+/// compounding, clitics) does not fit Hunspell's affix model, so the Hunspell fi_FI dictionary is a
+/// frozen word list that flags most inflected forms. SE 4 used Voikko for Finnish for the same reason.
+///
+/// The library is loaded dynamically at runtime (never a build-time dependency): on Windows from
+/// <c>libvoikko-1.dll</c> in the Voikko folder under the dictionaries folder, elsewhere from the
+/// system-installed <c>libvoikko.so.1</c> / <c>libvoikko.dylib</c>. The dictionary is the standard
+/// "format 5" morphology (<c>5/mor-standard/mor.vfst</c>) unpacked into the same Voikko folder.
+/// </summary>
+public sealed class VoikkoSpellChecker : IDisposable
+{
+    public const string FolderName = "Voikko";
+    public const string MarkerFileName = "fi_FI.voikko";
+    public const string WindowsLibraryFileName = "libvoikko-1.dll";
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate IntPtr VoikkoInitDelegate(ref IntPtr error, byte[] languageCode, byte[] path);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void VoikkoTerminateDelegate(IntPtr handle);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int VoikkoSpellDelegate(IntPtr handle, byte[] word);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate IntPtr VoikkoSuggestDelegate(IntPtr handle, byte[] word);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void VoikkoFreeCstrArrayDelegate(IntPtr array);
+
+    private IntPtr _library;
+    private IntPtr _handle;
+    private VoikkoTerminateDelegate? _terminate;
+    private VoikkoSpellDelegate? _spell;
+    private VoikkoSuggestDelegate? _suggest;
+    private VoikkoFreeCstrArrayDelegate? _freeCstrArray;
+
+    // Voikko handles are not documented as thread-safe; live spell check paints from the UI thread
+    // while the dialog may check on another, so serialize calls.
+    private readonly object _lock = new();
+
+    public static string GetVoikkoFolder(string dictionaryFolder) => Path.Combine(dictionaryFolder, FolderName);
+
+    public static string GetMarkerFile(string dictionaryFolder) => Path.Combine(GetVoikkoFolder(dictionaryFolder), MarkerFileName);
+
+    /// <summary>The dictionary files are present (the library may still be missing).</summary>
+    public static bool HasDictionary(string dictionaryFolder)
+    {
+        return File.Exists(Path.Combine(GetVoikkoFolder(dictionaryFolder), "5", "mor-standard", "mor.vfst"));
+    }
+
+    /// <summary>True when both the dictionary and a loadable libvoikko are available.</summary>
+    public static bool IsAvailable(string dictionaryFolder)
+    {
+        if (!HasDictionary(dictionaryFolder))
+        {
+            return false;
+        }
+
+        var library = LoadLibrary(GetVoikkoFolder(dictionaryFolder));
+        if (library == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        NativeLibrary.Free(library);
+        return true;
+    }
+
+    private static IntPtr LoadLibrary(string voikkoFolder)
+    {
+        var candidates = new List<string>();
+        if (OperatingSystem.IsWindows())
+        {
+            candidates.Add(Path.Combine(voikkoFolder, WindowsLibraryFileName));
+            candidates.Add(WindowsLibraryFileName);
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            candidates.Add(Path.Combine(voikkoFolder, "libvoikko.1.dylib"));
+            candidates.Add("libvoikko.1.dylib");
+            candidates.Add("libvoikko.dylib");
+            candidates.Add("/opt/homebrew/lib/libvoikko.1.dylib");
+            candidates.Add("/usr/local/lib/libvoikko.1.dylib");
+        }
+        else
+        {
+            candidates.Add(Path.Combine(voikkoFolder, "libvoikko.so.1"));
+            candidates.Add("libvoikko.so.1");
+            candidates.Add("libvoikko.so");
+        }
+
+        foreach (var candidate in candidates)
+        {
+            try
+            {
+                if (NativeLibrary.TryLoad(candidate, out var handle) && handle != IntPtr.Zero)
+                {
+                    return handle;
+                }
+            }
+            catch
+            {
+                // try next
+            }
+        }
+
+        return IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// Loads libvoikko and initializes a Finnish handle. Returns null (never throws) when the library
+    /// or dictionary cannot be loaded; the reason is written to <paramref name="error"/>.
+    /// </summary>
+    public static VoikkoSpellChecker? TryCreate(string dictionaryFolder, out string error)
+    {
+        error = string.Empty;
+        var voikkoFolder = GetVoikkoFolder(dictionaryFolder);
+        if (!HasDictionary(dictionaryFolder))
+        {
+            error = "Voikko dictionary not found in " + voikkoFolder;
+            return null;
+        }
+
+        var library = LoadLibrary(voikkoFolder);
+        if (library == IntPtr.Zero)
+        {
+            error = "Unable to load libvoikko";
+            return null;
+        }
+
+        var checker = new VoikkoSpellChecker { _library = library };
+        try
+        {
+            var init = GetExport<VoikkoInitDelegate>(library, "voikkoInit");
+            checker._terminate = GetExport<VoikkoTerminateDelegate>(library, "voikkoTerminate");
+            checker._spell = GetExport<VoikkoSpellDelegate>(library, "voikkoSpellCstr");
+            checker._suggest = GetExport<VoikkoSuggestDelegate>(library, "voikkoSuggestCstr");
+            checker._freeCstrArray = GetExport<VoikkoFreeCstrArrayDelegate>(library, "voikkoFreeCstrArray");
+            if (init == null || checker._terminate == null || checker._spell == null || checker._suggest == null || checker._freeCstrArray == null)
+            {
+                error = "Not all required functions were found in libvoikko";
+                checker.Dispose();
+                return null;
+            }
+
+            var initError = IntPtr.Zero;
+            checker._handle = init(ref initError, ToCString("fi"), ToCString(voikkoFolder));
+            if (checker._handle == IntPtr.Zero)
+            {
+                error = initError != IntPtr.Zero ? FromCString(initError) ?? "voikkoInit failed" : "voikkoInit failed";
+                checker.Dispose();
+                return null;
+            }
+
+            return checker;
+        }
+        catch (Exception exception)
+        {
+            error = exception.Message;
+            checker.Dispose();
+            return null;
+        }
+    }
+
+    private static T? GetExport<T>(IntPtr library, string name) where T : Delegate
+    {
+        return NativeLibrary.TryGetExport(library, name, out var address) && address != IntPtr.Zero
+            ? Marshal.GetDelegateForFunctionPointer<T>(address)
+            : null;
+    }
+
+    public bool Spell(string word)
+    {
+        if (string.IsNullOrEmpty(word) || _handle == IntPtr.Zero || _spell == null)
+        {
+            return false;
+        }
+
+        lock (_lock)
+        {
+            return _spell(_handle, ToCString(word)) != 0;
+        }
+    }
+
+    public List<string> Suggest(string word)
+    {
+        var suggestions = new List<string>();
+        if (string.IsNullOrEmpty(word) || _handle == IntPtr.Zero || _suggest == null || _freeCstrArray == null)
+        {
+            return suggestions;
+        }
+
+        lock (_lock)
+        {
+            var array = _suggest(_handle, ToCString(word));
+            if (array == IntPtr.Zero)
+            {
+                return suggestions;
+            }
+
+            try
+            {
+                for (var i = 0; ; i++)
+                {
+                    var item = Marshal.ReadIntPtr(array, i * IntPtr.Size);
+                    if (item == IntPtr.Zero)
+                    {
+                        break;
+                    }
+
+                    var s = FromCString(item);
+                    if (!string.IsNullOrEmpty(s))
+                    {
+                        suggestions.Add(s);
+                    }
+                }
+            }
+            finally
+            {
+                _freeCstrArray(array);
+            }
+        }
+
+        return suggestions;
+    }
+
+    private static byte[] ToCString(string s)
+    {
+        return Encoding.UTF8.GetBytes(s + '\0');
+    }
+
+    private static string? FromCString(IntPtr ptr)
+    {
+        return ptr == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(ptr);
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            try
+            {
+                if (_handle != IntPtr.Zero && _terminate != null)
+                {
+                    _terminate(_handle);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+
+            _handle = IntPtr.Zero;
+
+            if (_library != IntPtr.Zero)
+            {
+                try
+                {
+                    NativeLibrary.Free(_library);
+                }
+                catch
+                {
+                    // ignore
+                }
+
+                _library = IntPtr.Zero;
+            }
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    ~VoikkoSpellChecker()
+    {
+        Dispose();
+    }
+}

--- a/src/ui/Assets/HunspellDictionaries.json
+++ b/src/ui/Assets/HunspellDictionaries.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "EnglishName": "Afrikaans",
     "NativeName": "Afrikaans",
@@ -255,6 +255,16 @@
       "https://github.com/fginter/hunspell-fi/releases/download/0.2/fi-spell-0.2.xpi"
     ],
     "Description": "Finnish Spellchecker Dictionary - Dec 6, 2023"
+  },
+  {
+    "EnglishName": "Finnish (Voikko)",
+    "NativeName": "Suomi (Voikko)",
+    "Files": [
+      "https://www.puimula.org/htp/testing/voikko-sdk/win-crossbuild/libvoikko-4.3+win1/win64/libvoikko-1.dll",
+      "https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip"
+    ],
+    "Voikko": true,
+    "Description": "Finnish morphological spell checker (libvoikko 4.3 + voikko-fi standard dictionary) - much better than the Hunspell word list. On Linux/macOS install libvoikko from your package manager."
   },
   {
     "EnglishName": "French",

--- a/src/ui/Assets/HunspellDictionaries.json
+++ b/src/ui/Assets/HunspellDictionaries.json
@@ -260,8 +260,8 @@
     "EnglishName": "Finnish (Voikko)",
     "NativeName": "Suomi (Voikko)",
     "Files": [
-      "https://www.puimula.org/htp/testing/voikko-sdk/win-crossbuild/libvoikko-4.3+win1/win64/libvoikko-1.dll",
-      "https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip"
+      "https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/libvoikko-1.dll",
+      "https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/dict.zip"
     ],
     "Voikko": true,
     "Description": "Finnish morphological spell checker (libvoikko 4.3 + voikko-fi standard dictionary) - much better than the Hunspell word list. On Linux/macOS install libvoikko from your package manager."

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetDictionariesViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Platform;
 using Avalonia.Threading;
@@ -190,6 +190,12 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
             Directory.CreateDirectory(folder);
         }
 
+        if (dictionary.Voikko)
+        {
+            await DownloadVoikkoAsync(dictionary, progress, cancellationToken);
+            return;
+        }
+
         var dicFiles = new List<string>();
 
         for (var i = 0; i < files.Count; i++)
@@ -244,6 +250,60 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
                 Name = dictionary.EnglishName,
                 DictionaryFileName = largestDicFile,
             };
+    }
+
+    /// <summary>
+    /// Installs a Voikko package into the Voikko sub folder: the Windows DLL is saved as-is (and
+    /// skipped on other platforms, where the system libvoikko is used), the dictionary zip is
+    /// unpacked with its folder structure ("5/mor-standard/..."), and a marker file is written so the
+    /// dictionary pickers list "Finnish (Voikko)".
+    /// </summary>
+    private async Task DownloadVoikkoAsync(GetSpellCheckDictionaryDisplay dictionary, IProgress<float> progress, CancellationToken cancellationToken)
+    {
+        var voikkoFolder = VoikkoSpellChecker.GetVoikkoFolder(Se.DictionariesFolder);
+        if (!Directory.Exists(voikkoFolder))
+        {
+            Directory.CreateDirectory(voikkoFolder);
+        }
+
+        var files = dictionary.Files
+            .Where(url => OperatingSystem.IsWindows() || !RemoveUrlQuery(url).EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        for (var i = 0; i < files.Count; i++)
+        {
+            var url = files[i];
+            var fileIndex = i;
+            var fileProgress = new Progress<float>(p => progress.Report((fileIndex + p) / files.Count));
+
+            using var stream = new MemoryStream();
+            await _spellCheckDictionaryDownloadService.DownloadDictionary(stream, url, fileProgress, cancellationToken);
+            if (stream.Length == 0)
+            {
+                throw new InvalidOperationException($"Dictionary download failed: {url}");
+            }
+
+            stream.Position = 0;
+            if (RemoveUrlQuery(url).EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                _zipUnpacker.UnpackZipStream(stream, voikkoFolder);
+            }
+            else
+            {
+                var targetFileName = Path.Combine(voikkoFolder, GetFileNameFromUrl(url));
+                await using var fileStream = File.Create(targetFileName);
+                await stream.CopyToAsync(fileStream, cancellationToken);
+            }
+        }
+
+        var marker = VoikkoSpellChecker.GetMarkerFile(Se.DictionariesFolder);
+        await File.WriteAllTextAsync(marker, "Finnish spell check via libvoikko - see the Voikko folder", cancellationToken);
+
+        SpellCheckDictionary = new SpellCheckDictionaryDisplay
+        {
+            Name = dictionary.EnglishName,
+            DictionaryFileName = marker,
+        };
     }
 
     private static bool IsHunspellFile(string url)
@@ -366,6 +426,11 @@ public partial class GetDictionariesViewModel : ObservableObject, IClosingCleanu
 
     private static bool IsEntryInstalled(GetSpellCheckDictionaryDisplay entry, List<string> installedDicFiles)
     {
+        if (entry.Voikko)
+        {
+            return VoikkoSpellChecker.HasDictionary(Se.DictionariesFolder);
+        }
+
         var dicNames = entry.Files
             .Select(GetFileNameFromUrl)
             .Where(name => name.EndsWith(".dic", StringComparison.OrdinalIgnoreCase))

--- a/src/ui/Features/SpellCheck/GetDictionaries/GetSpellCheckDictionaryDisplay.cs
+++ b/src/ui/Features/SpellCheck/GetDictionaries/GetSpellCheckDictionaryDisplay.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
@@ -17,6 +17,12 @@ public partial class GetSpellCheckDictionaryDisplay : ObservableObject
     /// .aff and .dic link, while a legacy entry has a single .oxt/.zip/.xpi archive link.
     /// </summary>
     public List<string> Files { get; set; }
+
+    /// <summary>
+    /// A libvoikko package (Finnish): a native library plus a "format 5" dictionary zip, installed
+    /// into the Voikko sub folder instead of as .dic/.aff files.
+    /// </summary>
+    public bool Voikko { get; set; }
 
     public bool UseShortName { get; set; }
 

--- a/tests/libuilogic/SpellCheck/VoikkoSpellCheckerTests.cs
+++ b/tests/libuilogic/SpellCheck/VoikkoSpellCheckerTests.cs
@@ -1,0 +1,66 @@
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace LibUiLogicTests.SpellCheck;
+
+public class VoikkoSpellCheckerTests
+{
+    [Fact]
+    public void IsVoikkoDictionary_MatchesMarkerOnly()
+    {
+        Assert.True(SpellChecker.IsVoikkoDictionary(@"C:\x\Dictionaries\Voikko\fi_FI.voikko"));
+        Assert.False(SpellChecker.IsVoikkoDictionary(@"C:\x\Dictionaries\fi_FI.dic"));
+    }
+
+    [Fact]
+    public void MissingDictionary_IsNotAvailable()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-voikko-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        try
+        {
+            Assert.False(VoikkoSpellChecker.HasDictionary(folder));
+            Assert.False(VoikkoSpellChecker.IsAvailable(folder));
+            Assert.Null(VoikkoSpellChecker.TryCreate(folder, out var error));
+            Assert.False(string.IsNullOrEmpty(error));
+            Assert.False(new SpellChecker().Initialize(VoikkoSpellChecker.GetMarkerFile(folder), "fi"));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    /// <summary>
+    /// Runs only when a libvoikko + dictionary is installed in the SE_VOIKKO_DICTIONARIES folder
+    /// (the SE dictionaries folder); exercises the real native library end to end.
+    /// </summary>
+    [Fact]
+    public void RealVoikko_SpellsInflectedFinnish()
+    {
+        var folder = Environment.GetEnvironmentVariable("SE_VOIKKO_DICTIONARIES");
+        if (string.IsNullOrEmpty(folder) || !VoikkoSpellChecker.IsAvailable(folder))
+        {
+            return; // libvoikko not available
+        }
+
+        var checker = new SpellChecker();
+        Assert.True(checker.Initialize(VoikkoSpellChecker.GetMarkerFile(folder), "fi"));
+
+        // Inflected / compound forms the Hunspell word list typically lacks.
+        Assert.True(checker.DoSpell("taloissammekin"));
+        Assert.True(checker.DoSpell("lentokonesuihkuturbiinimoottori"));
+        Assert.True(checker.IsWordCorrect("kirjoitin"));
+        Assert.False(checker.DoSpell("talossx"));
+
+        var suggestions = checker.GetSuggestions("talosa");
+        Assert.True(suggestions.Count > 0, "no suggestions");
+        Assert.True(suggestions.Contains("talossa"), string.Join(", ", suggestions));
+
+        var languages = checker.GetDictionaryLanguages(folder);
+        Assert.True(languages.Any(l => l.Name.Contains("Voikko")), "Voikko not listed");
+        var voikko = languages.First(l => l.Name.Contains("Voikko"));
+        Assert.Equal("fi", SpellCheckDictionaryDisplay.GetTwoLetterLanguageCode(voikko));
+        Assert.Equal("fin", voikko.GetThreeLetterCode());
+        Assert.Equal("fi_FI", voikko.GetFiveLetterLanguageName());
+    }
+}


### PR DESCRIPTION
## Summary

Finnish morphology (15 cases, compounding, clitics) does not fit Hunspell's affix model, so the `fi_FI` Hunspell dictionary SE 5 downloads is a frozen word list that flags most inflected and compound forms. SE 4 special-cased Finnish to libvoikko for the same reason; this brings that back.

- **`VoikkoSpellChecker`** (libuilogic): loads libvoikko dynamically at runtime, never a build-time dependency. On Windows from `Dictionaries/Voikko/libvoikko-1.dll`, on Linux/macOS from the system-installed library (`libvoikko.so.1` / Homebrew `libvoikko.1.dylib`). Uses the standard "format 5" dictionary (`Voikko/5/mor-standard/mor.vfst`).
- **`SpellChecker`**: lists "Finnish (Voikko) [fi_FI]" via a `fi_FI.voikko` marker file when both library and dictionary load, so every dictionary picker (spell check, OCR, fix common OCR errors, live spell check, seconv) gets it without changes. Check and suggest route through Voikko when it is selected; the two-/three-/five-letter language code helpers resolve the marker like a normal `fi_FI` dictionary.
- **Get dictionaries**: new "Finnish (Voikko)" entry that downloads the libvoikko 4.3 win64 DLL and the voikko-fi standard dictionary zip from puimula.org into the Voikko folder. The DLL is skipped on non-Windows.

## Test plan

- [x] libuilogic tests: marker detection, missing-dictionary paths, and an end-to-end test against a real libvoikko (Homebrew on macOS): inflected forms (`taloissammekin`), a long compound, suggestions for `talosa` include `talossa`, dictionary listing and language codes.
- [x] Full libuilogic suite (861 tests) passes.
- [ ] Windows: Get dictionaries → "Finnish (Voikko)" → download, then pick "Finnish (Voikko)" in spell check. Not verified here (macOS session).

## Notes

- The win64 DLL is x86-64 only; on Windows ARM64 it fails to load and the entry simply is not listed.
- Downloads are mirrored at support-files release `voikko-4.3-fi-2024-06` (upstream: puimula.org libvoikko 4.3+win1 win64 and voikko-snapshot-v5 dict.zip).
- Linux/macOS packaging (Flatpak bundling, bundled dylib with signing) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)