### PR TITLE
Bundle libvoikko for Finnish spell check in Flatpak and macOS builds

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -532,6 +532,8 @@ jobs:
             arch_label: ARM64
             runtime: osx-arm64
             ffmpeg_url: https://www.osxexperts.net/ffmpeg81arm.zip
+            voikko_url: https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/libvoikko-4.3.3-macos-arm64.zip
+            voikko_sha256: 21a131d6a972890384c7900f2aace608a6c8baa14da8c63863ee7433def9bb2b
             ffmpeg_sha256: ebb82529562b71170807bbc6b0e7eb4f0b13af8cbb0e085bb9e8f6fe709598ad
             dmg_format: UDBZ
             expected_arch: arm64
@@ -539,6 +541,8 @@ jobs:
             arch_label: x64
             runtime: osx-x64
             ffmpeg_url: https://www.osxexperts.net/ffmpeg80intel.zip
+            voikko_url: https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/libvoikko-4.3.3-macos-x64.zip
+            voikko_sha256: fbd458122536708192a4f56f98f34d28a399547e628ce17d14d4cc6534b7a62b
             ffmpeg_sha256: 2d24d22db78c87f394a5822867acd5c5dc5e762cd261a44bd26923f3a5af3e07
             dmg_format: UDZO
             expected_arch: x86_64
@@ -628,6 +632,29 @@ jobs:
           }
           echo "Extracted $(ls libmpv-temp | wc -l) dylibs ($(du -sh libmpv-temp | cut -f1))"
 
+      # libvoikko for Finnish spell check: self-contained build of libvoikko 4.3.3 (no HFST,
+      # links only libc++/libSystem, install name @rpath/libvoikko.1.dylib) plus the voikko-fi
+      # "format 5" dictionary. The dylib joins the Frameworks payload (signed with the rest),
+      # the dictionary goes to Contents/Resources/voikko where VoikkoSpellChecker probes.
+      - name: Download + verify libvoikko + voikko-fi dictionary (${{ matrix.arch }})
+        run: |
+          set -e
+          curl -fL -o libvoikko.zip "${{ matrix.voikko_url }}"
+          echo "${{ matrix.voikko_sha256 }}  libvoikko.zip" | shasum -a 256 -c -
+          unzip -o libvoikko.zip -d libmpv-temp
+          rm libvoikko.zip
+          archs=$(lipo -archs libmpv-temp/libvoikko.1.dylib)
+          if [ "$archs" != "${{ matrix.expected_arch }}" ]; then
+            echo "ERROR: libvoikko archs are '$archs', expected exactly '${{ matrix.expected_arch }}'"
+            exit 1
+          fi
+          curl -fL -o voikko-dict.zip "https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/dict.zip"
+          echo "98f26bb67e08288910fbf1aa92521f28bee79538ba86aefa267713333e7fa537  voikko-dict.zip" | shasum -a 256 -c -
+          mkdir -p voikko-dict-temp
+          unzip -o voikko-dict.zip -d voikko-dict-temp
+          rm voikko-dict.zip
+          [ -f voikko-dict-temp/5/mor-standard/mor.vfst ] || { echo "ERROR: voikko dictionary layout changed"; exit 1; }
+
       - name: Setup code signing (if certificates available)
         run: |
           if [ -n "${{ secrets.MACOS_CERTIFICATE }}" ] && [ -n "${{ secrets.APPLE_ID_USER }}" ]; then
@@ -697,6 +724,10 @@ jobs:
           cp "./libmpv-temp/"*.dylib "$app/Contents/Frameworks/"
           chmod -R 755 "$app/Contents/Frameworks/"
           rm -rf "./libmpv-temp"
+
+          mkdir -p "$app/Contents/Resources/voikko"
+          cp -R "./voikko-dict-temp/5" "$app/Contents/Resources/voikko/"
+          rm -rf "./voikko-dict-temp"
 
           # Point the SE executable at the bundled Frameworks for @rpath resolution.
           # The dylibs themselves already use @rpath/* internally (IINA's CI fixed

--- a/installer/flatpak/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/dk.nikse.subtitleedit.yaml
@@ -398,6 +398,40 @@ modules:
         url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
         sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
 
