### PR TITLE
Subtitle grid: more "Selected lines" context menu items

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -1272,7 +1272,7 @@ public static partial class InitListViewAndEditBox
                 new MenuItem
                 {
                     Header = Se.Language.Main.Menu.TextToSpeech,
-                    Command = vm.ShowVideoTextToSpeechCommand,
+                    Command = vm.ShowVideoTextToSpeechSelectedLinesCommand,
                     DataContext = vm,
                 },
                 new MenuItem
@@ -1286,6 +1286,12 @@ public static partial class InitListViewAndEditBox
                 {
                     Header = Se.Language.Main.Menu.ChangeCasing,
                     Command = vm.ChangeCasingSelectedLinesCommand,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.Main.Menu.ChangeFormatting,
+                    Command = vm.ShowToolsChangeFormattingSelectedLinesCommand,
                     DataContext = vm,
                 },
                 new MenuItem
@@ -1311,6 +1317,18 @@ public static partial class InitListViewAndEditBox
                 {
                     Header = Se.Language.Main.Menu.MultipleReplace,
                     Command = vm.MultipleReplaceSelectedLinesCommand,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.Main.Menu.AdjustDurations,
+                    Command = vm.ShowToolsAdjustDurationsSelectedLinesCommand,
+                    DataContext = vm,
+                },
+                new MenuItem
+                {
+                    Header = Se.Language.Main.Menu.ApplyDurationLimits,
+                    Command = vm.ShowApplyDurationLimitsSelectedLinesCommand,
                     DataContext = vm,
                 },
                 new MenuItem

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -7391,6 +7391,26 @@ public partial class MainViewModel :
         }
     }
 
+    [RelayCommand]
+    private async Task ShowToolsAdjustDurationsSelectedLines()
+    {
+        var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>());
+        if (Window == null || selectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<AdjustDurationWindow, AdjustDurationViewModel>();
+        if (result.OkPressed)
+        {
+            // The whole grid goes in so a selected line is capped against its real neighbour.
+            RunWithoutChangeDetection(() => result.AdjustDuration(Subtitles, selectedItems));
+            _updateAudioVisualizer = true;
+        }
+
+        _shortcutManager.ClearKeys();
+    }
+
     public void RunWithoutChangeDetection(Action action)
     {
         _undoRedoManager.StopChangeDetection();
@@ -7418,10 +7438,29 @@ public partial class MainViewModel :
             return;
         }
 
+        await ApplyDurationLimits(null);
+    }
+
+    [RelayCommand]
+    private async Task ShowApplyDurationLimitsSelectedLines()
+    {
+        var selectedIds = new HashSet<Guid>(SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>().Select(p => p.Id));
+        if (Window == null || selectedIds.Count == 0)
+        {
+            return;
+        }
+
+        await ApplyDurationLimits(selectedIds);
+        _shortcutManager.ClearKeys();
+    }
+
+    /// <param name="onlyIds">Limit fixes to these rows; null fixes the whole subtitle.</param>
+    private async Task ApplyDurationLimits(ISet<Guid>? onlyIds)
+    {
         var result = await ShowDialogAsync<ApplyDurationLimitsWindow, ApplyDurationLimitsViewModel>(vm =>
         {
             var shotChanges = AudioVisualizer?.ShotChanges ?? new List<double>();
-            vm.Initialize(Subtitles.ToList(), shotChanges);
+            vm.Initialize(Subtitles.ToList(), shotChanges, onlyIds);
         });
 
         if (result.OkPressed && result.AllSubtitlesFixed.Count > 0)
@@ -7985,6 +8024,39 @@ public partial class MainViewModel :
         {
             ApplyFixedSubtitle(result.FixedSubtitle, idx);
         }
+    }
+
+    [RelayCommand]
+    private async Task ShowToolsChangeFormattingSelectedLines()
+    {
+        var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>());
+        var ordered = Subtitles.Where(p => selectedItems.Contains(p)).ToList();
+        if (Window == null || ordered.Count == 0)
+        {
+            return;
+        }
+
+        var result = await ShowDialogAsync<ChangeFormattingWindow, ChangeFormattingViewModel>(vm =>
+        {
+            vm.Initialize(ordered, SelectedSubtitleFormat);
+        });
+
+        if (result.OkPressed)
+        {
+            // The dialog works on copies that keep the row ids, so each result maps back to its row.
+            var rowById = ordered.ToDictionary(p => p.Id);
+            foreach (var fixedLine in result.FixedSubtitle)
+            {
+                if (rowById.TryGetValue(fixedLine.Id, out var row))
+                {
+                    row.UpdateFrom(fixedLine);
+                }
+            }
+
+            _updateAudioVisualizer = true;
+        }
+
+        _shortcutManager.ClearKeys();
     }
 
     [RelayCommand]
