### PR TITLE
Add shortcuts to move selected lines X ms back/forward (#14789)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14520,6 +14520,66 @@ public partial class MainViewModel :
     [RelayCommand]
     private void MoveEndOneFrameForwardKeepGapNext() => MoveEndByFrames(1, keepGapNextIfClose: true);
 
+    // #14789: repeatable fixed-ms nudges for fixing progressive drift section by section.
+    // Durations are kept, and a backward move is clamped so no start goes below zero.
+    [RelayCommand]
+    private void MoveSelectedLinesXMsBack() => MoveSelectedLinesByStep(-1, andForward: false);
+
+    [RelayCommand]
+    private void MoveSelectedLinesXMsForward() => MoveSelectedLinesByStep(1, andForward: false);
+
+    [RelayCommand]
+    private void MoveSelectedLinesAndForwardXMsBack() => MoveSelectedLinesByStep(-1, andForward: true);
+
+    [RelayCommand]
+    private void MoveSelectedLinesAndForwardXMsForward() => MoveSelectedLinesByStep(1, andForward: true);
+
+    internal void MoveSelectedLinesByStep(int direction, bool andForward)
+    {
+        if (AreTimeCodesLocked || SubtitleGridSelectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var stepMs = Math.Max(1, Se.Settings.General.MoveSelectedLinesStepMs);
+        var deltaMs = (double)(direction * stepMs);
+        if (deltaMs < 0)
+        {
+            var minStartMs = GetAffectedLines(andForward).Min(p => p.StartTime.TotalMilliseconds);
+            if (minStartMs <= 0)
+            {
+                return;
+            }
+
+            deltaMs = Math.Max(deltaMs, -minStartMs);
+        }
+
+        Adjust(TimeSpan.FromMilliseconds(deltaMs), adjustAll: false,
+            adjustSelectedLines: !andForward, adjustSelectedLinesAndForward: andForward);
+    }
+
+    private IEnumerable<SubtitleLineViewModel> GetAffectedLines(bool andForward)
+    {
+        var selected = SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().ToList();
+        if (!andForward)
+        {
+            return selected;
+        }
+
+        var selectedSet = new HashSet<SubtitleLineViewModel>(selected);
+        var first = -1;
+        for (var i = 0; i < Subtitles.Count; i++)
+        {
+            if (selectedSet.Contains(Subtitles[i]))
+            {
+                first = i;
+                break;
+            }
+        }
+
+        return first < 0 ? selected : Subtitles.Skip(first);
+    }
+
     private void MoveStartByFrames(int frames, bool keepGapPrevIfClose)
     {
         var s = SelectedSubtitle;

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -379,6 +379,7 @@ public class SettingsPage : UserControl
         [
             MakeNumericSettingInt(Se.Language.Options.Settings.NewEmptyDefaultMs, nameof(_vm.NewEmptyDefaultMs)),
             MakeNumericSettingInt(Se.Language.Options.Settings.TimeCodeUpDownStepMs, nameof(_vm.TimeCodeUpDownStepMs), 1, 5000),
+            MakeNumericSettingInt(Se.Language.Options.Settings.MoveSelectedLinesStepMs, nameof(_vm.MoveSelectedLinesStepMs), 1, 60000),
             MakeCheckboxSetting(Se.Language.Options.Settings.PromptBeforeDelete, nameof(_vm.PromptBeforeDelete)),
             MakeCheckboxSetting(Se.Language.Options.Settings.UseFrameMode, nameof(_vm.UseFrameMode)),
             MakeCheckboxSetting(Se.Language.Options.Settings.TextBoxLimitNewLines, nameof(_vm.TextBoxLimitNewLines)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -121,6 +121,7 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty] private int? _newEmptyDefaultMs;
     [ObservableProperty] private int? _timeCodeUpDownStepMs;
+    [ObservableProperty] private int? _moveSelectedLinesStepMs;
     [ObservableProperty] private bool _promptBeforeDelete;
     [ObservableProperty] private bool _lockTimeCodes;
     [ObservableProperty] private bool _rememberPositionAndSize;
@@ -763,6 +764,7 @@ public partial class SettingsViewModel : ObservableObject
         TextBoxLimitNewLines = general.SubtitleTextBoxLimitNewLines;
         NewEmptyDefaultMs = general.NewEmptyDefaultMs;
         TimeCodeUpDownStepMs = general.TimeCodeUpDownStepMs;
+        MoveSelectedLinesStepMs = general.MoveSelectedLinesStepMs;
         PromptBeforeDelete = general.PromptBeforeDelete;
         LockTimeCodes = general.LockTimeCodes;
         RememberPositionAndSize = general.RememberPositionAndSize;
@@ -1637,6 +1639,7 @@ public partial class SettingsViewModel : ObservableObject
         general.SubtitleTextBoxLimitNewLines = TextBoxLimitNewLines;
         general.NewEmptyDefaultMs = NewEmptyDefaultMs ?? general.NewEmptyDefaultMs;
         general.TimeCodeUpDownStepMs = TimeCodeUpDownStepMs ?? general.TimeCodeUpDownStepMs;
+        general.MoveSelectedLinesStepMs = MoveSelectedLinesStepMs ?? general.MoveSelectedLinesStepMs;
         general.PromptBeforeDelete = PromptBeforeDelete;
         general.LockTimeCodes = LockTimeCodes;
         general.RememberPositionAndSize = RememberPositionAndSize;

--- a/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
+++ b/src/ui/Features/Options/Shortcuts/Se4ShortcutsImporter.cs
@@ -297,9 +297,10 @@ public static class Se4ShortcutsImporter
         ["MainAdjustExtendNextLineStartToCurrentEnd"] = nameof(MainViewModel.ExtendNextStartToSelectedEndCommand),
         ["MainAdjustExtendToNextShotChange"] = nameof(MainViewModel.ExtendSelectedLinesToNextShotChangeOrNextSubtitleCommand),
         ["MainAdjustExtendToPreviousShotChange"] = nameof(MainViewModel.ExtendSelectedLinesToPreviousShotChangeCommand),
-        // MainAdjustSelected100MsBack/Forward move the SELECTED LINES 100 ms in SE 4; SE 5 has no
-        // such command, and mapping them to the video-seek commands silently rebound the key.
-        // Left unmapped so the import reports them as skipped.
+        // SE 4's fixed 100 ms nudges of the selected lines; SE 5's step is configurable
+        // (General.MoveSelectedLinesStepMs, default 100), so the import keeps the old feel.
+        ["MainAdjustSelected100MsBack"] = nameof(MainViewModel.MoveSelectedLinesXMsBackCommand),
+        ["MainAdjustSelected100MsForward"] = nameof(MainViewModel.MoveSelectedLinesXMsForwardCommand),
         ["MainAdjustSnapStartToNextShotChange"] = nameof(MainViewModel.SnapSelectedLinesStartToNextShotChangeCommand),
         ["MainAdjustSnapEndToPreviousShotChange"] = nameof(MainViewModel.SnapSelectedLinesEndToPreviousShotChangeCommand),
         ["MainSetInCueToClosestShotChangeLeftGreenZone"] = nameof(MainViewModel.SetInCueToClosestShotChangeLeftGreenZoneCommand),

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -98,6 +98,7 @@ public class LanguageSettings
     public string UseDoNotBreakAfterList { get; set; }
     public string NewEmptyDefaultMs { get; set; }
     public string TimeCodeUpDownStepMs { get; set; }
+    public string MoveSelectedLinesStepMs { get; set; }
     public string PromptBeforeDelete { get; set; }
     public string RememberPositionAndSize { get; set; }
     public string OpenLastFileOnStart { get; set; }
@@ -417,6 +418,7 @@ public class LanguageSettings
         UseDoNotBreakAfterList = "Use do-not-break-after list";
         NewEmptyDefaultMs = "Default new subtitle duration (ms)";
         TimeCodeUpDownStepMs = "Time up/down increment (ms)";
+        MoveSelectedLinesStepMs = "Move selected lines shortcut step (ms)";
         PromptBeforeDelete = "Prompt before delete";
         RememberPositionAndSize = "Remember window position and size";
         OpenLastFileOnStart = "Open last recent file on start";

--- a/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettingsShortcuts.cs
@@ -279,6 +279,10 @@ public class LanguageSettingsShortcuts
     public string MoveStartOneFrameForwardKeepGapPrev { get; set; }
     public string MoveEndOneFrameBackKeepGapNext { get; set; }
     public string MoveEndOneFrameForwardKeepGapNext { get; set; }
+    public string MoveSelectedLinesXMsBack { get; set; }
+    public string MoveSelectedLinesXMsForward { get; set; }
+    public string MoveSelectedLinesAndForwardXMsBack { get; set; }
+    public string MoveSelectedLinesAndForwardXMsForward { get; set; }
 
     public LanguageSettingsShortcuts()
     {
@@ -561,5 +565,9 @@ public class LanguageSettingsShortcuts
         MoveStartOneFrameForwardKeepGapPrev = "Move start one frame forward (keep gap to previous if close)";
         MoveEndOneFrameBackKeepGapNext = "Move end one frame back (keep gap to next if close)";
         MoveEndOneFrameForwardKeepGapNext = "Move end one frame forward (keep gap to next if close)";
+        MoveSelectedLinesXMsBack = "Move selected lines X ms back (X set in Settings)";
+        MoveSelectedLinesXMsForward = "Move selected lines X ms forward (X set in Settings)";
+        MoveSelectedLinesAndForwardXMsBack = "Move selected lines and all following X ms back (X set in Settings)";
+        MoveSelectedLinesAndForwardXMsForward = "Move selected lines and all following X ms forward (X set in Settings)";
     }
 }

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -84,6 +84,9 @@ public class SeGeneral
     /// <summary>How much the time up/down controls change per step when the caret is on the
     /// milliseconds part. Frame mode always steps one frame (#12506).</summary>
     public int TimeCodeUpDownStepMs { get; set; }
+    /// <summary>How far the "move selected lines X ms back/forward" shortcuts shift, in
+    /// milliseconds (SE 4 had fixed 100 ms variants; #14789 asks for repeatable drift fixes).</summary>
+    public int MoveSelectedLinesStepMs { get; set; }
     public bool PromptBeforeDelete { get; set; }
     public bool LockTimeCodes { get; set; }
 
@@ -256,6 +259,7 @@ public class SeGeneral
         AutoGuessAnsiEncoding = true;
         NewEmptyDefaultMs = 2000;
         TimeCodeUpDownStepMs = 100;
+        MoveSelectedLinesStepMs = 100;
         PromptBeforeDelete = true;
         AutoBackupOn = true;
         AutoBackupIntervalMinutes = 5;

--- a/src/ui/Logic/ShortcutsMain.cs
+++ b/src/ui/Logic/ShortcutsMain.cs
@@ -408,6 +408,10 @@ public static class ShortcutsMain
         { nameof(MainViewModel.MoveStartOneFrameForwardKeepGapPrevCommand), Se.Language.Options.Shortcuts.MoveStartOneFrameForwardKeepGapPrev },
         { nameof(MainViewModel.MoveEndOneFrameBackKeepGapNextCommand), Se.Language.Options.Shortcuts.MoveEndOneFrameBackKeepGapNext },
         { nameof(MainViewModel.MoveEndOneFrameForwardKeepGapNextCommand), Se.Language.Options.Shortcuts.MoveEndOneFrameForwardKeepGapNext },
+        { nameof(MainViewModel.MoveSelectedLinesXMsBackCommand), Se.Language.Options.Shortcuts.MoveSelectedLinesXMsBack },
+        { nameof(MainViewModel.MoveSelectedLinesXMsForwardCommand), Se.Language.Options.Shortcuts.MoveSelectedLinesXMsForward },
+        { nameof(MainViewModel.MoveSelectedLinesAndForwardXMsBackCommand), Se.Language.Options.Shortcuts.MoveSelectedLinesAndForwardXMsBack },
+        { nameof(MainViewModel.MoveSelectedLinesAndForwardXMsForwardCommand), Se.Language.Options.Shortcuts.MoveSelectedLinesAndForwardXMsForward },
         { nameof(MainViewModel.MergeSelectedLinesCommand), Se.Language.General.MergeSelectedLines },
         { nameof(MainViewModel.MergeSelectedLinesDialogCommand), Se.Language.General.MergeSelectedLinesDialog },
         { nameof(MainViewModel.MergeSelectedLinesBilingualCommand), Se.Language.Options.Shortcuts.GeneralMergeSelectedLinesBilingual },
@@ -862,6 +866,10 @@ public static class ShortcutsMain
         AddShortcut(shortcuts, vm.MoveStartOneFrameForwardKeepGapPrevCommand, nameof(vm.MoveStartOneFrameForwardKeepGapPrevCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MoveEndOneFrameBackKeepGapNextCommand, nameof(vm.MoveEndOneFrameBackKeepGapNextCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MoveEndOneFrameForwardKeepGapNextCommand, nameof(vm.MoveEndOneFrameForwardKeepGapNextCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MoveSelectedLinesXMsBackCommand, nameof(vm.MoveSelectedLinesXMsBackCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MoveSelectedLinesXMsForwardCommand, nameof(vm.MoveSelectedLinesXMsForwardCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MoveSelectedLinesAndForwardXMsBackCommand, nameof(vm.MoveSelectedLinesAndForwardXMsBackCommand), ShortcutCategory.General);
+        AddShortcut(shortcuts, vm.MoveSelectedLinesAndForwardXMsForwardCommand, nameof(vm.MoveSelectedLinesAndForwardXMsForwardCommand), ShortcutCategory.General);
 
         AddShortcut(shortcuts, vm.MergeSelectedLinesDialogCommand, nameof(vm.MergeSelectedLinesDialogCommand), ShortcutCategory.General);
         AddShortcut(shortcuts, vm.MergeSelectedLinesBilingualCommand, nameof(vm.MergeSelectedLinesBilingualCommand), ShortcutCategory.General);

--- a/tests/UI/Features/Main/MoveSelectedLinesStepTests.cs
+++ b/tests/UI/Features/Main/MoveSelectedLinesStepTests.cs
@@ -1,0 +1,137 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Nikse.SubtitleEdit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Config;
+using System;
+using System.Collections.Generic;
+
+namespace UITests.Features.Main;
+
+/// <summary>
+/// "Move selected lines X ms back/forward" and the "and all following" variants (#14789):
+/// durations are kept, only the intended lines move, and a backward move is clamped so no start
+/// goes below zero.
+/// </summary>
+public class MoveSelectedLinesStepTests : IDisposable
+{
+    private readonly List<Window> _windows = new();
+    private readonly int _stepMs = Se.Settings.General.MoveSelectedLinesStepMs;
+    private readonly bool _locked = Se.Settings.General.LockTimeCodes;
+
+    public void Dispose()
+    {
+        Se.Settings.General.MoveSelectedLinesStepMs = _stepMs;
+        Se.Settings.General.LockTimeCodes = _locked;
+        foreach (var w in _windows)
+        {
+            w.Close();
+        }
+    }
+
+    private (Window Window, MainViewModel Vm) ThreeLines()
+    {
+        Se.Settings.General.MoveSelectedLinesStepMs = 100;
+        Se.Settings.General.LockTimeCodes = false;
+
+        var services = new ServiceCollection();
+        services.AddSubtitleEditServices();
+        Locator.Services = services.BuildServiceProvider();
+
+        var window = new Window { Width = 1400, Height = 900 };
+        _windows.Add(window);
+        MainView.NextHostWindow = window;
+        var view = new MainView();
+        window.Content = view;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var vm = (MainViewModel)view.DataContext!;
+        window.SuppressSaveChangesPromptOnClose(vm);
+
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("one", 50, 1000), null!) { Number = 1 });
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("two", 2000, 3000), null!) { Number = 2 });
+        vm.Subtitles.Add(new SubtitleLineViewModel(new Paragraph("three", 4000, 5000), null!) { Number = 3 });
+        Dispatcher.UIThread.RunJobs();
+        return (window, vm);
+    }
+
+    private static void Select(MainViewModel vm, int index)
+    {
+        vm.SelectedSubtitle = vm.Subtitles[index];
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void Forward_MovesOnlySelectedLine_KeepsDuration()
+    {
+        var (_, vm) = ThreeLines();
+        Select(vm, 1);
+
+        vm.MoveSelectedLinesXMsForwardCommand.Execute(null);
+
+        Assert.Equal(2100, vm.Subtitles[1].StartTime.TotalMilliseconds);
+        Assert.Equal(3100, vm.Subtitles[1].EndTime.TotalMilliseconds);
+        Assert.Equal(50, vm.Subtitles[0].StartTime.TotalMilliseconds);
+        Assert.Equal(4000, vm.Subtitles[2].StartTime.TotalMilliseconds);
+    }
+
+    [AvaloniaFact]
+    public void AndForward_MovesSelectedAndFollowing_NotEarlier()
+    {
+        var (_, vm) = ThreeLines();
+        Select(vm, 1);
+
+        vm.MoveSelectedLinesAndForwardXMsBackCommand.Execute(null);
+
+        Assert.Equal(50, vm.Subtitles[0].StartTime.TotalMilliseconds);
+        Assert.Equal(1900, vm.Subtitles[1].StartTime.TotalMilliseconds);
+        Assert.Equal(2900, vm.Subtitles[1].EndTime.TotalMilliseconds);
+        Assert.Equal(3900, vm.Subtitles[2].StartTime.TotalMilliseconds);
+        Assert.Equal(4900, vm.Subtitles[2].EndTime.TotalMilliseconds);
+    }
+
+    [AvaloniaFact]
+    public void Back_ClampsAtZero_AndStopsOnceThere()
+    {
+        var (_, vm) = ThreeLines();
+        Select(vm, 0);
+
+        vm.MoveSelectedLinesXMsBackCommand.Execute(null);
+        Assert.Equal(0, vm.Subtitles[0].StartTime.TotalMilliseconds);
+        Assert.Equal(950, vm.Subtitles[0].EndTime.TotalMilliseconds);
+
+        vm.MoveSelectedLinesXMsBackCommand.Execute(null);
+        Assert.Equal(0, vm.Subtitles[0].StartTime.TotalMilliseconds);
+        Assert.Equal(950, vm.Subtitles[0].EndTime.TotalMilliseconds);
+    }
+
+    [AvaloniaFact]
+    public void UsesConfiguredStep()
+    {
+        var (_, vm) = ThreeLines();
+        Se.Settings.General.MoveSelectedLinesStepMs = 250;
+        Select(vm, 2);
+
+        vm.MoveSelectedLinesXMsForwardCommand.Execute(null);
+
+        Assert.Equal(4250, vm.Subtitles[2].StartTime.TotalMilliseconds);
+    }
+
+    [AvaloniaFact]
+    public void LockedTimeCodes_DoesNothing()
+    {
+        var (_, vm) = ThreeLines();
+        vm.LockTimeCodes = true;
+        Select(vm, 1);
+
+        vm.MoveSelectedLinesXMsForwardCommand.Execute(null);
+
+        Assert.Equal(2000, vm.Subtitles[1].StartTime.TotalMilliseconds);
+    }
+}


### PR DESCRIPTION
Addresses #14789.

SE 5 already shifts "selected lines and forward" via Sync > Adjust all times and the "Set start and offset the rest" waveform button, but had no one-keystroke fixed-ms nudge (SE 4 had "Move selected lines 100 ms back/forward").

## Changes
- Four new shortcut commands (Options > Shortcuts > General):
  - Move selected lines X ms back / forward
  - Move selected lines and all following X ms back / forward
- X is a new setting, Settings > General > "Move selected lines shortcut step (ms)", default 100.
- Durations are kept. A backward move is clamped so no line starts before 00:00:00.000, and it is a no-op once a line is already at zero.
- Respects locked time codes.
- SE 4 shortcut importer now maps `MainAdjustSelected100MsBack/Forward` onto the new commands instead of skipping them.

## Tests
New `MoveSelectedLinesStepTests` covers selected-only vs and-forward scope, duration retention, zero clamp, configured step, and locked time codes. Importer map guard test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)