### PR TITLE
Video preview: draw EBU STL <box> without an STL header

### DIFF
--- a/src/ui/Logic/Media/EbuStlPreviewStyler.cs
+++ b/src/ui/Logic/Media/EbuStlPreviewStyler.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
 using SkiaSharp;
@@ -28,18 +28,20 @@ internal static class EbuStlPreviewStyler
     }
 
     /// <summary>
-    /// True when the subtitle in the video preview is still a teletext format - EBU STL, or DVB
+    /// True when the subtitle in the video preview is a teletext format - EBU STL, or DVB
     /// teletext (.dvbttx), which draws the same boxed double height rows.
     /// </summary>
     /// <remarks>
     /// The GSI block (and the dvbteletext marker) stays on the subtitle when the format is
     /// switched in the toolbar, so the header on its own says only which file the subtitle was
     /// read from - a subtitle shown as SubRip must lose the teletext box and the double height
-    /// with the format.
+    /// with the format. The other way round needs no header at all: a subtitle switched to EBU
+    /// STL in the toolbar can carry a per-line &lt;box&gt; (the "Box" toggle, PR #14780), and
+    /// without the styling the tag was drawn as literal text on the video.
     /// </remarks>
-    public static bool IsTeletextPreview([NotNullWhen(true)] string? header, Type? uiFormatType)
+    public static bool IsTeletextPreview(string? header, Type? uiFormatType)
     {
-        return (uiFormatType == typeof(Ebu) && IsStlHeader(header)) ||
+        return uiFormatType == typeof(Ebu) ||
                (uiFormatType == typeof(DvbTeletext) && DvbTeletext.IsDvbTeletextHeader(header));
     }
 
@@ -48,10 +50,10 @@ internal static class EbuStlPreviewStyler
     /// the right one.
     /// </summary>
     /// <param name="subtitle">Preview copy of the subtitle - the header and the paragraphs are rewritten in place.</param>
-    /// <param name="sourceHeader">The GSI block of the STL file the subtitle came from.</param>
+    /// <param name="sourceHeader">The GSI block of the STL file the subtitle came from, or null/anything else for a subtitle that was switched to EBU STL in the toolbar.</param>
     /// <param name="previewStyle">The style the preview is configured with - font, size, colors, alignment, margins.</param>
     /// <param name="title">Script title for the generated ASSA header.</param>
-    public static void Apply(Subtitle subtitle, string sourceHeader, SsaStyle previewStyle, string title)
+    public static void Apply(Subtitle subtitle, string? sourceHeader, SsaStyle previewStyle, string title)
     {
         // The box and the double height are teletext control codes, so display standard "0"
         // (open subtitling) is written without either however the save options are set - see
@@ -65,7 +67,7 @@ internal static class EbuStlPreviewStyler
             useBox = true;
             useDoubleHeight = true;
         }
-        else
+        else if (IsStlHeader(sourceHeader))
         {
             try
             {
@@ -83,6 +85,9 @@ internal static class EbuStlPreviewStyler
                 // ignore - an unreadable header is previewed as plain text
             }
         }
+        // No STL header: the subtitle was switched to EBU STL in the toolbar. Ebu.Save invents an
+        // open subtitling header for it (display standard "0"), which is written without the
+        // file-wide box and double height - only a per-line <box> below draws a box.
 
         var defaultStyle = new SsaStyle(previewStyle);
 

--- a/tests/UI/Logic/Media/EbuStlPreviewStylerTests.cs
+++ b/tests/UI/Logic/Media/EbuStlPreviewStylerTests.cs
@@ -1,4 +1,4 @@
-using Nikse.SubtitleEdit.Core.Common;
+﻿using Nikse.SubtitleEdit.Core.Common;
 using Nikse.SubtitleEdit.Core.SubtitleFormats;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.Media;
@@ -164,7 +164,56 @@ public class EbuStlPreviewStylerTests
         Assert.True(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(Ebu)));
         Assert.False(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(SubRip)));
         Assert.False(EbuStlPreviewStyler.IsTeletextPreview(header, null));
