### PR TITLE
Subtitle grid: add "Show formatting, keep non-visual tags" mode

### DIFF
--- a/docs/features/subtitle-grid.md
+++ b/docs/features/subtitle-grid.md
@@ -84,16 +84,17 @@ Both are a normal edit, so `Ctrl+Z` undoes them.
 
 ## Formatting Display
 
-How the grid treats HTML/ASSA markup is a four-way choice — **Show formatted (HTML/ASSA) text in subtitle grid** in **Options → Settings → Appearance**:
+How the grid treats HTML/ASSA markup is a five-way choice — **Show formatted (HTML/ASSA) text in subtitle grid** in **Options → Settings → Appearance**:
 
 | Mode | What the grid shows |
 |------|---------------------|
 | **Show formatting** | The tags are hidden and what they mean is rendered — italic, bold, color, font size. The default |
+| **Show formatting, keep non-visual tags** | Like *Show formatting*, but tags the grid cannot render — position, alignment, animation, borders, karaoke timing and other HTML tags — stay visible as text, so you can still see that a line is positioned or animated |
 | **Show tags** | The text with its tags, with the tags colored so they are easy to pick out |
 | **No formatting** | The raw text exactly as it is stored |
 | **Hide tags** | The markup is stripped and only the dialogue is drawn, as plain themed text — no colors, fonts or sizes. Useful for translation, where the styling is only a distraction. Vector drawing tags are dropped too |
 
-A shortcut can be assigned in **Options → Shortcuts** to cycle the four modes on the fly; the status bar names the mode you land on.
+A shortcut can be assigned in **Options → Shortcuts** to cycle the five modes on the fly; the status bar names the mode you land on.
 
 ## Bookmarks
 

--- a/src/ui/Assets/Languages/English.json
+++ b/src/ui/Assets/Languages/English.json
@@ -3086,6 +3086,7 @@
       "subtitleGridFormattingShowFormatting": "Show formatting",
       "subtitleGridFormattingShowTags": "Show tags",
       "subtitleGridFormattingHideTags": "Hide tags",
+      "subtitleGridFormattingShowFormattingKeepTags": "Show formatting, keep non-visual tags",
       "waveformParagraphBackgroundColor": "Waveform subtitle background color",
       "waveformParagraphSelectedBackgroundColor": "Waveform selected subtitle background color",
       "waveformAllowOverlap": "Allow overlap (when moving/resizing)",

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -14107,8 +14107,9 @@ public partial class MainViewModel :
     }
 
     // Cycle the grid's Text/Original text formatting mode (issue #12321): "show formatting"
-    // (tags hidden, styling rendered) -> "show tags" -> "no formatting" -> "hide tags"
-    // (tags stripped, plain text - issue #13824). Handy for heavy ASS karaoke tags where the
+    // (tags hidden, styling rendered) -> "show formatting, keep non-visual tags" (styling
+    // rendered, position/animation tags left as text) -> "show tags" -> "no formatting" ->
+    // "hide tags" (tags stripped, plain text - issue #13824). Handy for heavy ASS karaoke tags where the
     // full tag text makes the grid hard to read. The grid cell converter reads the setting
     // live, so re-notifying Text/OriginalText re-renders the rows.
     [RelayCommand]
@@ -14117,6 +14118,11 @@ public partial class MainViewModel :
         int newMode;
         string newModeName;
         if (Se.Settings.Appearance.SubtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowFormatting)
+        {
+            newMode = (int)SubtitleGridFormattingTypes.ShowFormattingKeepTags;
+            newModeName = Se.Language.Options.Settings.SubtitleGridFormattingShowFormattingKeepTags;
+        }
+        else if (Se.Settings.Appearance.SubtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowFormattingKeepTags)
         {
             newMode = (int)SubtitleGridFormattingTypes.ShowTags;
             newModeName = Se.Language.Options.Settings.SubtitleGridFormattingShowTags;

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -496,6 +496,7 @@ public partial class SettingsViewModel : ObservableObject
             Se.Language.Options.Settings.SubtitleGridFormattingShowFormatting,
             Se.Language.Options.Settings.SubtitleGridFormattingShowTags,
             Se.Language.Options.Settings.SubtitleGridFormattingHideTags,
+            Se.Language.Options.Settings.SubtitleGridFormattingShowFormattingKeepTags,
         };
         SubtitleGridFormatting = SubtitleGridFormattings[0];
 
@@ -1425,6 +1426,10 @@ public partial class SettingsViewModel : ObservableObject
         {
             return Se.Language.Options.Settings.SubtitleGridFormattingHideTags;
         }
