### PR TITLE
Spell check: work around WeCantSpell COMPOUNDRULE comment bug (#14788)

### DIFF
--- a/src/libuilogic/SpellCheck/SpellChecker.cs
+++ b/src/libuilogic/SpellCheck/SpellChecker.cs
@@ -146,7 +146,7 @@ public class SpellChecker : ISpellChecker, IDoSpell
         else
         {
             var affixFile = Path.ChangeExtension(dictionaryFile, ".aff");
-            _hunspellWeCantSpell = WordList.CreateFromFiles(dictionaryFile, affixFile);
+            _hunspellWeCantSpell = LoadHunspell(dictionaryFile, affixFile);
         }
 
         if (string.IsNullOrEmpty(twoLetterLanguageCode))
@@ -424,6 +424,69 @@ public class SpellChecker : ISpellChecker, IDoSpell
         }
 
         return _hunspellWeCantSpell != null && _hunspellWeCantSpell.Check(word);
+    }
+
+    /// <summary>
+    /// Loads a Hunspell dictionary via WeCantSpell, working around an upstream parser bug: a trailing
+    /// "# comment" on a COMPOUNDRULE line is read as part of the rule, so the rule never matches. The
+    /// Dutch nl_NL.aff comments most of its number rules that way, which flagged "achtenzestig" etc.
+    /// as misspelled (#14788, aarondandy/WeCantSpell.Hunspell#118). Native Hunspell ignores the comment.
+    /// </summary>
+    internal static WordList LoadHunspell(string dictionaryFile, string affixFile)
+    {
+        var affixBytes = StripCompoundRuleComments(File.ReadAllBytes(affixFile));
+        using var dictionaryStream = File.OpenRead(dictionaryFile);
+        using var affixStream = new MemoryStream(affixBytes, writable: false);
+        return WordList.CreateFromStreams(dictionaryStream, affixStream);
+    }
+
+    /// <summary>
+    /// Cuts "&lt;whitespace&gt;#..." off every COMPOUNDRULE line. Works on bytes so the .aff keeps
+    /// whatever encoding its SET line declares (all supported encodings are ASCII supersets).
+    /// </summary>
+    internal static byte[] StripCompoundRuleComments(byte[] affix)
+    {
+        var keyword = "COMPOUNDRULE"u8;
+        var output = new MemoryStream(affix.Length);
+        var lineStart = 0;
+        while (lineStart < affix.Length)
+        {
+            var lineEnd = Array.IndexOf(affix, (byte)'\n', lineStart);
+            if (lineEnd < 0)
+            {
+                lineEnd = affix.Length;
+            }
+
+            var line = affix.AsSpan(lineStart, lineEnd - lineStart);
+            var contentEnd = line.Length;
+            if (line.StartsWith(keyword))
+            {
+                var hash = line.IndexOf((byte)'#');
+                if (hash > 0 && (line[hash - 1] == (byte)' ' || line[hash - 1] == (byte)'\t'))
+                {
+                    contentEnd = hash;
+                    while (contentEnd > 0 && (line[contentEnd - 1] == (byte)' ' || line[contentEnd - 1] == (byte)'\t'))
+                    {
+                        contentEnd--;
+                    }
+                }
+            }
+
+            output.Write(line[..contentEnd]);
+            if (contentEnd < line.Length && line[^1] == (byte)'\r')
+            {
+                output.WriteByte((byte)'\r'); // keep CRLF line endings untouched
+            }
+
+            if (lineEnd < affix.Length)
+            {
+                output.WriteByte((byte)'\n');
+            }
+
+            lineStart = lineEnd + 1;
+        }
+
+        return output.ToArray();
     }
 
     public static bool IsVoikkoDictionary(string dictionaryFile)