+  # --- libvoikko + voikko-fi (Finnish spell check) ---
+  #
+  # Finnish morphology does not fit Hunspell's affix model, so SE checks Finnish through
+  # libvoikko (SE 4 did the same). The app loads libvoikko.so.1 at runtime from the sandbox
+  # library path and finds the "format 5" dictionary in /app/share/voikko (both are also
+  # probed explicitly by VoikkoSpellChecker). HFST/VISL CG-3 backends are off: the Finnish
+  # dictionary is VFST and the extra backends pull in libraries the runtime does not have.
+  - name: libvoikko
+    config-opts:
+      - --disable-hfst
+      - --disable-buildtools
+      - --disable-testtools
+      - --with-dictionary-path=/app/share/voikko
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/libvoikko-4.3.3.tar.gz
+        sha256: d1162965c61de44f72162fd87ec1394bd4f90f87bc8152d13fe4ae692fdc73fa
+
+  # voikko-fi standard dictionary (Joukahainen snapshot 2024-06-18, dictionary format 5),
+  # mirrored from https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip
+  - name: voikko-fi-dict
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/voikko
+      - cp -r 5 /app/share/voikko/
+    sources:
+      - type: archive
+        url: https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/dict.zip
+        sha256: 98f26bb67e08288910fbf1aa92521f28bee79538ba86aefa267713333e7fa537
+        strip-components: 0
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit

--- a/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
+++ b/installer/flatpak/flathub/dk.nikse.subtitleedit.yaml
@@ -398,6 +398,40 @@ modules:
         url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
         sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
 
+  # --- libvoikko + voikko-fi (Finnish spell check) ---
+  #
+  # Finnish morphology does not fit Hunspell's affix model, so SE checks Finnish through
+  # libvoikko (SE 4 did the same). The app loads libvoikko.so.1 at runtime from the sandbox
+  # library path and finds the "format 5" dictionary in /app/share/voikko (both are also
+  # probed explicitly by VoikkoSpellChecker). HFST/VISL CG-3 backends are off: the Finnish
+  # dictionary is VFST and the extra backends pull in libraries the runtime does not have.
+  - name: libvoikko
+    config-opts:
+      - --disable-hfst
+      - --disable-buildtools
+      - --disable-testtools
+      - --with-dictionary-path=/app/share/voikko
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/libvoikko-4.3.3.tar.gz
+        sha256: d1162965c61de44f72162fd87ec1394bd4f90f87bc8152d13fe4ae692fdc73fa
+
+  # voikko-fi standard dictionary (Joukahainen snapshot 2024-06-18, dictionary format 5),
+  # mirrored from https://www.puimula.org/htp/testing/voikko-snapshot-v5/dict.zip
+  - name: voikko-fi-dict
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/voikko
+      - cp -r 5 /app/share/voikko/
+    sources:
+      - type: archive
+        url: https://github.com/SubtitleEdit/support-files/releases/download/voikko-4.3-fi-2024-06/dict.zip
+        sha256: 98f26bb67e08288910fbf1aa92521f28bee79538ba86aefa267713333e7fa537
+        strip-components: 0
+
   # --- SubtitleEdit application ---
 
   - name: subtitleedit

--- a/installer/macBundle/THIRD_PARTY_LICENSES.txt
+++ b/installer/macBundle/THIRD_PARTY_LICENSES.txt
@@ -153,11 +153,27 @@ The bundled dylibs and their upstream projects / licenses:
 
 
 --------------------------------------------------------------------------------
+3. libvoikko + voikko-fi (Contents/Frameworks/libvoikko.1.dylib, Contents/Resources/voikko)
+--------------------------------------------------------------------------------
+
+Project:        libvoikko 4.3.3       https://voikko.puimula.org/
+License:        GPL-2.0-or-later (see LICENSE.CORE in the source tarball)
+Copyright:      (C) Harri Pitkänen and contributors
+
+Project:        voikko-fi (Suomi-malaga / Joukahainen) standard dictionary,
+                dictionary format 5, snapshot 2024-06-18
+License:        GPL-2.0-or-later
+Copyright:      (C) Hannu Väisänen, Harri Pitkänen and contributors
+
+Built by Subtitle Edit without the HFST and VISL CG-3 backends so the library
+links only libc++ and libSystem. Used for Finnish spell checking.
+
+--------------------------------------------------------------------------------
 Source code availability (GPL components)
 --------------------------------------------------------------------------------
 
 For the GPL-licensed components above (FFmpeg, x264, x265, librubberband,
-libdvdread/libdvdnav, libvidstab), the corresponding source code is available
+libdvdread/libdvdnav, libvidstab, libvoikko, voikko-fi), the corresponding source code is available
 from each project's upstream website linked in the section above. Subtitle
 Edit does not modify these binaries.
 

