### PR TITLE
Batch convert: add "Add folder recursive..."

### DIFF
--- a/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertViewModel.cs
@@ -1926,6 +1926,17 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
     [RelayCommand]
     private async Task AddFolder()
     {
+        await AddFolderAsync(Se.Settings.Tools.BatchConvert.ScanFolderRecursive);
+    }
+
+    [RelayCommand]
+    private async Task AddFolderRecursive()
+    {
+        await AddFolderAsync(recursive: true);
+    }
+
+    private async Task AddFolderAsync(bool recursive)
+    {
         if (Window == null)
         {
             return;
@@ -1937,7 +1948,7 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
             return;
         }
 
-        await AddFilesAndFoldersAsync(Array.Empty<string>(), new[] { folder });
+        await AddFilesAndFoldersAsync(Array.Empty<string>(), new[] { folder }, recursive);
     }
 
     [RelayCommand]
@@ -1946,13 +1957,13 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
         _addFilesCancellationTokenSource.Cancel();
     }
 
-    private async Task AddFilesAndFoldersAsync(IReadOnlyList<string> fileNames, IReadOnlyList<string> folders)
+    private async Task AddFilesAndFoldersAsync(IReadOnlyList<string> fileNames, IReadOnlyList<string> folders, bool? recursive = null)
     {
         var allFileNames = new List<string>(fileNames);
 
         if (folders.Count > 0)
         {
-            var scanned = await ScanFoldersAsync(folders);
+            var scanned = await ScanFoldersAsync(folders, recursive ?? Se.Settings.Tools.BatchConvert.ScanFolderRecursive);
             if (scanned == null)
             {
                 return; // cancelled during the scan - add nothing
@@ -1971,13 +1982,12 @@ public partial class BatchConvertViewModel : ObservableObject, IClosingCleanup
 
     /// <summary>
     /// Collects the files the batch converter can open from <paramref name="folders"/> (and their
-    /// subfolders when "include subfolders" is on). Walking a deep tree or a network share can take
-    /// a long time, so this runs off the UI thread behind the "please wait" overlay and can be
-    /// cancelled - returns null when it was.
+    /// subfolders when <paramref name="recursive"/> is set). Walking a deep tree or a network share
+    /// can take a long time, so this runs off the UI thread behind the "please wait" overlay and can
+    /// be cancelled - returns null when it was.
     /// </summary>
-    private async Task<List<string>?> ScanFoldersAsync(IReadOnlyList<string> folders)
+    private async Task<List<string>?> ScanFoldersAsync(IReadOnlyList<string> folders, bool recursive)
     {
-        var recursive = Se.Settings.Tools.BatchConvert.ScanFolderRecursive;
         _addFilesCancellationTokenSource = new CancellationTokenSource();
         var token = _addFilesCancellationTokenSource.Token;
 

--- a/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
+++ b/src/ui/Features/Tools/BatchConvert/BatchConvertWindow.cs
@@ -259,6 +259,7 @@ public class BatchConvertWindow : Window
             {
                 UiUtil.MakeButton(vm.AddFilesCommand, IconNames.Plus, Se.Language.General.Add).WithMarginLeft(10),
                 UiUtil.MakeButton(vm.AddFolderCommand, IconNames.Folder, Se.Language.Tools.BatchConvert.AddFolderDotDotDot).WithMarginLeft(5),
+                UiUtil.MakeButton(vm.AddFolderRecursiveCommand, IconNames.FolderMultiple, Se.Language.Tools.BatchConvert.AddFolderRecursiveDotDotDot).WithMarginLeft(5),
                 UiUtil.MakeButton(vm.RemoveSelectedFilesCommand, IconNames.Trash, Se.Language.General.Remove).WithMarginLeft(5),
                 UiUtil.MakeButton(vm.ClearAllFilesCommand, IconNames.Close, Se.Language.General.Clear).WithMarginLeft(5),
                 UiUtil.MakeLabel(Se.Language.General.TargetFormat).WithMarginLeft(15),
@@ -336,6 +337,14 @@ public class BatchConvertWindow : Window
             Command = vm.AddFolderCommand,
         };
         flyout.Items.Add(menuItemImportFolder);
+
+        var menuItemImportFolderRecursive = new MenuItem
+        {
+            Header = Se.Language.Tools.BatchConvert.AddFolderRecursiveDotDotDot,
+            DataContext = vm,
+            Command = vm.AddFolderRecursiveCommand,
+        };
+        flyout.Items.Add(menuItemImportFolderRecursive);
 
         // hack to make drag and drop work on the file grid - also on empty rows
         var dropHost = new Border

--- a/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageBatchConvert.cs
@@ -55,6 +55,7 @@ public class LanguageBatchConvert
     public string ConvertColorsToDialogReBreakLines { get; set; }
     public string SnapTimeCodesToFramesInfo { get; set; }
     public string AddFolderDotDotDot { get; set; }
+    public string AddFolderRecursiveDotDotDot { get; set; }
     public string SelectFolderToConvert { get; set; }
     public string IncludeSubfolders { get; set; }
     public string KeepSourceFileTimestamp { get; set; }
@@ -125,6 +126,7 @@ public class LanguageBatchConvert
         ConvertColorsToDialogReBreakLines = "Re-break lines";
         SnapTimeCodesToFramesInfo = "Rounds every start and end time to the nearest frame. The frame rate is read from a video file with the same name as the subtitle file, unless a fixed frame rate is chosen.";
         AddFolderDotDotDot = "Add folder...";
+        AddFolderRecursiveDotDotDot = "Add folder recursive...";
         SelectFolderToConvert = "Select folder with files to convert";
         IncludeSubfolders = "Include subfolders when adding a folder";
         KeepSourceFileTimestamp = "Keep source file date/time on output files";

--- a/src/ui/Logic/IconNames.cs
+++ b/src/ui/Logic/IconNames.cs
@@ -55,6 +55,7 @@ internal class IconNames
     public const string FindReplace = "mdi-find-replace";
     public const string Folder = "mdi-folder";
     public const string FolderOpen = "mdi-folder-open";
+    public const string FolderMultiple = "mdi-folder-multiple";
     public const string FormatClear = "mdi-format-clear";
     public const string FormatFont = "mdi-format-font";
     public const string FormTextBox = "mdi-form-textbox";


### PR DESCRIPTION
## Summary
- Adds an **Add folder recursive...** button next to *Add folder...* in Batch convert, plus a matching entry in the file list context menu.
- It always includes subfolders, independent of the *scan folder recursive* setting. *Add folder...* and drag-and-drop keep honoring that setting as before.
- The folder scan still runs off the UI thread behind the please-wait overlay and can be cancelled.

## Test plan
- [ ] Tools > Batch convert > *Add folder recursive...* on a folder with nested subfolders adds files from all levels.
- [ ] *Add folder...* with the setting off adds only the top level.
- [ ] Context menu on the file list shows both entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)