--- a/tests/libuilogic/SpellCheck/HunspellCompoundRuleCommentTests.cs
+++ b/tests/libuilogic/SpellCheck/HunspellCompoundRuleCommentTests.cs
@@ -1,0 +1,48 @@
+using System.Text;
+using Nikse.SubtitleEdit.UiLogic.SpellCheck;
+
+namespace LibUiLogicTests.SpellCheck;
+
+/// <summary>
+/// WeCantSpell.Hunspell reads a trailing "# comment" on a COMPOUNDRULE line as part of the rule, so
+/// the rule never matches (#14788, aarondandy/WeCantSpell.Hunspell#118). SE strips those comments
+/// before loading; native Hunspell ignores them.
+/// </summary>
+public class HunspellCompoundRuleCommentTests
+{
+    private const string Dic = "2\nachten/N1\nzestig/n2\n";
+
+    [Fact]
+    public void CompoundRuleWithTrailingComment_MatchesLikeNativeHunspell()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-hunspell-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        try
+        {
+            var dic = Path.Combine(folder, "nl_NL.dic");
+            File.WriteAllText(dic, Dic);
+            File.WriteAllText(Path.Combine(folder, "nl_NL.aff"),
+                "SET UTF-8\nFLAG long\nCOMPOUNDRULE 1\nCOMPOUNDRULE (N1)(n2)\t  \t# eenen+zestig[ste]\n");
+
+            var spellChecker = new SpellChecker();
+            Assert.True(spellChecker.Initialize(dic, "nl"));
+            Assert.True(spellChecker.DoSpell("achtenzestig"));
+            Assert.False(spellChecker.DoSpell("zestigachten"));
+        }
+        finally
+        {
+            Directory.Delete(folder, true);
+        }
+    }
+
+    [Fact]
+    public void StripCompoundRuleComments_OnlyTouchesCommentedCompoundRules()
+    {
+        var input = "SET UTF-8\r\nCOMPOUNDRULE 3 # count\r\nCOMPOUNDRULE (N1)(n2)\t# c\r\nCOMPOUNDRULE (N4)(NH)\r\nCOMPOUNDRULE #x\r\nREP a b # keep\r\n# full comment\r\nSFX Yb 0 je [^m]\t\t# keep";
+        var expected = "SET UTF-8\r\nCOMPOUNDRULE 3\r\nCOMPOUNDRULE (N1)(n2)\r\nCOMPOUNDRULE (N4)(NH)\r\nCOMPOUNDRULE\r\nREP a b # keep\r\n# full comment\r\nSFX Yb 0 je [^m]\t\t# keep";
+
+        var output = SpellChecker.StripCompoundRuleComments(Encoding.UTF8.GetBytes(input));
+
+        Assert.Equal(expected, Encoding.UTF8.GetString(output));
+    }
+}


### PR DESCRIPTION
Fixes #14788.

**Problem:** Dutch compound numbers (achtenzestig, eenenzestig, zevenenveertig, drieëntachtig, ...) were flagged as misspelled while native Hunspell / Firefox accept them.

**Root cause (upstream):** WeCantSpell.Hunspell's `TryParseCompoundRuleIntoList` walks the whole parameter text of a `COMPOUNDRULE` line and turns every character outside parentheses into a flag, so a trailing `# comment` becomes bogus rule elements and the rule can never match. `nl_NL.aff` comments 22 of its 37 number rules that way. Reported upstream as aarondandy/WeCantSpell.Hunspell#118.

**Workaround:** strip `<whitespace>#...` from `COMPOUNDRULE` lines at the byte level (encoding-neutral, CRLF preserved) and load via `WordList.CreateFromStreams`. Only COMPOUNDRULE lines are touched.

**Verified:** with the bundled LibreOffice nl_NL dictionary the listed words now pass and rejected words (rotmuggen, Heer = FORBIDDENWORD, hoofdseiner) still match native Hunspell 1.7.3; da_DK unaffected. Unit tests added; full libuilogic suite green (865).

Not bugs from the report: `Heer` is marked forbidden in the dictionary itself, `hoofdseiner`/`rotmuggen` are rejected by native Hunspell with the current LibreOffice and OpenTaal dictionaries too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)