--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -63,14 +63,14 @@ public class SpellChecker : ISpellChecker, IDoSpell
             });
         }
 
-        // Finnish via Voikko is listed as a pseudo dictionary (a marker file rather than a .dic) so
-        // every dictionary picker gets it for free. Only listed when libvoikko can actually be loaded.
-        var voikkoMarker = VoikkoSpellChecker.GetMarkerFile(dictionaryFolder);
-        if (File.Exists(voikkoMarker) && VoikkoSpellChecker.IsAvailable(dictionaryFolder))
+        // Finnish via Voikko is listed as a pseudo dictionary (a marker path rather than a .dic) so
+        // every dictionary picker gets it for free. Only listed when libvoikko and a dictionary can
+        // actually be loaded - from the user's Voikko folder, the app bundle, or the system.
+        if (VoikkoSpellChecker.IsAvailable(dictionaryFolder))
         {
             list.Add(new SpellCheckDictionaryDisplay
             {
-                DictionaryFileName = voikkoMarker,
+                DictionaryFileName = VoikkoSpellChecker.GetMarkerFile(dictionaryFolder),
                 Name = "Finnish (Voikko) [fi_FI]",
             });
         }
@@ -124,7 +124,8 @@ public class SpellChecker : ISpellChecker, IDoSpell
         SkipAllList.Clear();
         _twoLetterLanguageCode = twoLetterLanguageCode ?? string.Empty;
 
-        if (!File.Exists(dictionaryFile))
+        // The Voikko marker path need not exist (bundled / system dictionary); TryCreate validates.
+        if (!IsVoikkoDictionary(dictionaryFile) && !File.Exists(dictionaryFile))
         {
             return false;
         }

--- a/src/libuilogic/SpellCheck/VoikkoSpellChecker.cs
+++ b/src/libuilogic/SpellCheck/VoikkoSpellChecker.cs
@@ -8,10 +8,13 @@ namespace Nikse.SubtitleEdit.UiLogic.SpellCheck;
 /// compounding, clitics) does not fit Hunspell's affix model, so the Hunspell fi_FI dictionary is a
 /// frozen word list that flags most inflected forms. SE 4 used Voikko for Finnish for the same reason.
 ///
