### PR TITLE
Add engine settings/info dialog for every video OCR engine

### DIFF
--- a/src/ui/DependencyInjectionExtensions.cs
+++ b/src/ui/DependencyInjectionExtensions.cs
@@ -491,6 +491,7 @@ public static class DependencyInjectionExtensions
         collection.AddTransient<NOcrSettingsViewModel>();
         collection.AddTransient<NOcrTrainViewModel>();
         collection.AddTransient<LlamaCppOcrSettingsViewModel>();
+        collection.AddTransient<Features.Video.VideoOcr.EngineSettings.VideoOcrEngineSettingsViewModel>();
         collection.AddTransient<Features.Ocr.CrispEmbedSettings.CrispEmbedSettingsViewModel>();
         collection.AddTransient<LlamaCppEngineSettingsViewModel>();
         collection.AddTransient<Features.Translate.LlamaCppAdvanced.LlamaCppAdvancedSettingsViewModel>();

--- a/src/ui/Features/Ocr/Download/PaddleOcrInstallHelper.cs
+++ b/src/ui/Features/Ocr/Download/PaddleOcrInstallHelper.cs
@@ -42,83 +42,15 @@ public static class PaddleOcrInstallHelper
     /// </summary>
     public static async Task<bool> EnsureInstalled(Window window, IWindowService windowService, OcrEngineType engineType)
     {
-        if (engineType == OcrEngineType.PaddleOcrStandalone)
+        // Only Windows and Linux have a standalone build; on macOS there is nothing to fetch and
+        // the engine check is skipped as before.
+        if (engineType == OcrEngineType.PaddleOcrStandalone
+            && (Configuration.IsRunningOnWindows || Configuration.IsRunningOnLinux)
+            && !IsStandaloneEngineInstalled())
         {
-            if (Configuration.IsRunningOnWindows && !File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe")))
+            if (!await DownloadEngineAsync(window, windowService))
             {
-                var answer = await MessageBox.Show(
-                    window,
-                    "Download Paddle OCR?",
-                    $"{Environment.NewLine}\"Paddle OCR\" requires downloading Paddle OCR.{Environment.NewLine}{Environment.NewLine}Download and use Paddle OCR?",
-                    MessageBoxButtons.Cancel,
-                    MessageBoxIcon.Question,
-                    "CPU",
-                    "GPU CUDA 11",
-                    "GPU CUDA 12");
-
-                if (answer == MessageBoxResult.Cancel)
-                {
-                    return false;
-                }
-
-                var result = await windowService.ShowDialogAsync<DownloadPaddleOcrWindow, DownloadPaddleOcrViewModel>(window,
-                    vm =>
-                    {
-                        var engine = PaddleOcrDownloadType.EngineCpu;
-                        if (answer == MessageBoxResult.Custom2)
-                        {
-                            engine = PaddleOcrDownloadType.EngineGpu11;
-                        }
-                        else if (answer == MessageBoxResult.Custom3)
-                        {
-                            engine = PaddleOcrDownloadType.EngineGpu12;
-                        }
-
-                        vm.Initialize(engine);
-                    });
-
-                if (!result.OkPressed)
-                {
-                    return false;
-                }
-            }
-            else if (Configuration.IsRunningOnLinux && !File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin")))
-            {
-                var answer = await MessageBox.Show(
-                    window,
-                    "Download Paddle OCR?",
-                    $"{Environment.NewLine}\"Paddle OCR\" requires downloading Paddle OCR.{Environment.NewLine}{Environment.NewLine}Download and use Paddle OCR?",
-                    MessageBoxButtons.Cancel,
-                    MessageBoxIcon.Question,
-                    "CPU",
-                    "GPU CUDA 11",
-                    "GPU CUDA 12");
-
-                if (answer == MessageBoxResult.Cancel)
-                {
-                    return false;
-                }
-
-                var result = await windowService.ShowDialogAsync<DownloadPaddleOcrWindow, DownloadPaddleOcrViewModel>(window,
-                    vm =>
-                    {
-                        var engine = PaddleOcrDownloadType.EngineCpuLinux;
-                        if (answer == MessageBoxResult.Custom2)
-                        {
-                            engine = PaddleOcrDownloadType.EngineGpu11Linux;
-                        }
-                        else if (answer == MessageBoxResult.Custom3)
-                        {
-                            engine = PaddleOcrDownloadType.EngineGpu12Linux;
-                        }
-
-                        vm.Initialize(engine);
-                    });
-
-                if (!result.OkPressed)
-                {
-                    return false;
-                }
+                return false;
             }
         }
 
@@ -134,5 +66,71 @@ public static class PaddleOcrInstallHelper
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// True when the standalone engine binary is on disk (models are checked separately).
+    /// Always false on macOS, where there is no standalone build.
+    /// </summary>
+    public static bool IsStandaloneEngineInstalled()
+    {
+        if (Configuration.IsRunningOnWindows)
+        {
+            return File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.exe"));
+        }
+
+        if (Configuration.IsRunningOnLinux)
+        {
+            return File.Exists(Path.Combine(Se.PaddleOcrFolder, "paddleocr.bin"));
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Asks CPU / CUDA 11 / CUDA 12 and downloads the standalone engine, whether or not one is
+    /// already installed - the engine settings dialog uses it to re-download or switch build.
+    /// Returns false if the user cancelled.
+    /// </summary>
+    public static async Task<bool> DownloadEngineAsync(Window window, IWindowService windowService)
+    {
+        if (!Configuration.IsRunningOnWindows && !Configuration.IsRunningOnLinux)
+        {
+            return false;
+        }
+
+        var answer = await MessageBox.Show(
+            window,
+            "Download Paddle OCR?",
+            $"{Environment.NewLine}\"Paddle OCR\" requires downloading Paddle OCR.{Environment.NewLine}{Environment.NewLine}Download and use Paddle OCR?",
+            MessageBoxButtons.Cancel,
+            MessageBoxIcon.Question,
+            "CPU",
+            "GPU CUDA 11",
+            "GPU CUDA 12");
+
+        if (answer == MessageBoxResult.Cancel)
+        {
+            return false;
+        }
+
+        var result = await windowService.ShowDialogAsync<DownloadPaddleOcrWindow, DownloadPaddleOcrViewModel>(window,
+            vm =>
+            {
+                var isLinux = Configuration.IsRunningOnLinux;
+                var engine = isLinux ? PaddleOcrDownloadType.EngineCpuLinux : PaddleOcrDownloadType.EngineCpu;
+                if (answer == MessageBoxResult.Custom2)
+                {
+                    engine = isLinux ? PaddleOcrDownloadType.EngineGpu11Linux : PaddleOcrDownloadType.EngineGpu11;
+                }
+                else if (answer == MessageBoxResult.Custom3)
+                {
+                    engine = isLinux ? PaddleOcrDownloadType.EngineGpu12Linux : PaddleOcrDownloadType.EngineGpu12;
+                }
+
+                vm.Initialize(engine);
+            });
+
+        return result.OkPressed;
     }
 }

--- a/src/ui/Features/Video/VideoOcr/EngineSettings/VideoOcrEngineSettingsViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/EngineSettings/VideoOcrEngineSettingsViewModel.cs
@@ -1,0 +1,225 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Nikse.SubtitleEdit.Features.Ocr.Download;
+using Nikse.SubtitleEdit.Features.Ocr.Engines;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Nikse.SubtitleEdit.Features.Video.VideoOcr.EngineSettings;
+
+/// <summary>
+/// Engine info/settings dialog for the video OCR engines that have no dialog of their own
+/// (CrispEmbed and llama.cpp open their existing dialogs instead): what the engine is, whether
+/// it is installed, where it lives, its request timeout, plus re-download and open-folder.
+/// </summary>
+public partial class VideoOcrEngineSettingsViewModel : ObservableObject
+{
+    private readonly IFolderHelper _folderHelper;
+
+    private VideoOcrEngineItem? _engine;
+    private Func<Task>? _redownloadAsync;
+
+    [ObservableProperty] private string _titleText = string.Empty;
+    [ObservableProperty] private string _subtitleText = string.Empty;
+    [ObservableProperty] private string _backendLabel = string.Empty;
+    [ObservableProperty] private string _statusLabel = string.Empty;
+    [ObservableProperty] private IBrush _statusBrush = Brushes.Gray;
+    [ObservableProperty] private string _installFolder = string.Empty;
+    [ObservableProperty] private bool _hasInstallFolder;
+    [ObservableProperty] private bool _canRedownload;
+    [ObservableProperty] private bool _hasTimeout;
+    [ObservableProperty] private int _timeoutMinutes = 5;
+    [ObservableProperty] private string _websiteUrl = string.Empty;
+    [ObservableProperty] private bool _hasWebsite;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadButtonLabel))]
+    private bool _isInstalled;
+
+    public string DownloadButtonLabel => IsInstalled ? Se.Language.General.Redownload : Se.Language.General.Download;
+
+    public Window? Window { get; set; }
+    public bool OkPressed { get; private set; }
+
+    public VideoOcrEngineSettingsViewModel(IFolderHelper folderHelper)
+    {
+        _folderHelper = folderHelper;
+    }
+
+    public void Initialize(VideoOcrEngineItem engine, Func<Task>? redownloadAsync)
+    {
+        _engine = engine;
+        _redownloadAsync = redownloadAsync;
+
+        TitleText = engine.Name;
+        SubtitleText = engine.Description;
+
+        switch (engine.EngineType)
+        {
+            case OcrEngineType.PaddleOcrStandalone:
+                HasInstallFolder = true;
+                InstallFolder = Se.PaddleOcrFolder;
+                CanRedownload = redownloadAsync != null;
+                HasWebsite = true;
+                WebsiteUrl = "https://github.com/PaddlePaddle/PaddleOCR";
+                BackendLabel = Se.Settings.Ocr.PaddleOcrMode == "server"
+                    ? "PaddleOCR (server models)"
+                    : "PaddleOCR (mobile models)";
+                break;
+            case OcrEngineType.Ollama:
+                HasTimeout = true;
+                TimeoutMinutes = Math.Max(1, Se.Settings.Ocr.OllamaOcrTimeoutMinutes);
+                HasWebsite = true;
+                WebsiteUrl = "https://ollama.com";
+                BackendLabel = Se.Language.Video.VideoOcr.EngineExternalServer;
+                break;
+            case OcrEngineType.Glm:
+                HasWebsite = true;
+                WebsiteUrl = "https://docs.z.ai";
+                BackendLabel = Se.Language.Video.VideoOcr.EngineCloudApi;
+                break;
+            case OcrEngineType.AppleVision:
+                HasWebsite = true;
+                WebsiteUrl = "https://developer.apple.com/documentation/vision";
+                BackendLabel = Se.Language.Video.VideoOcr.EngineBuiltIn;
+                break;
+            default:
+                BackendLabel = engine.Name;
+                break;
+        }
+
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        if (_engine == null)
+        {
+            return;
+        }
+
+        switch (_engine.EngineType)
+        {
+            case OcrEngineType.PaddleOcrStandalone:
+                // Engine binary plus the models folder - the same test the combo's status dot uses.
+                IsInstalled = PaddleOcrInstallHelper.IsStandaloneInstalled();
+                if (IsInstalled)
+                {
+                    SetStatus(Se.Language.General.Installed, 0x4C, 0xAF, 0x50); // green
+                }
+                else if (PaddleOcrInstallHelper.IsStandaloneEngineInstalled() && !Directory.Exists(Se.PaddleOcrModelsFolder))
+                {
+                    SetStatus(Se.Language.Video.VideoOcr.EngineModelsMissing, 0xFF, 0x98, 0x00); // amber
+                }
+                else
+                {
+                    SetStatus(Se.Language.General.NotInstalled, 0xF4, 0x43, 0x36); // red
+                }
+
+                break;
+
+            case OcrEngineType.AppleVision:
+                IsInstalled = true;
+                SetStatus(Se.Language.General.Installed, 0x4C, 0xAF, 0x50);
+                break;
+
+            default:
+                // Ollama and the GLM API: nothing SE installs, so there is no install state to
+                // report - only whether the request would go to a server we can name.
+                IsInstalled = true;
+                SetStatus(Se.Language.Video.VideoOcr.EngineNothingToInstall, 0x9E, 0x9E, 0x9E); // grey
+                break;
+        }
+    }
+
+    private void SetStatus(string label, byte r, byte g, byte b)
+    {
+        StatusLabel = label;
+        StatusBrush = new SolidColorBrush(Color.FromRgb(r, g, b));
+    }
+
+    [RelayCommand]
+    private async Task Redownload()
+    {
+        if (_redownloadAsync == null)
+        {
+            return;
+        }
+
+        await _redownloadAsync();
+        Refresh();
+    }
+
+    [RelayCommand]
+    private async Task OpenFolder()
+    {
+        if (Window == null || string.IsNullOrEmpty(InstallFolder))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(InstallFolder);
+            await _folderHelper.OpenFolder(Window, InstallFolder);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    [RelayCommand]
+    private void OpenWebsite()
+    {
+        if (!string.IsNullOrEmpty(WebsiteUrl))
+        {
+            UiUtil.OpenUrl(WebsiteUrl);
+        }
+    }
+
+    [RelayCommand]
+    private void Ok()
+    {
+        if (HasTimeout && _engine?.EngineType == OcrEngineType.Ollama)
+        {
+            Se.Settings.Ocr.OllamaOcrTimeoutMinutes = Math.Max(1, TimeoutMinutes);
+        }
+
+        OkPressed = true;
+        Close();
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        Close();
+    }
+
+    private void Close()
+    {
+        Dispatcher.UIThread.Post(() => Window?.Close());
+    }
+
+    internal void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            Close();
+        }
+        else if (UiUtil.IsHelp(e))
+        {
+            e.Handled = true;
+            UiUtil.ShowHelp("features/video-ocr");
+        }
+    }
+}