-        Assert.False(EbuStlPreviewStyler.IsTeletextPreview(null, typeof(Ebu)));
+    }
+
+    // The other way round needs no header: a subtitle switched to EBU STL in the toolbar can
+    // carry a per-line <box> from the "Box" toggle (PR #14780), and without the styling the tag
+    // was drawn as literal text on the video.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("WEBVTT")]
+    public void EbuStlIsStyledWithoutAnStlHeader(string? header)
+    {
+        Assert.True(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(Ebu)));
+        Assert.False(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(SubRip)));
+    }
+
+    // Without an STL header Ebu.Save invents an open subtitling one, which is written without the
+    // file-wide box and double height - so only the lines that ask for the box get it, and the tag
+    // never reaches the video as text.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void WithoutAnStlHeaderOnlyTheBoxTagDrawsABox(string? header)
+    {
+        var settings = Configuration.Settings.SubtitleSettings;
+        var oldUseBox = settings.EbuStlTeletextUseBox;
+        var oldUseDoubleHeight = settings.EbuStlTeletextUseDoubleHeight;
+        try
+        {
+            settings.EbuStlTeletextUseBox = true;
+            settings.EbuStlTeletextUseDoubleHeight = true;
+
+            var subtitle = new Subtitle { Header = header };
+            subtitle.Paragraphs.Add(new Paragraph("<box>until I finish the final" + Environment.NewLine + "level of Breath of the Wild.</box>", 1000, 3000));
+            subtitle.Paragraphs.Add(new Paragraph("Plain line", 4000, 6000));
+
+            var previewStyle = new SsaStyle { Name = "Default", FontName = "Verdana", FontSize = 33 };
+            EbuStlPreviewStyler.Apply(subtitle, header, previewStyle, "preview");
+
+            Assert.Equal("Box", subtitle.Paragraphs[0].Extra);
+            Assert.DoesNotContain("box", subtitle.Paragraphs[0].Text, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("Default", subtitle.Paragraphs[1].Extra);
+            Assert.Equal("3", GetStyle(subtitle, "Box")[BorderStyleField]);
+            Assert.Equal("100", GetStyle(subtitle, "Box")[ScaleYField]);
+            Assert.Equal("100", GetStyle(subtitle, "Default")[ScaleYField]);
+        }
+        finally
+        {
+            settings.EbuStlTeletextUseBox = oldUseBox;
+            settings.EbuStlTeletextUseDoubleHeight = oldUseDoubleHeight;
+        }
     }
 
     // Same gate for the other teletext format: the dvbteletext marker styles the preview only
@@ -176,7 +225,7 @@ public class EbuStlPreviewStylerTests
 
         Assert.True(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(DvbTeletext)));
         Assert.False(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(SubRip)));
-        Assert.False(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(Ebu)));
+        Assert.True(EbuStlPreviewStyler.IsTeletextPreview(header, typeof(Ebu))); // EBU STL is styled whatever the header
         Assert.False(EbuStlPreviewStyler.IsTeletextPreview(MakeStlHeader("1"), typeof(DvbTeletext)));
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #14780. The preview styler only ran when the subtitle header was a real STL GSI block, so a subtitle opened from another format, switched to EBU STL in the toolbar and boxed with the new Box toggle showed the `<box>` tag as literal text on the video.

- `EbuStlPreviewStyler.IsTeletextPreview` now returns true for EBU STL whatever the header is.
- Without an STL header only the per-line `<box>` draws a box, and no file-wide box or double height is applied - matching the open subtitling header `Ebu.Save` invents for such a file.
- A loaded STL file behaves exactly as before.

## Test plan

- [x] Updated the gate test and added two tests for the no-header case (27 styler tests pass).
- [x] Manually verified: open .srt, switch to EBU STL, Box a line - the preview shows a black box and no tag text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)