+        else if (subtitleGridFormattingType == (int)SubtitleGridFormattingTypes.ShowFormattingKeepTags)
+        {
+            return Se.Language.Options.Settings.SubtitleGridFormattingShowFormattingKeepTags;
+        }
         else
         {
             return Se.Language.Options.Settings.SubtitleGridFormattingNone;
@@ -1444,6 +1449,10 @@ public partial class SettingsViewModel : ObservableObject
         else if (translation == Se.Language.Options.Settings.SubtitleGridFormattingHideTags)
         {
             return (int)SubtitleGridFormattingTypes.HideTags;
+        }
+        else if (translation == Se.Language.Options.Settings.SubtitleGridFormattingShowFormattingKeepTags)
+        {
+            return (int)SubtitleGridFormattingTypes.ShowFormattingKeepTags;
         }
         else
         {

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -271,6 +271,7 @@ public class LanguageSettings
     public string SubtitleGridFormattingShowFormatting { get; set; }
     public string SubtitleGridFormattingShowTags { get; set; }
     public string SubtitleGridFormattingHideTags { get; set; }
+    public string SubtitleGridFormattingShowFormattingKeepTags { get; set; }
     public string WaveformParagraphBackgroundColor { get; set; }
     public string WaveformParagraphSelectedBackgroundColor { get; set; }
     public string WaveformAllowOverlap { get; set; }
@@ -590,6 +591,7 @@ public class LanguageSettings
         SubtitleGridFormattingShowFormatting = "Show formatting";
         SubtitleGridFormattingShowTags = "Show tags";
         SubtitleGridFormattingHideTags = "Hide tags";
+        SubtitleGridFormattingShowFormattingKeepTags = "Show formatting, keep non-visual tags";
         WaveformParagraphBackgroundColor = "Waveform subtitle background color";
         WaveformParagraphSelectedBackgroundColor = "Waveform selected subtitle background color";
         WaveformAllowOverlap = "Allow overlap (when moving/resizing)";

--- a/src/ui/Logic/Config/SubtitleGridFormattingTypes.cs
+++ b/src/ui/Logic/Config/SubtitleGridFormattingTypes.cs
@@ -6,4 +6,10 @@ public enum SubtitleGridFormattingTypes
     ShowFormatting = 1,
     ShowTags = 2,
     HideTags = 3,
+
+    /// <summary>
+    /// Like <see cref="ShowFormatting"/>, but tags that have no visible effect in the grid
+    /// (position, alignment, animation, borders...) are kept as text instead of hidden.
+    /// </summary>
+    ShowFormattingKeepTags = 4,
 }

--- a/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
+++ b/src/ui/Logic/ValueConverters/TextWithSubtitleSyntaxHighlightingConverter.cs
@@ -144,8 +144,24 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                 str = str.Substring(0, MaxRawLength);
             }
 
-            var lines = MakeShowFormatting(str);
+            var lines = MakeShowFormatting(str, keepNonVisualTags: false);
             return SpellCheckLines(lines);
+        }
+
+        // "Show formatting, keep non-visual tags" renders the styling like "show formatting" but
+        // leaves the tags the grid cannot render - \pos, \an, \move, \t, \fad, <box>... - as
+        // text, so a positioned or animated line still looks different from a plain one. The
+        // echoed tags carry their own foreground, and skipColouredRuns keeps them out of the
+        // spell check (colored dialogue runs are skipped too, same trade-off as "show tags").
+        if (formattingType == (int)SubtitleGridFormattingTypes.ShowFormattingKeepTags)
+        {
+            if (str.Length > MaxRawLength)
+            {
+                str = str.Substring(0, MaxRawLength);
+            }
+
+            var lines = MakeShowFormatting(str, keepNonVisualTags: true);
+            return SpellCheckLines(lines, skipColouredRuns: true);
         }
 
         // "Hide tags" strips the markup and renders what is left as plain themed text - no
@@ -684,12 +700,33 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         return builder.Build();
     }
 