-/// The library is loaded dynamically at runtime (never a build-time dependency): on Windows from
-/// <c>libvoikko-1.dll</c> in the Voikko folder under the dictionaries folder, elsewhere from the
-/// system-installed <c>libvoikko.so.1</c> / <c>libvoikko.dylib</c>. The dictionary is the standard
-/// "format 5" morphology (<c>5/mor-standard/mor.vfst</c>) unpacked into the same Voikko folder.
+/// The library is loaded dynamically at runtime (never a build-time dependency). Probe order: the
+/// Voikko folder under the dictionaries folder (what "Get dictionaries" installs on Windows), the
+/// application folder (the macOS bundle ships <c>libvoikko.1.dylib</c> in Contents/Frameworks), then
+/// the system library (<c>libvoikko.so.1</c> in the Flatpak's /app/lib or a distro package, Homebrew
+/// on macOS). The dictionary is the standard "format 5" morphology (<c>5/mor-standard/mor.vfst</c>),
+/// looked up in the same order: user Voikko folder, bundled copy (macOS Contents/Resources/voikko,
+/// Flatpak /app/share/voikko), then the usual system locations.
 /// </summary>
 public sealed class VoikkoSpellChecker : IDisposable
 {
@@ -52,7 +55,56 @@ public sealed class VoikkoSpellChecker : IDisposable
     /// <summary>The dictionary files are present (the library may still be missing).</summary>
     public static bool HasDictionary(string dictionaryFolder)
     {
-        return File.Exists(Path.Combine(GetVoikkoFolder(dictionaryFolder), "5", "mor-standard", "mor.vfst"));
+        return FindDictionaryRoot(dictionaryFolder) != null;
+    }
+
+    private static bool IsDictionaryRoot(string folder)
+    {
+        return File.Exists(Path.Combine(folder, "5", "mor-standard", "mor.vfst"));
+    }
+
+    /// <summary>
+    /// The folder to hand to voikkoInit (the one containing "5/mor-standard"): the user's Voikko
+    /// folder first, then a copy bundled with the app, then the system locations.
+    /// </summary>
+    public static string? FindDictionaryRoot(string dictionaryFolder)
+    {
+        foreach (var candidate in GetDictionaryRootCandidates(dictionaryFolder))
+        {
+            try
+            {
+                if (IsDictionaryRoot(candidate))
+                {
+                    return candidate;
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> GetDictionaryRootCandidates(string dictionaryFolder)
+    {
+        yield return GetVoikkoFolder(dictionaryFolder);
+
+        var appFolder = AppContext.BaseDirectory;
+        yield return Path.Combine(appFolder, "voikko");
+        if (OperatingSystem.IsMacOS())
+        {
+            yield return Path.GetFullPath(Path.Combine(appFolder, "..", "Resources", "voikko"));
+            yield return "/opt/homebrew/share/voikko";
+            yield return "/usr/local/share/voikko";
+        }
+        else if (!OperatingSystem.IsWindows())
+        {
+            yield return "/app/share/voikko";
+            yield return "/usr/share/voikko";
+            yield return "/usr/lib/voikko";
+        }
     }
 
     /// <summary>True when both the dictionary and a loadable libvoikko are available.</summary>
@@ -76,14 +128,18 @@ public sealed class VoikkoSpellChecker : IDisposable
     private static IntPtr LoadLibrary(string voikkoFolder)
     {
         var candidates = new List<string>();
+        var appFolder = AppContext.BaseDirectory;
         if (OperatingSystem.IsWindows())
         {
             candidates.Add(Path.Combine(voikkoFolder, WindowsLibraryFileName));
+            candidates.Add(Path.Combine(appFolder, WindowsLibraryFileName));
             candidates.Add(WindowsLibraryFileName);
         }
         else if (OperatingSystem.IsMacOS())
         {
             candidates.Add(Path.Combine(voikkoFolder, "libvoikko.1.dylib"));
+            candidates.Add(Path.Combine(appFolder, "libvoikko.1.dylib"));
+            candidates.Add(Path.GetFullPath(Path.Combine(appFolder, "..", "Frameworks", "libvoikko.1.dylib")));
             candidates.Add("libvoikko.1.dylib");
             candidates.Add("libvoikko.dylib");
             candidates.Add("/opt/homebrew/lib/libvoikko.1.dylib");
@@ -92,6 +148,7 @@ public sealed class VoikkoSpellChecker : IDisposable
         else
         {
             candidates.Add(Path.Combine(voikkoFolder, "libvoikko.so.1"));
+            candidates.Add(Path.Combine(appFolder, "libvoikko.so.1"));
             candidates.Add("libvoikko.so.1");
             candidates.Add("libvoikko.so");
         }
@@ -122,7 +179,8 @@ public sealed class VoikkoSpellChecker : IDisposable
     {
         error = string.Empty;
         var voikkoFolder = GetVoikkoFolder(dictionaryFolder);
-        if (!HasDictionary(dictionaryFolder))
+        var dictionaryRoot = FindDictionaryRoot(dictionaryFolder);
+        if (dictionaryRoot == null)
         {
             error = "Voikko dictionary not found in " + voikkoFolder;
             return null;
@@ -151,7 +209,7 @@ public sealed class VoikkoSpellChecker : IDisposable
             }
 
             var initError = IntPtr.Zero;
-            checker._handle = init(ref initError, ToCString("fi"), ToCString(voikkoFolder));
+            checker._handle = init(ref initError, ToCString("fi"), ToCString(dictionaryRoot));
             if (checker._handle == IntPtr.Zero)
             {
                 error = initError != IntPtr.Zero ? FromCString(initError) ?? "voikkoInit failed" : "voikkoInit failed";

--- a/tests/libuilogic/SpellCheck/VoikkoSpellCheckerTests.cs
+++ b/tests/libuilogic/SpellCheck/VoikkoSpellCheckerTests.cs
@@ -30,6 +30,34 @@ public class VoikkoSpellCheckerTests
         }
     }
 
+    [Fact]
+    public void BundledDictionary_NextToApp_IsFoundWhenUserFolderHasNone()
+    {
+        // The macOS bundle / Flatpak ship the dictionary outside the user's dictionaries folder;
+        // the app folder is one of the probed roots.
+        var userFolder = Path.Combine(Path.GetTempPath(), "se-voikko-" + Guid.NewGuid().ToString("N"));
+        var bundled = Path.Combine(AppContext.BaseDirectory, "voikko", "5", "mor-standard");
+        Directory.CreateDirectory(userFolder);
+        Directory.CreateDirectory(bundled);
+        try
+        {
+            File.WriteAllText(Path.Combine(bundled, "mor.vfst"), "x");
+            Assert.True(VoikkoSpellChecker.HasDictionary(userFolder));
+            Assert.Equal(Path.Combine(AppContext.BaseDirectory, "voikko"), VoikkoSpellChecker.FindDictionaryRoot(userFolder));
+
+            // The user's own copy wins over the bundled one.
+            var user = Path.Combine(VoikkoSpellChecker.GetVoikkoFolder(userFolder), "5", "mor-standard");
+            Directory.CreateDirectory(user);
+            File.WriteAllText(Path.Combine(user, "mor.vfst"), "x");
+            Assert.Equal(VoikkoSpellChecker.GetVoikkoFolder(userFolder), VoikkoSpellChecker.FindDictionaryRoot(userFolder));
+        }
+        finally
+        {
+            Directory.Delete(userFolder, true);
+            Directory.Delete(Path.Combine(AppContext.BaseDirectory, "voikko"), true);
+        }
+    }
+
     /// <summary>
     /// Runs only when a libvoikko + dictionary is installed in the SE_VOIKKO_DICTIONARIES folder
     /// (the SE dictionaries folder); exercises the real native library end to end.


### PR DESCRIPTION
## Summary

Follow-up to #14784. Finnish (Voikko) now works out of the box in the Flatpak and in the signed macOS DMGs, without a "Get dictionaries" download.

- **Flatpak** (both manifest copies): a `libvoikko` autotools module (4.3.3, `--disable-hfst`, dictionary path `/app/share/voikko`) and a `voikko-fi-dict` module that installs the standard "format 5" dictionary. Sources are the mirrored files on the `voikko-4.3-fi-2024-06` support-files release, SHA-256 pinned.
- **macOS**: the workflow downloads a self-contained `libvoikko.1.dylib` per arch (built from the 4.3.3 tarball with `--disable-hfst`, links only libc++/libSystem, install name `@rpath/libvoikko.1.dylib`, arch-checked with `lipo`) into the Frameworks payload, so it is signed with hardened runtime alongside the other dylibs. The dictionary goes to `Contents/Resources/voikko`. GPL entries added to `THIRD_PARTY_LICENSES.txt`.
- **`VoikkoSpellChecker`**: probes the app folder / bundle (`Contents/Frameworks`, `Contents/Resources/voikko`, `/app/lib`, `/app/share/voikko`) and the usual system locations for both library and dictionary, after the user's own Voikko folder. The Voikko marker path no longer has to exist for `Initialize`.

## Test plan

- [x] libuilogic tests (862) pass, including a new test for the bundled-dictionary probe order and the end-to-end test against the self-built arm64 dylib + dictionary.
- [x] Both dylibs verified: single-arch, `@rpath` install name, no Homebrew dependencies.
- [x] Manifest and workflow YAML parse; the libvoikko tarball builds with a plain top-level `make`.
- [ ] Flatpak build in CI (`build-flatpak.yml`) - not runnable on this Mac.
- [ ] Launch the built macOS DMG and pick "Finnish (Voikko)" in spell check - CI never launches the app, so this needs a manual check on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)