@@ -11018,6 +11090,51 @@ public partial class MainViewModel :
             return;
         }
 
+        await TextToSpeech(GetUpdateSubtitle(), ShowColumnOriginalText ? GetUpdateSubtitleOriginal() : null, null);
+    }
+
+    [RelayCommand]
+    private async Task ShowVideoTextToSpeechSelectedLines()
+    {
+        var selectedItems = new HashSet<SubtitleLineViewModel>(SubtitleGridSelectedItems.Cast<SubtitleLineViewModel>());
+        var ordered = Subtitles.Where(p => selectedItems.Contains(p) && !p.IsReferenceOnly).ToList();
+        if (Window == null || ordered.Count == 0)
+        {
+            return;
+        }
+
+        var ffmpegOk = await RequireFfmpegOk();
+        if (!ffmpegOk)
+        {
+            return;
+        }
+
+        var sub = new Subtitle();
+        foreach (var line in ordered)
+        {
+            sub.Paragraphs.Add(line.ToParagraph(SelectedSubtitleFormat));
+        }
+
+        Subtitle? original = null;
+        if (ShowColumnOriginalText)
+        {
+            // Built here rather than via GetUpdateSubtitleOriginal, which owns the saved
+            // instance and re-stamps every row's reference id.
+            var originalFormat = _subtitleOriginal?.OriginalFormat ?? SelectedSubtitleFormat;
+            original = new Subtitle();
+            foreach (var line in ordered)
+            {
+                original.Paragraphs.Add(line.ToParagraphOriginal(originalFormat));
+            }
+        }
+
+        await TextToSpeech(sub, original, selectedItems);
+        _shortcutManager.ClearKeys();
+    }
+
+    /// <param name="onlyRows">The rows <paramref name="subtitle"/> was built from, or null for the whole grid.</param>
+    private async Task TextToSpeech(Subtitle subtitle, Subtitle? originalSubtitle, ISet<SubtitleLineViewModel>? onlyRows)
+    {
         var result = await ShowDialogAsync<TextToSpeechWindow, TextToSpeechViewModel>(vm =>
         {
             // Pass SelectedSubtitleFormat explicitly so the TTS window's cast detection uses the
@@ -11026,9 +11143,9 @@ public partial class MainViewModel :
             // The original subtitle travels too when one is loaded: per-line voice cloning cuts
             // its reference from the video, and the original line - not the translation being
             // dubbed - is what is spoken in that clip.
-            vm.Initialize(GetUpdateSubtitle(), SelectedSubtitleFormat,
+            vm.Initialize(subtitle, SelectedSubtitleFormat,
                 _videoFileName ?? string.Empty, AudioVisualizer?.WavePeaks, Path.GetTempPath(),
-                ShowColumnOriginalText ? GetUpdateSubtitleOriginal() : null);
+                originalSubtitle);
         });
 
         // OK is the consent to apply the session's subtitle changes; Cancel/Escape/title-bar
@@ -11043,7 +11160,7 @@ public partial class MainViewModel :
             // diagnosable even with tools logging off (#12626).
             try
             {
-                ApplyTtsChanges(result.MergedSubtitle, result.ReviewTextChanges);
+                ApplyTtsChanges(result.MergedSubtitle, result.ReviewTextChanges, onlyRows);
             }
             catch (Exception ex)
             {
@@ -11094,7 +11211,10 @@ public partial class MainViewModel :
     /// (empty-line removal keeps times) so numbers/indices can't be used. Changes that match no
     /// line (e.g. an imported session for a different subtitle) are ignored silently.
     /// </summary>
-    private void ApplyTtsChanges(Subtitle? mergedSubtitle, List<ReviewTextChange> changes)
+    /// <param name="onlyRows">When the session ran on a selection, the rows it covered: a merge
+    /// may then only swallow rows in that set, since lines adjacent in the selection need not be
+    /// adjacent in the grid.</param>
+    private void ApplyTtsChanges(Subtitle? mergedSubtitle, List<ReviewTextChange> changes, ISet<SubtitleLineViewModel>? onlyRows = null)
     {
         const double toleranceMs = 0.5;
 
@@ -11137,6 +11257,11 @@ public partial class MainViewModel :
             }
 
             if (lastIndex < 0)
+            {
+                continue;
+            }
+
+            if (onlyRows != null && Enumerable.Range(firstIndex, lastIndex - firstIndex + 1).Any(i => !onlyRows.Contains(Subtitles[i])))
             {
                 continue;
             }

--- a/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
+++ b/src/ui/Features/Tools/AdjustDuration/AdjustDurationViewModel.cs
@@ -9,6 +9,7 @@ using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.UiLogic.AdjustDuration;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,6 +32,10 @@ public partial class AdjustDurationViewModel : ObservableObject
 
     public bool OkPressed { get; private set; }
 
+    private ISet<SubtitleLineViewModel>? _onlyLines;
+
+    private bool IsSkipped(SubtitleLineViewModel line) => _onlyLines != null && !_onlyLines.Contains(line);
+
     public AdjustDurationViewModel()
     {
         AdjustTypes = new ObservableCollection<AdjustDurationDisplay>(AdjustDurationDisplay.ListAll());
@@ -38,8 +43,14 @@ public partial class AdjustDurationViewModel : ObservableObject
         LoadSettings();
     }
 
-    public void AdjustDuration(ObservableCollection<SubtitleLineViewModel> subtitles)
+    /// <summary>
+    /// Adjusts every line in <paramref name="subtitles"/>, or only those in <paramref name="onlyLines"/>
+    /// when given. The whole list is still walked so a limited line is capped against its real
+    /// neighbour in the grid, not against the next line that happened to be selected.
+    /// </summary>
+    public void AdjustDuration(ObservableCollection<SubtitleLineViewModel> subtitles, ISet<SubtitleLineViewModel>? onlyLines = null)
     {
+        _onlyLines = onlyLines;
         if (SelectedAdjustType.Type == AdjustDurationType.Seconds)
         {
             DoAdjustViaSeconds(subtitles);
@@ -63,6 +74,11 @@ public partial class AdjustDurationViewModel : ObservableObject
         for (var i = 0; i < subtitles.Count; i++)
         {
             var subtitle = subtitles[i];
+            if (IsSkipped(subtitle))
+            {
+                continue;
+            }
+
             var nextSubtitle = subtitles.GetOrNull(i + 1);
             var newEndTime = subtitle.EndTime + TimeSpan.FromSeconds(AdjustSeconds);
 
@@ -93,6 +109,11 @@ public partial class AdjustDurationViewModel : ObservableObject
         for (int i = 0; i < subtitles.Count; i++)
         {
             var subtitle = subtitles[i];
+            if (IsSkipped(subtitle))
+            {
+                continue;
+            }
+
             var nextSubtitle = subtitles.GetOrNull(i + 1);
             var adjustment = TimeSpan.FromSeconds(AdjustFixed);
             var newEndTime = subtitle.StartTime + adjustment;
@@ -134,6 +155,11 @@ public partial class AdjustDurationViewModel : ObservableObject
         for (int i = 0; i < subtitles.Count; i++)
         {
             var subtitle = subtitles[i];
+            if (IsSkipped(subtitle))
+            {
+                continue;
+            }
+
             var nextSubtitle = subtitles.GetOrNull(i + 1);
 
             var originalDuration = subtitle.EndTime - subtitle.StartTime;
@@ -161,6 +187,11 @@ public partial class AdjustDurationViewModel : ObservableObject
         for (int i = 0; i < subtitles.Count; i++)
         {
             var subtitle = subtitles[i];
+            if (IsSkipped(subtitle))
+            {
+                continue;
+            }
+
             // Count like the grid's CPS column does (tags and line breaks stripped), so the
             // recalculated durations actually land at the requested chars-per-second.
             var charCount = (double)(subtitle.Text ?? string.Empty).CountCharacters(true);

--- a/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
+++ b/src/ui/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModel.cs
@@ -41,6 +41,7 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
     public List<SubtitleLineViewModel> AllSubtitlesFixed { get; set; }
 
     private List<SubtitleLineViewModel> _allSubtitles;
+    private ISet<Guid>? _onlyIds;
 
     private readonly System.Timers.Timer _previewTimer;
     private volatile bool _isClosing;
@@ -133,6 +134,10 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
         {
             var item = new SubtitleLineViewModel(_allSubtitles[index]);
             AllSubtitlesFixed.Add(item);
+            if (_onlyIds != null && !_onlyIds.Contains(item.Id))
+            {
+                continue;
+            }
 
             var next = _allSubtitles.GetOrNull(index + 1);
 
@@ -324,9 +329,12 @@ public partial class ApplyDurationLimitsViewModel : ObservableObject, IClosingCl
         }
     }
 
-    public void Initialize(List<SubtitleLineViewModel> toList, List<double> shotChanges)
+    /// <param name="onlyIds">When given, only lines with these ids are fixed; the rest travel
+    /// through unchanged so a fix is still capped against the real next line.</param>
+    public void Initialize(List<SubtitleLineViewModel> toList, List<double> shotChanges, ISet<Guid>? onlyIds = null)
     {
         _allSubtitles = toList;
+        _onlyIds = onlyIds;
         _shotChanges = shotChanges.OrderBy(p => p).ToList();
         IsDoNotGoPastShotChangeVisible = _shotChanges.Count > 0;
         _previewTimer.Start();

--- a/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
+++ b/tests/UI/Features/Tools/AdjustDuration/AdjustDurationViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Nikse.SubtitleEdit.Features.Main;
 using Nikse.SubtitleEdit.Features.Tools.AdjustDuration;
 using Nikse.SubtitleEdit.UiLogic.AdjustDuration;
@@ -110,5 +111,25 @@ public class AdjustDurationViewModelTests
         vm.AdjustDuration(subtitles);
 
         Assert.Equal(TimeSpan.FromMilliseconds(3400), subtitles[0].EndTime);
+    }
+    [Fact]
+    public void AdjustDuration_OnlySelectedLines_CapsAgainstTheRealNeighbour()
+    {
+        var vm = new AdjustDurationViewModel
+        {
+            SelectedAdjustType = new AdjustDurationDisplay { Type = AdjustDurationType.Seconds },
+            AdjustSeconds = 5,
+        };
+        var first = new SubtitleLineViewModel { Text = "First", StartTime = TimeSpan.FromSeconds(1), EndTime = TimeSpan.FromSeconds(2) };
+        var second = new SubtitleLineViewModel { Text = "Second", StartTime = TimeSpan.FromSeconds(3), EndTime = TimeSpan.FromSeconds(4) };
+        var third = new SubtitleLineViewModel { Text = "Third", StartTime = TimeSpan.FromSeconds(20), EndTime = TimeSpan.FromSeconds(21) };
+        var subtitles = new ObservableCollection<SubtitleLineViewModel> { first, second, third };
+
+        vm.AdjustDuration(subtitles, new HashSet<SubtitleLineViewModel> { first, third });
+
+        // First is capped 10 ms before its real neighbour, not before the next selected line
+        Assert.Equal(TimeSpan.FromMilliseconds(2990), first.EndTime);
+        Assert.Equal(TimeSpan.FromSeconds(4), second.EndTime);
+        Assert.Equal(TimeSpan.FromSeconds(26), third.EndTime);
     }
 }

--- a/tests/UI/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModelTests.cs
+++ b/tests/UI/Features/Tools/ApplyDurationLimits/ApplyDurationLimitsViewModelTests.cs
@@ -75,4 +75,25 @@ public class ApplyDurationLimitsViewModelTests : IDisposable
 
         Assert.Equal(2000, vm.AllSubtitlesFixed[1].Duration.TotalMilliseconds);
     }
+    [AvaloniaFact]
+    public async Task OnlySelectedIdsAreFixedAndTheRestPassThroughUnchanged()
+    {
+        var vm = new ApplyDurationLimitsViewModel();
+        var window = new ApplyDurationLimitsWindow(vm);
+        _windows.Add(window);
+        window.Show();
+        var subtitles = MakeSubtitles();
+        vm.Initialize(subtitles, new List<double>(), new HashSet<Guid> { subtitles[1].Id });
+        Dispatcher.UIThread.RunJobs();
+        vm.FixMinDurationMs = true;
+        vm.MinDurationMs = 1000;
+        vm.FixMaxDurationMs = true;
+        vm.MaxDurationMs = 5000;
+
+        await vm.OkCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, vm.AllSubtitlesFixed.Count);
+        Assert.Equal(200, vm.AllSubtitlesFixed[0].Duration.TotalMilliseconds);
+        Assert.Equal(5000, vm.AllSubtitlesFixed[1].Duration.TotalMilliseconds);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds **Adjust durations...**, **Apply duration limits...** and **Change formatting...** to the subtitle grid's *Selected lines* context submenu, each applied to the selected rows only.
- Adjust durations and Apply duration limits keep walking the whole grid, so a selected line is capped against its real next line rather than the next *selected* line.
- Fixes the submenu's **Text to speech** item, which ran the whole-file command. It now opens the TTS window with just the selected lines (plus their original lines when an original is shown), and a TTS merge can only swallow rows inside the selection.

## Test plan
- [x] `AdjustDurationViewModelTests` and `ApplyDurationLimitsViewModelTests` pass, including two new tests for the selected-rows filters.
- [x] UI project builds.
- Note: `ShorteningStillWorksWhenTheUnusedMinimumIsHigherThanTheMaximum` fails on `main` as well (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