-    private static InlineCollection MakeShowFormatting(string str)
+    private static InlineCollection MakeShowFormatting(string str, bool keepNonVisualTags)
     {
         // Track current formatting state
         var state = new FormattingState();
         var inlines = new InlineCollection();
         var visibleLength = 0;
+
+        // Echoed tags (keepNonVisualTags) count as visible characters like any other text, and
+        // are cut by the same cap. Returns false when the cap is hit and parsing must stop.
+        bool AppendTagText(string tagText)
+        {
+            if (tagText.Length == 0)
+            {
+                return true;
+            }
+
+            if (visibleLength + tagText.Length > MaxVisibleLength)
+            {
+                var keep = Math.Max(0, MaxVisibleLength - visibleLength - 3);
+                inlines.Add(CreateTagRun(tagText.Substring(0, keep).TrimEnd() + "..."));
+                return false;
+            }
+
+            visibleLength += tagText.Length;
+            inlines.Add(CreateTagRun(tagText));
+            return true;
+        }
 
         // Limit iterations to prevent infinite loops (should never exceed string length)
         var maxIterations = str.Length * 2; // Safety margin
@@ -715,6 +752,16 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                     if (tagEnd - i < MaxParsedTagLength)
                     {
                         ParseAssaTags(str, i + 1, tagEnd, state); // Content between { and }
+                        if (keepNonVisualTags && !AppendTagText(GetNonVisualAssaTags(str, i + 1, tagEnd)))
+                        {
+                            break;
+                        }
+                    }
+                    else if (keepNonVisualTags && !AppendTagText(str.Substring(i, tagEnd + 1 - i)))
+                    {
+                        // Too long to interpret at all - nothing of it was rendered, so all of
+                        // it is shown.
+                        break;
                     }
 
                     i = tagEnd + 1;
@@ -776,6 +823,7 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         contentStart,
                         (tagNameEnd > contentStart ? tagNameEnd : contentEnd) - contentStart);
 
+                    var isRenderedTag = true;
                     if (isClosingTag)
                     {
                         // Handle closing tags
@@ -797,6 +845,10 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                             state.FontName = null;
                             state.FontSize = null;
                         }
+                        else
+                        {
+                            isRenderedTag = false;
+                        }
                     }
                     else
                     {
@@ -817,7 +869,19 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
                         {
                             ParseFontTag(str.AsSpan(contentStart, contentEnd - contentStart), state);
                         }
+                        else
+                        {
+                            isRenderedTag = false;
+                        }
                     }
+
+                    // An HTML tag the grid has no rendering for (<box>, <ruby>, <span>...) is
+                    // echoed as text in the keep-tags mode.
+                    if (keepNonVisualTags && !isRenderedTag && !AppendTagText(str.Substring(i, tagEnd + 1 - i)))
+                    {
+                        break;
+                    }
+
                     i = tagEnd + 1;
                     continue;
                 }
@@ -885,6 +949,104 @@ public class TextWithSubtitleSyntaxHighlightingConverter : IValueConverter
         }
 
         return inlines;
+    }
+
+    /// <summary>
+    /// A run for a tag echoed as text in the keep-tags mode: no dialogue styling, the "show tags"
+    /// element color so it reads as markup rather than as part of the line.
+    /// </summary>
+    private static Run CreateTagRun(string text)
+    {
+        return new Run(text) { Foreground = ElementBrush };
+    }
+
+    /// <summary>
+    /// The override tags in source[start..end) that <see cref="ParseAssaTags"/> does not render
+    /// - everything but reset, italic, bold, underline, font name, font size and primary color -
+    /// re-wrapped in braces, or an empty string when the block was fully rendered. Splits on a
+    /// backslash outside parentheses so a \t(...) transition stays one tag, colors inside it
+    /// included: the transition as a whole is what the grid cannot show.
+    /// </summary>
+    private static string GetNonVisualAssaTags(string source, int start, int end)
+    {
+        var content = source.AsSpan(start, end - start);
+        StringBuilder? sb = null;
+        var pos = 0;
+        while (pos < content.Length)
+        {
+            if (content[pos] != '\\')
+            {
+                pos++;
+                continue;
+            }
+
+            var tagStart = pos;
+            var depth = 0;
+            pos++;
+            while (pos < content.Length)
+            {
+                var ch = content[pos];
+                if (ch == '(')
+                {
+                    depth++;
+                }
+                else if (ch == ')' && depth > 0)
+                {
+                    depth--;
+                }
+                else if (ch == '\\' && depth == 0)
+                {
+                    break;
+                }
+
+                pos++;
+            }
+
+            var tag = content.Slice(tagStart + 1, pos - tagStart - 1).Trim();
+            if (tag.Length == 0 || IsRenderedAssaTag(tag))
+            {
+                continue;
+            }
+
+            sb ??= new StringBuilder(end - start + 2).Append('{');
+            sb.Append('\\').Append(tag);
+        }
+
+        if (sb == null)
+        {
+            return string.Empty;
+        }
+
+        return sb.Append('}').ToString();
+    }
+
+    /// <summary>Mirrors the tags <see cref="ParseAssaTags"/> turns into run formatting.</summary>
+    private static bool IsRenderedAssaTag(ReadOnlySpan<char> tag)
+    {
+        var c0 = tag[0];
+        var c1 = tag.Length > 1 ? tag[1] : '\0';
+        if (c0 == 'r' && tag.Length == 1)
+        {
+            return true;
+        }
+
+        if ((c0 == 'i' || c0 == 'b' || c0 == 'u') && char.IsDigit(c1))
+        {
+            return true;
+        }
+
+        if (c0 == 'f' && (c1 == 'n' || c1 == 's') && tag.Length > 2)
+        {
+            // \fs20 is rendered; \fsp, \fscx and \fscy are not.
+            return c1 == 'n' || char.IsDigit(tag[2]) || tag[2] == '.' || tag[2] == '-';
+        }
+
+        if (c0 == 'c' && (tag.Length == 1 || !char.IsLetterOrDigit(c1)))
+        {
+            return true;
+        }
+
+        return c0 == '1' && c1 == 'c';
     }
 
     /// <summary>