--- a/src/ui/Features/Video/VideoOcr/EngineSettings/VideoOcrEngineSettingsWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/EngineSettings/VideoOcrEngineSettingsWindow.cs
@@ -1,0 +1,194 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+
+namespace Nikse.SubtitleEdit.Features.Video.VideoOcr.EngineSettings;
+
+public class VideoOcrEngineSettingsWindow : Window
+{
+    private const int LabelWidth = 150;
+    private const int ValueWidth = 360;
+
+    private readonly VideoOcrEngineSettingsViewModel _vm;
+
+    public VideoOcrEngineSettingsWindow(VideoOcrEngineSettingsViewModel vm)
+    {
+        UiUtil.InitializeWindow(this, GetType().Name);
+        Title = Se.Language.Video.VideoOcr.EngineSettings;
+        SizeToContent = SizeToContent.WidthAndHeight;
+        CanResize = false;
+        MinWidth = 560;
+
+        _vm = vm;
+        vm.Window = this;
+        DataContext = vm;
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.OkCommand);
+        var buttonCancel = UiUtil.MakeButtonCancel(vm.CancelCommand);
+
+        var stack = new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 14,
+            Children = { BuildHeader(vm), BuildDetails(vm), BuildActions(vm, buttonOk, buttonCancel) },
+        };
+
+        Content = new Border
+        {
+            Child = new Grid { Margin = UiUtil.MakeWindowMargin(), Children = { stack } },
+            Padding = new Thickness(4),
+        };
+
+        UiUtil.FocusOnFirstActivation(this, buttonOk);
+    }
+
+    private static StackPanel BuildHeader(VideoOcrEngineSettingsViewModel vm)
+    {
+        var title = new TextBlock
+        {
+            FontSize = 18,
+            FontWeight = FontWeight.SemiBold,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.TitleText)),
+        };
+
+        var subtitle = new TextBlock
+        {
+            FontSize = 12,
+            Opacity = 0.75,
+            TextWrapping = TextWrapping.Wrap,
+            MaxWidth = LabelWidth + ValueWidth + 40,
+            Margin = new Thickness(0, 2, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.SubtitleText)),
+        };
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Vertical,
+            Children = { title, subtitle },
+        };
+    }
+
+    private static Border BuildDetails(VideoOcrEngineSettingsViewModel vm)
+    {
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = new GridLength(LabelWidth, GridUnitType.Pixel) },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+            },
+            ColumnSpacing = 12,
+            RowSpacing = 10,
+        };
+
+        for (var i = 0; i < 5; i++)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+        }
+
+        // Backend
+        grid.Add(MakeLabel(Se.Language.General.Backend), 0, 0);
+        grid.Add(MakeValue(nameof(vm.BackendLabel)), 0, 1);
+
+        // Status (coloured dot + text)
+        grid.Add(MakeLabel(Se.Language.General.Status), 1, 0);
+        var statusDot = new Ellipse
+        {
+            Width = 10,
+            Height = 10,
+            VerticalAlignment = VerticalAlignment.Center,
+            [!Ellipse.FillProperty] = new Binding(nameof(vm.StatusBrush)),
+        };
+        var statusText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(8, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.StatusLabel)),
+        };
+        grid.Add(new StackPanel { Orientation = Orientation.Horizontal, Children = { statusDot, statusText } }, 1, 1);
+
+        // Install folder - only for engines SE downloads
+        grid.Add(MakeLabel(Se.Language.General.InstallFolder).WithBindIsVisible(nameof(vm.HasInstallFolder)), 2, 0);
+        var folderText = new TextBox
+        {
+            IsReadOnly = true,
+            Width = ValueWidth,
+            BorderThickness = new Thickness(0),
+            Background = Brushes.Transparent,
+            Padding = new Thickness(0),
+            VerticalContentAlignment = VerticalAlignment.Center,
+            FontSize = 12,
+            [!TextBox.TextProperty] = new Binding(nameof(vm.InstallFolder)),
+        };
+        grid.Add(folderText.WithBindIsVisible(nameof(vm.HasInstallFolder)), 2, 1);
+
+        // Request timeout - only for the server engines that have one
+        grid.Add(MakeLabel(Se.Language.Ocr.LlamaCppOcrTimeoutMinutes).WithBindIsVisible(nameof(vm.HasTimeout)), 3, 0);
+        grid.Add(UiUtil.MakeNumericUpDownInt(1, 120, 5, 140, vm, nameof(vm.TimeoutMinutes))
+            .WithBindIsVisible(nameof(vm.HasTimeout)), 3, 1);
+
+        // Website
+        grid.Add(MakeLabel(Se.Language.Video.VideoOcr.Website).WithBindIsVisible(nameof(vm.HasWebsite)), 4, 0);
+        var link = UiUtil.MakeLink(string.Empty, vm.OpenWebsiteCommand, vm, nameof(vm.WebsiteUrl));
+        link.HorizontalAlignment = HorizontalAlignment.Left;
+        grid.Add(link.WithBindIsVisible(nameof(vm.HasWebsite)), 4, 1);
+
+        return new Border
+        {
+            Child = grid,
+            Padding = new Thickness(14),
+            CornerRadius = new CornerRadius(6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+        };
+    }
+
+    private static Grid BuildActions(VideoOcrEngineSettingsViewModel vm, Button buttonOk, Button buttonCancel)
+    {
+        var redownload = UiUtil.MakeButton(string.Empty, vm.RedownloadCommand)
+            .WithIconLeftBindText(IconNames.Download, nameof(vm.DownloadButtonLabel))
+            .WithBindIsVisible(nameof(vm.CanRedownload));
+        var openFolder = UiUtil.MakeButton(Se.Language.General.OpenContainingFolder, vm.OpenFolderCommand)
+            .WithIconLeft(IconNames.FolderOpen)
+            .WithBindIsVisible(nameof(vm.HasInstallFolder));
+
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                new ColumnDefinition { Width = GridLength.Auto },
+            },
+        };
+        grid.Add(new StackPanel { Orientation = Orientation.Horizontal, Spacing = 8, Children = { redownload, openFolder } }, 0, 0);
+        grid.Add(UiUtil.MakeButtonBar(buttonOk, buttonCancel), 0, 2);
+        return grid;
+    }
+
+    private static TextBlock MakeLabel(string text) => new()
+    {
+        Text = text,
+        Opacity = 0.7,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    private static TextBlock MakeValue(string bindingPath) => new()
+    {
+        FontWeight = FontWeight.SemiBold,
+        VerticalAlignment = VerticalAlignment.Center,
+        [!TextBlock.TextProperty] = new Binding(bindingPath),
+    };
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        _vm.OnKeyDown(e);
+    }
+}

