### PR TITLE
Burn-in: generate a video without subtitles instead of failing in ffmpeg

### DIFF
--- a/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
+++ b/src/ui/Features/Video/BurnIn/BurnInViewModel.cs
@@ -133,6 +133,7 @@ public partial class BurnInViewModel : ObservableObject
     private SubtitleFormat? _subtitleFormat;
     private string _inputVideoFileName;
     private string _imageSubtitleFileName = string.Empty;
+    private const string StatusSkipped = "Skipped";
     private List<BurnInEffectItem> _selectedEffects;
 
     public VideoPlayerControl? VideoPlayerControl { get; set; }
@@ -452,42 +453,52 @@ public partial class BurnInViewModel : ObservableObject
 
         Dispatcher.UIThread.Invoke(async () =>
         {
-            ProgressValue = 0;
-
-            if (_jobItemIndex < JobItems.Count - 1)
-            {
-                await InitAndStartJobItem(_jobItemIndex + 1).ConfigureAwait(false);
-                return;
-            }
-
-            IsGenerating = false;
-
-            if (JobItems.Count == 1)
-            {
-                await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window!, vm =>
-                {
-                    vm.Initialize(
-                        Se.Language.General.VideoFileGenerated,
-                        string.Format(Se.Language.General.VideoFileGeneratedX, jobItem.OutputVideoFileName),
-                        jobItem.OutputVideoFileName,
-                        true,
-                        true);
-                });
-            }
-            else
-            {
-                var sb = new StringBuilder($"Generated files ({JobItems.Count}):" + Environment.NewLine + Environment.NewLine);
-                foreach (var item in JobItems)
-                {
-                    sb.AppendLine($"{item.OutputVideoFileName} ==> {item.Status}");
-                }
-
-                await MessageBox.Show(Window!,
-                    "Generating done",
-                    sb.ToString(),
-                    MessageBoxButtons.OK);
-            }
+            await ContinueWithNextJobItemOrFinish();
         });
+    }
+
+    /// <summary>
+    /// Starts the next batch item, or ends the run with the "done" dialog. Called on the UI thread
+    /// after an item finished - or was skipped before ffmpeg was ever started.
+    /// </summary>
+    private async Task ContinueWithNextJobItemOrFinish()
+    {
+        ProgressValue = 0;
+
+        if (_jobItemIndex < JobItems.Count - 1)
+        {
+            await InitAndStartJobItem(_jobItemIndex + 1).ConfigureAwait(false);
+            return;
+        }
+
+        IsGenerating = false;
+
+        var jobItem = JobItems[_jobItemIndex];
+        if (JobItems.Count == 1 && jobItem.Status != StatusSkipped)
+        {
+            await _windowService.ShowDialogAsync<PromptFileSavedWindow, PromptFileSavedViewModel>(Window!, vm =>
+            {
+                vm.Initialize(
+                    Se.Language.General.VideoFileGenerated,
+                    string.Format(Se.Language.General.VideoFileGeneratedX, jobItem.OutputVideoFileName),
+                    jobItem.OutputVideoFileName,
+                    true,
+                    true);
+            });
+        }
+        else
+        {
+            var sb = new StringBuilder($"Generated files ({JobItems.Count}):" + Environment.NewLine + Environment.NewLine);
+            foreach (var item in JobItems)
+            {
+                sb.AppendLine($"{item.OutputVideoFileName} ==> {item.Status}");
+            }
+
+            await MessageBox.Show(Window!,
+                "Generating done",
+                sb.ToString(),
+                MessageBoxButtons.OK);
+        }
     }
 
     /// <summary>
@@ -574,12 +585,22 @@ public partial class BurnInViewModel : ObservableObject
         jobItem.TargetFileSize = UseTargetFileSize
             ? (MatchSourceVideoSize ? GetSourceFileSizeInMb(jobItem.InputVideoFileName) : TargetFileSize ?? 0)
             : 0;
-        jobItem.AssaSubtitleFileName = MakeAssa(jobItem.SubtitleFileName);
-        jobItem.Status = Se.Language.General.Generating;
         if (IsBatchMode)
         {
             jobItem.OutputVideoFileName = MakeOutputFileName(jobItem.InputVideoFileName);
         }