--- a/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
+++ b/tests/UI/Logic/ValueConverters/ValueConverterTests.cs
@@ -452,6 +452,42 @@ public class ValueConverterTests : IDisposable
     }
 
     [AvaloniaFact]
+    public void ShowFormattingKeepTags_RendersStylingButEchoesNonVisualTags()
+    {
+        var inlines = Highlight("{\\an8\\pos(960,540)\\i1\\c&H00FF00&}one",
+            SubtitleGridFormattingTypes.ShowFormattingKeepTags);
+
+        Assert.Equal("{\\an8\\pos(960,540)}one", FlatText(inlines));
+        var tag = Assert.IsType<Run>(inlines[0]);
+        Assert.Equal(FontStyle.Normal, tag.FontStyle);
+        var text = Assert.IsType<Run>(inlines[1]);
+        Assert.Equal(FontStyle.Italic, text.FontStyle);
+        Assert.Equal("one", TextWithColor(inlines, Color.FromRgb(0, 255, 0)));
+    }
+
+    [AvaloniaTheory]
+    [InlineData("{\\i1}<b>x</b>{\\i0}", "x")]                                    // fully rendered - nothing echoed
+    [InlineData("{\\fnArial\\fs20\\r}x", "x")]                                 // font, size, reset are rendered
+    [InlineData("{\\fscx110\\fsp2}x", "{\\fscx110\\fsp2}x")]                  // \\fs prefix but not the size tag
+    [InlineData("{\\t(0,500,\\c&HFF0000&)}x", "{\\t(0,500,\\c&HFF0000&)}x")]  // transition kept whole
+    [InlineData("<box>x</box>", "<box>x</box>")]                              // HTML the grid cannot render
+    [InlineData("<font color=\"#00ff00\">x</font>", "x")]
+    public void ShowFormattingKeepTags_EchoesOnlyWhatIsNotRendered(string text, string expected)
+    {
+        Assert.Equal(expected, FlatText(Highlight(text, SubtitleGridFormattingTypes.ShowFormattingKeepTags)));
+    }
+
+    [AvaloniaFact]
+    public void ShowFormattingKeepTags_EchoedTagsCountTowardTheVisibleCap()
+    {
+        var text = "{\\pos(" + new string('1', 300) + ")}abc";
+
+        var flat = FlatText(Highlight(text, SubtitleGridFormattingTypes.ShowFormattingKeepTags));
+        Assert.EndsWith("...", flat);
+        Assert.True(flat.Length <= 200, flat.Length.ToString());
+    }
+
+    [AvaloniaFact]
     public void ShowTags_ShowsTheMarkupItself()
     {
         var text = "<font color=\"#00ff00\">hi</font>";


### PR DESCRIPTION
## Summary
- New grid formatting option **Show formatting, keep non-visual tags** (Options → Settings → Appearance, and in the toggle shortcut cycle after "Show formatting").
- Styling tags (`\i`, `\b`, `\u`, `\fn`, `\fs`, `\c`/`\1c`, `\r`, `<i>`, `<b>`, `<u>`, `<font>`) are rendered as before; everything else (`\pos`, `\an`, `\move`, `\t(...)`, `\fad`, `\fscx`, `\k`, `<box>`, ...) is echoed as text in the tag color, so a positioned or animated line still looks different from a plain one.
- `\t(...)` transitions are kept whole (paren-aware split), echoed tags count toward the 200-character visible cap and are excluded from live spell check.
- Docs table updated; English strings added.

## Test plan
- [x] `ValueConverterTests` – 9 new tests for rendering/echo split, `\fs` vs `\fscx`/`\fsp`, transitions, HTML `<box>`, and the visible cap (83/83 pass)
- [ ] Manual: cycle the grid formatting shortcut through all five modes; check an ASSA file with `{\pos}`/`{\an8}` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