--- a/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrViewModel.cs
@@ -15,6 +15,8 @@ using Nikse.SubtitleEdit.Features.SpellCheck.GetDictionaries;
 using Nikse.SubtitleEdit.Features.Translate;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
+using Nikse.SubtitleEdit.Logic.Download;
+using Nikse.SubtitleEdit.Features.Video.VideoOcr.EngineSettings;
 using Nikse.SubtitleEdit.Logic.LlamaCpp;
 using Nikse.SubtitleEdit.Logic.Media;
 using SkiaSharp;
@@ -311,22 +313,99 @@ public partial class VideoOcrViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Opens the CrispEmbed dialog: engine install state and hardware build, every backend's
-    /// models, and the (re-)download buttons for both. Re-downloading the engine there re-asks
-    /// CPU/Vulkan/CUDA, the only way to change hardware build after the first install (#13400).
+    /// Gear button next to the engine combo: every engine opens a settings/info dialog. CrispEmbed
+    /// and llama.cpp have dialogs of their own (engine build, models, prompt, timeout); the rest
+    /// share <see cref="VideoOcrEngineSettingsWindow"/> with install state, folder and website.
     /// </summary>
     [RelayCommand]
-    private async Task ShowCrispEmbedSettings()
+    private async Task ShowEngineSettings()
     {
         if (Window == null)
         {
             return;
         }
 
-        await _windowService.ShowDialogAsync<CrispEmbedSettingsWindow, CrispEmbedSettingsViewModel>(
-            Window, vm => vm.Initialize());
+        switch (SelectedEngine.EngineType)
+        {
+            case OcrEngineType.CrispEmbed:
+                // Engine install state and hardware build, every backend's models, and the
+                // (re-)download buttons for both. Re-downloading the engine there re-asks
+                // CPU/Vulkan/CUDA, the only way to change hardware build after the first install (#13400).
+                await _windowService.ShowDialogAsync<CrispEmbedSettingsWindow, CrispEmbedSettingsViewModel>(
+                    Window, vm => vm.Initialize());
+                break;
+
+            case OcrEngineType.LlamaCpp:
+                // Same dialog as the image OCR window: server URL, request timeout, prompt and the
+                // engine build's update status. The settings are shared with image OCR.
+                await _windowService.ShowDialogAsync<LlamaCppOcrSettingsWindow, LlamaCppOcrSettingsViewModel>(
+                    Window, vm => vm.Initialize(UpdateLlamaCppEngineAsync));
+                break;
+
+            default:
+                var engine = SelectedEngine;
+                Func<Task>? redownload = engine.EngineType == OcrEngineType.PaddleOcrStandalone
+                    ? RedownloadPaddleOcrAsync
+                    : null;
+                await _windowService.ShowDialogAsync<VideoOcrEngineSettingsWindow, VideoOcrEngineSettingsViewModel>(
+                    Window, vm => vm.Initialize(engine, redownload));
+                break;
+        }
 
         (Window as VideoOcrWindow)?.RefreshDownloadDots();
+    }
+
+    /// <summary>
+    /// Re-downloads the standalone Paddle engine (asking CPU/CUDA again, so this is also how the
+    /// build is switched) and then any missing models.
+    /// </summary>
+    private async Task RedownloadPaddleOcrAsync()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        if (await PaddleOcrInstallHelper.DownloadEngineAsync(Window, _windowService))
+        {
+            await PaddleOcrInstallHelper.EnsureInstalled(Window, _windowService, OcrEngineType.PaddleOcrStandalone);
+        }
+
+        (Window as VideoOcrWindow)?.RefreshDownloadDots();
+    }
+
+    /// <summary>
+    /// Stops the running llama-server (it holds the binary open and would keep serving a stale
+    /// build), re-downloads the matching llama.cpp build, and refreshes the model list and dots.
+    /// Wired to the download button in the llama.cpp OCR settings dialog.
+    /// </summary>
+    private async Task UpdateLlamaCppEngineAsync()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        LlamaCppServerManager.StopServer();
+        UpdateLlamaCppServerButtonText();
+
+        // Re-download the same backend that is installed (CPU/Vulkan/CUDA all unpack into one
+        // folder); when nothing is installed yet, DownloadAsync falls back to asking the user.
+        var folder = LlamaCppServerManager.GetAndCreateFolder();
+        var variant = LlamaCppServerManager.IsEngineInstalled() && OperatingSystem.IsWindows()
+            ? DownloadHashManager.DetectLlamaCppWindowsVariant(folder)
+            : null;
+
+        var model = SelectedLlamaCppModel?.Model;
+        var downloaded = await LlamaCppDownloadHelper.DownloadAsync(Window, _windowService, model, variant, forceEngineDownload: true);
+        if (downloaded != null)
+        {
+            var selectName = string.IsNullOrEmpty(downloaded) ? model?.FileName : downloaded;
+            SelectedLlamaCppModel = LlamaCppDownloadHelper.PopulateModels(LlamaCppModels, LlamaCppServerManager.GetAllOcrModels(), selectName);
+        }
+
+        (Window as VideoOcrWindow)?.RefreshDownloadDots();
+        UpdateLlamaCppServerButtonText();
     }
 
     private async Task<bool> EnsureCrispEmbedReady()