+
+        jobItem.AssaSubtitleFileName = MakeAssa(jobItem.SubtitleFileName);
+        if (jobItem.Status == StatusSkipped)
+        {
+            // An unreadable subtitle file used to be marked "Skipped" and then encoded anyway,
+            // with an empty "ass=" file name that ffmpeg rejects.
+            Se.WriteToolsLog($"Burn-in: skipped \"{jobItem.InputVideoFileName}\" - subtitle file \"{jobItem.SubtitleFileName}\" could not be read");
+            await ContinueWithNextJobItemOrFinish();
+            return;
+        }
+
+        jobItem.Status = Se.Language.General.Generating;
 
         Dispatcher.UIThread.Post(() =>
         {
@@ -938,13 +959,41 @@ public partial class BurnInViewModel : ObservableObject
         return new ObservableCollection<BurnInJobItem>(new[] { jobItem });
     }
 
+    /// <summary>
+    /// True when the file is a text subtitle without a single line: an empty .srt (what the
+    /// current subtitle is written as when nothing is loaded) or a format that parses to no
+    /// paragraphs. Unreadable files are not "empty" - they are skipped by <see cref="MakeAssa"/>.
+    /// </summary>
+    private static bool HasNoSubtitleLines(string subtitleFileName)
+    {
+        if (string.IsNullOrWhiteSpace(subtitleFileName) || !File.Exists(subtitleFileName) || FileUtil.IsBluRaySup(subtitleFileName))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(File.ReadAllText(subtitleFileName)))
+            {
+                return true;
+            }
+
+            var subtitle = Subtitle.Parse(subtitleFileName);
+            return subtitle != null && subtitle.Paragraphs.Count == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private string MakeAssa(string subtitleFileName)
     {
         var jobItem = JobItems[_jobItemIndex];
 
         if (string.IsNullOrWhiteSpace(subtitleFileName) || !File.Exists(subtitleFileName))
         {
-            jobItem.Status = "Skipped";
+            jobItem.Status = StatusSkipped;
             return string.Empty;
         }
 
@@ -956,6 +1005,13 @@ public partial class BurnInViewModel : ObservableObject
             return subtitleFileName;
         }
 
+        if (HasNoSubtitleLines(subtitleFileName))
+        {
+            // Nothing to burn in - the user confirmed this in Generate. An empty file name makes
+            // FfmpegGenerator leave the "ass" filter out, so the video is only re-encoded (#14777).
+            return string.Empty;
+        }
+
         var isAssa = subtitleFileName.EndsWith(".ass", StringComparison.OrdinalIgnoreCase);
 
         var subtitle = Subtitle.Parse(subtitleFileName);
@@ -963,7 +1019,7 @@ public partial class BurnInViewModel : ObservableObject
         {
             // Not a subtitle format we know: Parse returns null, and everything below
             // dereferences it. TransparentSubtitlesViewModel skips the job the same way.
-            jobItem.Status = "Skipped";
+            jobItem.Status = StatusSkipped;
             return string.Empty;
         }
 
@@ -1464,6 +1520,21 @@ public partial class BurnInViewModel : ObservableObject
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
 
+                return;
+            }
+        }
+
+        // A subtitle without lines is most likely a mistake (nothing loaded yet), but it can also
+        // be a deliberate re-encode/cut with no text - so ask instead of failing in ffmpeg (#14777).
+        var emptySubtitleCount = JobItems.Count(p => HasNoSubtitleLines(p.SubtitleFileName));
+        if (emptySubtitleCount > 0)
+        {
+            var prompt = IsBatchMode
+                ? string.Format(Se.Language.Video.BurnIn.NoSubtitlesInXItemsGenerateAnyway, emptySubtitleCount)
+                : Se.Language.Video.BurnIn.NoSubtitlesGenerateAnyway;
+            var answer = await MessageBox.Show(Window!, Se.Language.General.Warning, prompt, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            if (answer != MessageBoxResult.Yes)
+            {
                 return;
             }
         }

--- a/src/ui/Logic/Config/Language/Video/LanguageBurnIn.cs
+++ b/src/ui/Logic/Config/Language/Video/LanguageBurnIn.cs
@@ -23,6 +23,8 @@ public class LanguageBurnIn
     public string VideoFileSize { get; set; }
     public string OneBox { get; set; }
     public string LogoInfo { get; set; }
+    public string NoSubtitlesGenerateAnyway { get; set; }
+    public string NoSubtitlesInXItemsGenerateAnyway { get; set; }
 
     public LanguageBurnIn()
     {
@@ -47,5 +49,7 @@ public class LanguageBurnIn
         VideoFileSize = "Video file size";
         OneBox = "One box";
         LogoInfo = "Pick a PNG image and drag it to position it on the video.";
+        NoSubtitlesGenerateAnyway = "There are no subtitle lines to burn in.\n\nGenerate the video without subtitles?";
+        NoSubtitlesInXItemsGenerateAnyway = "{0} batch item(s) have no subtitle lines to burn in.\n\nGenerate those videos without subtitles?";
     }
 }

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -266,22 +266,28 @@ public class FfmpegGenerator
         // sup demuxer cannot seek, so the subtitle input is shifted back by the cut instead.
         var imageSubtitleInput = string.Empty;
         string withSubtitles;
+        string filterParameter;
         if (subtitleIsImage)
         {
             imageSubtitleInput = $"{GetImageSubtitleOffset(cutStart)} -i \"{assaSubtitleFileName}\"";
             withSubtitles = $"{mainVideoStream}scale={width}:{height}[video];[{inputCount}:s]scale={width}:{height}[subs];[video][subs]overlay";
+            filterParameter = $"-filter_complex \"{withSubtitles}\"";
             inputCount++;
         }
         else
         {
-            withSubtitles = $"{mainVideoStream}scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}";
+            // Nothing to burn in (the subtitle has no lines) leaves only the scale: an "ass="
+            // filter without a file name makes ffmpeg fail with "Invalid argument" (exit code
+            // 234 on some builds) before a single frame is written (#14777).
+            var videoChain = string.IsNullOrWhiteSpace(assaSubtitleFileName)
+                ? $"scale={width}:{height}"
+                : $"scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}";
+            withSubtitles = mainVideoStream + videoChain;
+            filterParameter = $"-vf \"{videoChain}\"";
         }
 
         // Add logo overlay if specified
         var logoInput = string.Empty;