--- a/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
+++ b/src/ui/Features/Video/VideoOcr/VideoOcrWindow.cs
@@ -221,8 +221,8 @@ public class VideoOcrWindow : Window
             Margin = new Thickness(0, 0, 12, 0),
         };
 
-        // The engine picker, plus a settings button for the one engine here with something to
-        // configure: CrispEmbed's engine build and models are downloaded from that dialog.
+        // The engine picker, plus a settings/info button for the selected engine - like the
+        // speech-to-text and text-to-speech windows.
         var enginePanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
@@ -230,9 +230,8 @@ public class VideoOcrWindow : Window
             Children =
             {
                 comboEngine,
-                UiUtil.MakeButton(vm.ShowCrispEmbedSettingsCommand, IconNames.Settings,
-                        $"{CrispEmbedEngine.StaticName} - {Se.Language.General.Settings}")
-                    .WithBindIsVisible(nameof(vm.IsCrispEmbedEngine)),
+                UiUtil.MakeButton(vm.ShowEngineSettingsCommand, IconNames.Settings,
+                    $"{Se.Language.Video.VideoOcr.Engine} - {Se.Language.General.Settings}"),
             },
         };
 

--- a/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageVideoOcr.cs
@@ -44,6 +44,13 @@ public class LanguageVideoOcr
     public string TestOcrRunning { get; set; }
     public string TestOcrResultX { get; set; }
     public string TestOcrNoTextFound { get; set; }
+    public string EngineSettings { get; set; }
+    public string EngineBuiltIn { get; set; }
+    public string EngineExternalServer { get; set; }
+    public string EngineCloudApi { get; set; }
+    public string EngineNothingToInstall { get; set; }
+    public string EngineModelsMissing { get; set; }
+    public string Website { get; set; }
 
     public LanguageVideoOcr()
     {
@@ -89,5 +96,12 @@ public class LanguageVideoOcr
         TestOcrRunning = "Testing OCR on current frame...";
         TestOcrResultX = "Test result: {0}";
         TestOcrNoTextFound = "Test: no text found in the scan area";
+        EngineSettings = "OCR engine settings";
+        EngineBuiltIn = "Built into the operating system";
+        EngineExternalServer = "External server (installed and managed outside Subtitle Edit)";
+        EngineCloudApi = "Cloud API (requires an API key)";
+        EngineNothingToInstall = "Nothing to install";
+        EngineModelsMissing = "Engine installed, models missing";
+        Website = "Website";
     }
 }

--- a/tests/UI/Features/Video/VideoOcr/VideoOcrCrispEmbedSettingsButtonTests.cs
+++ b/tests/UI/Features/Video/VideoOcr/VideoOcrCrispEmbedSettingsButtonTests.cs
@@ -17,10 +17,10 @@ using System.Linq;
 namespace UITests.Features.Video.VideoOcr;
 
 /// <summary>