-        var filterParameter = subtitleIsImage
-            ? $"-filter_complex \"{withSubtitles}\""
-            : $"-vf \"scale={width}:{height},ass={Path.GetFileName(assaSubtitleFileName)}\"";
 
         if (burnInLogo != null && !string.IsNullOrEmpty(burnInLogo.LogoFileName) && File.Exists(burnInLogo.LogoFileName))
         {

--- a/tests/UI/Features/Video/FfmpegBurnInParametersTests.cs
+++ b/tests/UI/Features/Video/FfmpegBurnInParametersTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using System.IO;
 using Nikse.SubtitleEdit.Logic.Media;
 
@@ -195,5 +195,50 @@ public class FfmpegBurnInParametersTests
         Assert.Contains("-vf \"scale=320:240,ass=subtitle.ass\"", parameters);
         Assert.DoesNotContain("-filter_complex", parameters);
         Assert.DoesNotContain("overlay", parameters);
+    }
+
+    /// <summary>
+    /// No subtitle lines (issue #14777): the ass filter is left out entirely - "ass=" with no
+    /// file name makes ffmpeg fail with "Invalid argument" before writing a frame.
+    /// </summary>
+    [Fact]
+    public void NoSubtitle_OnlyScales()
+    {
+        var parameters = FfmpegGenerator.GenerateHardcodedVideoFile(
+            "input.mp4", string.Empty, "output.mp4", 320, 240, "h264_nvenc", string.Empty, "yuv420p",
+            string.Empty, "aac", false, "48000", string.Empty, "128k", string.Empty, string.Empty);
+
+        Assert.Contains("-vf \"scale=320:240\"", parameters);
+        Assert.DoesNotContain("ass=", parameters);
+        Assert.DoesNotContain("-filter_complex", parameters);
+    }
+
+    [Fact]
+    public void NoSubtitle_WithLogo_OverlaysTheLogoOnTheScaledVideo()
+    {
+        var logoFileName = Path.GetTempFileName();
+        try
+        {
+            var logo = new Nikse.SubtitleEdit.Features.Video.BurnIn.BurnInLogo
+            {
+                LogoFileName = logoFileName,
+                X = 10,
+                Y = 20,
+                Size = 100,
+                Alpha = 100,
+            };
+
+            var parameters = FfmpegGenerator.GenerateHardcodedVideoFile(
+                "input.mp4", string.Empty, "output.mp4", 320, 240, "libx264", string.Empty, "yuv420p",
+                string.Empty, "aac", false, "48000", string.Empty, "128k", string.Empty, string.Empty,
+                burnInLogo: logo);
+
+            Assert.Contains("-filter_complex \"[0:v]scale=320:240[withsubs];[1:v]scale=", parameters);
+            Assert.DoesNotContain("ass=", parameters);
+        }
+        finally
+        {
+            File.Delete(logoFileName);
+        }
     }
 }


### PR DESCRIPTION
Fixes #14777

## Problem
With no subtitle lines loaded, the burn-in dialog wrote the current subtitle as an empty .srt. `Subtitle.Parse` cannot read that, so `MakeAssa` marked the job "Skipped" - and the caller then ran ffmpeg anyway with an empty `ass=` file name:

```
[Parsed_ass_1] No filename provided!
Error initializing filter 'ass' with args ''
Failed to inject frame into filter network: Invalid argument
```

That is the exit code 234 in the report (EINVAL on that ffmpeg build). Any unreadable batch subtitle file hit the same path. The encoder is irrelevant.

## Fix
- **FfmpegGenerator** leaves the `ass` filter out when there is no subtitle file: the video is only scaled, cut and re-encoded, and a logo still goes on top.
- **Warning first**: a subtitle without lines is usually a mistake, so `Generate` asks "There are no subtitle lines to burn in - generate the video without subtitles?" (Yes/No). Batch mode reports how many items are affected.
- **"Skipped" is honoured**: a job whose subtitle file really cannot be read now moves on to the next batch item (or ends the run) instead of launching ffmpeg with an empty file name. The single-file "video generated" dialog is not shown for a skipped item.

Two new language strings in `LanguageBurnIn` (English.json left untouched, as usual).

## Testing
- Two new tests in `FfmpegBurnInParametersTests` for the no-subtitle command line, with and without a logo; the burn-in ffmpeg parameter tests pass (52).
- Ran the resulting command shape (`-vf "scale=320:240"` plus the usual encode flags) through ffmpeg on a generated clip: exit 0, output written.

Not touched: `TransparentSubtitlesViewModel` has the same "Skipped then encode anyway" pattern, but a transparent video with no subtitles is an empty output, so it is left for a separate change if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)