-/// The Video OCR window builds its settings column in code, so the CrispEmbed gear button that
+/// The Video OCR window builds its settings column in code, so the engine gear button that
 /// replaced the two small download icon buttons is only proven to exist once the window is
-/// constructed. These tests assert it reaches the logical tree, follows the engine selection,
-/// and that the CrispEmbed dialog it opens lists every downloadable model.
+/// constructed. These tests assert it reaches the logical tree, stays visible for every engine
+/// (it opens a per-engine dialog), and that the CrispEmbed dialog lists every downloadable model.
 /// </summary>
 public class VideoOcrCrispEmbedSettingsButtonTests : IDisposable
 {
@@ -61,28 +61,22 @@ public class VideoOcrCrispEmbedSettingsButtonTests : IDisposable
     }
 
     private static string SettingsButtonName =>
-        $"{CrispEmbedEngine.StaticName} - {Se.Language.General.Settings}";
+        $"{Se.Language.Video.VideoOcr.Engine} - {Se.Language.General.Settings}";
 
     [AvaloniaFact]
-    public void Window_HasCrispEmbedSettingsButton_HiddenUntilCrispEmbedIsSelected()
+    public void Window_HasEngineSettingsButton_VisibleForEveryEngine()
     {
-        if (!CrispEmbedEngine.CanBeDownloaded())
-        {
-            return;
-        }
-
         var window = BuildWindow(out var viewModel);
         try
         {
-            viewModel.SelectedEngine = viewModel.Engines.First(p => p.EngineType != OcrEngineType.CrispEmbed);
-
             var button = FindButton(window, SettingsButtonName);
             Assert.NotNull(button);
-            Assert.False(button!.IsVisible);
 
-            viewModel.SelectedEngine = viewModel.Engines.First(p => p.EngineType == OcrEngineType.CrispEmbed);
-
-            Assert.True(button.IsVisible);
+            foreach (var engine in viewModel.Engines)
+            {
+                viewModel.SelectedEngine = engine;
+                Assert.True(button!.IsVisible);
+            }
         }
         finally
         {


### PR DESCRIPTION
## Summary
- The gear button next to the engine combo in **Video > OCR burned-in subtitle** was only shown for CrispEmbed. It is now always visible and opens a settings/info dialog for the selected engine, like the speech-to-text and text-to-speech windows.
- **CrispEmbed**: existing CrispEmbed settings dialog (unchanged).
- **llama.cpp**: reuses the llama.cpp OCR settings dialog from image OCR (URL, request timeout, prompt, engine update status, re-download). Settings are already shared with image OCR.
- **Paddle OCR, Ollama, GLM API, Apple Vision**: new `VideoOcrEngineSettingsWindow` showing backend, install status, install folder + "Open containing folder", request timeout (Ollama), a website link, and Re-download for Paddle (re-asks CPU/CUDA 11/CUDA 12, so it is also how the build is switched).
- The Paddle CPU/CUDA prompt + engine download is refactored out of `PaddleOcrInstallHelper.EnsureInstalled` into `DownloadEngineAsync` so it can be forced; `EnsureInstalled` behaves as before (including the macOS skip).

## Test plan
- [ ] Open Video > OCR burned-in subtitle, select each engine, click the gear: correct dialog opens, status dot/folder/website are right.
- [ ] Paddle: Re-download prompts CPU/CUDA and downloads engine then models; status dots refresh on close.
- [ ] llama.cpp: settings dialog saves URL/timeout/prompt; Re-download stops the server and re-fetches the engine.
- [ ] Ollama: timeout change is saved on OK, discarded on Cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)