### PR TITLE
Auto-backup: daily Settings.json snapshots + Settings tab in Restore auto-backup

### DIFF
--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -22,10 +23,21 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
     [ObservableProperty] private ObservableCollection<DisplayFile> _files;
     [ObservableProperty] private bool _isEmptyFilesVisible;
 
+    [ObservableProperty] private int _selectedTabIndex;
+    [ObservableProperty] private DisplayFile? _selectedSettingsFile;
+    [ObservableProperty] private ObservableCollection<DisplayFile> _settingsFiles;
+    [ObservableProperty] private bool _isRestoreSettingsEnabled;
+    [ObservableProperty] private bool _isSettingsFilesVisible;
+    [ObservableProperty] private string _settingsBackupInfo = string.Empty;
+    [ObservableProperty] private string _lastSettingsBackupText = string.Empty;
+
     public Window? Window { get; set; }
     public string? RestoreFileName { get; set; }
 
     public bool OkPressed { get; private set; }
+
+    /// <summary>Set when a settings backup was restored into <see cref="Se.Settings"/> while the window was open.</summary>
+    public bool SettingsRestored { get; private set; }
 
     private readonly IAutoBackupService _autoBackupService;
     private readonly IFolderHelper _folderHelper;
@@ -35,6 +47,7 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         _autoBackupService = autoBackupService;
         _folderHelper = folderHelper;
         Files = new ObservableCollection<DisplayFile>();
+        SettingsFiles = new ObservableCollection<DisplayFile>();
         Initialize();
     }
 
@@ -43,31 +56,73 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         var files = new List<DisplayFile>();
         foreach (var fileName in _autoBackupService.GetAutoBackupFiles())
         {
-            var fileInfo = new FileInfo(fileName);
-
-            var path = Path.GetFileName(fileName);
-            if (string.IsNullOrEmpty(path))
+            var displayFile = MakeDisplayFile(fileName);
+            if (displayFile != null)
             {
-                continue;
+                files.Add(displayFile);
             }
-
-            var displayDate = path[..19].Replace('_', ' ');
-            displayDate = displayDate.Remove(13, 1).Insert(13, ":");
-            displayDate = displayDate.Remove(16, 1).Insert(16, ":");
-
-            files.Add(new DisplayFile(fileName, displayDate, Utilities.FormatBytesToDisplayFileSize(fileInfo.Length)));
         }
 
         foreach (var file in files.OrderByDescending(f => f.DateAndTime))
         {
             Files.Add(file);
         }
-        
+
         if (Files.Count > 0)
         {
             SelectedFile = Files[0];
             IsEmptyFilesVisible = true;
         }
+
+        LoadSettingsBackups();
+    }
+
+    private static DisplayFile? MakeDisplayFile(string fileName)
+    {
+        var path = Path.GetFileName(fileName);
+        if (string.IsNullOrEmpty(path) || path.Length < 19)
+        {
+            return null;
+        }
+
+        var fileInfo = new FileInfo(fileName);
+        var displayDate = path[..19].Replace('_', ' ');
+        displayDate = displayDate.Remove(13, 1).Insert(13, ":");
+        displayDate = displayDate.Remove(16, 1).Insert(16, ":");
+
+        return new DisplayFile(fileName, displayDate, Utilities.FormatBytesToDisplayFileSize(fileInfo.Length));
+    }
+
+    private void LoadSettingsBackups()
+    {
+        var files = new List<DisplayFile>();
+        foreach (var fileName in _autoBackupService.GetSettingsBackupFiles())
+        {
+            var displayFile = MakeDisplayFile(fileName);
+            if (displayFile != null)
+            {
+                files.Add(displayFile);
+            }
+        }
+
+        SettingsFiles.Clear();
+        foreach (var file in files.OrderByDescending(f => f.DateAndTime))
+        {
+            SettingsFiles.Add(file);
+        }
+
+        IsSettingsFilesVisible = SettingsFiles.Count > 0;
+        SelectedSettingsFile = SettingsFiles.FirstOrDefault();
+        IsRestoreSettingsEnabled = SelectedSettingsFile != null;
+
+        var l = Se.Language.File.RestoreAutoBackup;
+        var general = Se.Settings.General;
+        SettingsBackupInfo = general.SettingsBackupOn
+            ? string.Format(l.SettingsBackupInfo, Math.Max(1, general.SettingsBackupIntervalDays), Math.Max(1, general.SettingsBackupMaxCount))
+            : l.SettingsBackupOff;
+        LastSettingsBackupText = SelectedSettingsFile != null
+            ? string.Format(l.LastSettingsBackupX, SettingsFiles[0].DateAndTime)
+            : l.NoSettingsBackupsYet;
     }
 
     [RelayCommand]
@@ -95,19 +150,7 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
 
         // A single locked/read-only file must not abort the sweep and leave the list
         // claiming everything was deleted - keep what could not be removed.
-        var remaining = new List<DisplayFile>();
-        foreach (var file in Files)
-        {
-            try
-            {
-                File.Delete(file.FullPath);
-            }
-            catch (System.Exception exception)
-            {
-                Se.LogError(exception, "Could not delete auto-backup file " + file.FullPath);
-                remaining.Add(file);
-            }
-        }
+        var remaining = DeleteFiles(Files);
 
         Files.Clear();
         foreach (var file in remaining)
@@ -118,6 +161,25 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         IsEmptyFilesVisible = Files.Count > 0;
         SelectedFile = Files.FirstOrDefault();
         IsOkButtonEnabled = SelectedFile != null;
+    }
+
+    private static List<DisplayFile> DeleteFiles(IEnumerable<DisplayFile> files)
+    {
+        var remaining = new List<DisplayFile>();
+        foreach (var file in files)
+        {
+            try
+            {
+                File.Delete(file.FullPath);
+            }
+            catch (Exception exception)
+            {
+                Se.LogError(exception, "Could not delete auto-backup file " + file.FullPath);
+                remaining.Add(file);
+            }
+        }
+
+        return remaining;
     }
 
     [RelayCommand]
@@ -153,12 +215,22 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenFolder()
     {
+        await OpenFolder(Se.AutoBackupFolder);
+    }
+
+    [RelayCommand]
+    private async Task OpenSettingsFolder()
+    {
+        await OpenFolder(Se.SettingsBackupFolder);
+    }
+
+    private async Task OpenFolder(string folder)
+    {
         if (Window == null)
         {
             return;
         }
-        
-        var folder = Se.AutoBackupFolder;
+
         if (!Directory.Exists(folder))
         {
             try
@@ -172,6 +244,107 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         }
 
         await _folderHelper.OpenFolder(Window, folder);
+    }
+
+    [RelayCommand]
+    private async Task BackupSettingsNow()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        // Persist first so the snapshot holds what the user sees, not the last written file.
+        string? backupFileName = null;
+        try
+        {
+            Se.SaveSettings();
+            backupFileName = await Task.Run(() => _autoBackupService.BackupSettingsNow());
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Could not back up settings");
+        }
+
+        LoadSettingsBackups();
+        if (backupFileName != null)
+        {
+            SelectedSettingsFile = SettingsFiles.FirstOrDefault(f => f.FullPath == backupFileName) ?? SelectedSettingsFile;
+        }
+    }
+
+    [RelayCommand]
+    private async Task RestoreSettings()
+    {
+        if (SelectedSettingsFile is not { } file || Window == null || !File.Exists(file.FullPath))
+        {
+            return;
+        }
+
+        var l = Se.Language.File.RestoreAutoBackup;
+        var answer = await MessageBox.Show(
+            Window,
+            l.RestoreSettings,
+            string.Format(l.RestoreSettingsFromX, file.DateAndTime),
+            MessageBoxButtons.YesNoCancel,
+            MessageBoxIcon.Question);
+
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            // Safety net: the settings being replaced get their own backup, so a wrong pick
+            // is itself undoable from this list.
+            Se.SaveSettings();
+            _autoBackupService.BackupSettingsNow();
+
+            // Load into the live Se.Settings and write it back: the main window saves
+            // settings on exit, so a plain file copy would be overwritten by the old
+            // in-memory state a moment later.
+            Se.LoadSettings(file.FullPath);
+            Se.SaveSettings();
+            SettingsRestored = true;
+        }
+        catch (Exception exception)
+        {
+            Se.LogError(exception, "Could not restore settings from " + file.FullPath);
+            LoadSettingsBackups();
+            await MessageBox.Show(Window, l.RestoreSettings, string.Format(l.SettingsRestoreFailed, exception.Message), MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        LoadSettingsBackups();
+        await MessageBox.Show(Window, l.RestoreSettings, l.SettingsRestored, MessageBoxButtons.OK, MessageBoxIcon.Information);
+    }
+
+    [RelayCommand]
+    private async Task DeleteAllSettingsFiles()
+    {
+        if (Window == null)
+        {
+            return;
+        }
+
+        var answer = MessageBoxResult.Yes;
+        if (Se.Settings.General.PromptBeforeDelete)
+        {
+            answer = await MessageBox.Show(
+                Window,
+                Se.Language.General.Delete,
+                Se.Language.File.RestoreAutoBackup.DeleteAllSettingsBackups,
+                MessageBoxButtons.YesNoCancel,
+                MessageBoxIcon.Question);
+        }
+        if (answer != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        DeleteFiles(SettingsFiles);
+        LoadSettingsBackups();
     }
 
     internal void OnKeyDown(KeyEventArgs e)
@@ -198,8 +371,18 @@ public partial class RestoreAutoBackupViewModel : ObservableObject
         IsOkButtonEnabled = value != null;
     }
 
+    partial void OnSelectedSettingsFileChanged(DisplayFile? value)
+    {
+        IsRestoreSettingsEnabled = value != null;
+    }
+
     public void GridSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
         IsOkButtonEnabled = SelectedFile != null;
+    }
+
+    public void SettingsGridSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        IsRestoreSettingsEnabled = SelectedSettingsFile != null;
     }
 }

--- a/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
+++ b/src/ui/Features/Files/RestoreAutoBackup/RestoreAutoBackupWindow.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls.Templates;
 using Avalonia.Media;
 using Avalonia.Data;
 using Avalonia.Layout;
+using Nikse.SubtitleEdit.Controls;
+using Optris.Icons.Avalonia;
 using Nikse.SubtitleEdit.Logic;
 using Nikse.SubtitleEdit.Logic.Config;
 
@@ -23,6 +25,62 @@ public class RestoreAutoBackupWindow : Window
         vm.Window = this;
         DataContext = vm;
 
+        var l = Se.Language.File.RestoreAutoBackup;
+
+        var subtitleGrid = MakeSubtitleGrid(vm);
+        var settingsGrid = MakeSettingsGrid(vm);
+
+        var tabControl = new TabControl
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            Items =
+            {
+                new TabItem
+                {
+                    Header = MakeTabHeader(IconNames.ClosedCaption, l.Subtitles),
+                    Content = MakeSubtitlesView(vm, subtitleGrid),
+                },
+                new TabItem
+                {
+                    Header = MakeTabHeader(IconNames.Settings, l.Settings),
+                    Content = MakeSettingsView(vm, settingsGrid),
+                },
+            },
+        };
+        tabControl.Bind(TabControl.SelectedIndexProperty, new Binding(nameof(vm.SelectedTabIndex)) { Source = vm, Mode = BindingMode.TwoWay });
+
+        var buttonOk = UiUtil.MakeButtonOk(vm.CancelCommand);
+        var panelButtons = UiUtil.MakeButtonBar(buttonOk);
+
+        var grid = new Grid
+        {
+            RowDefinitions =
+            {
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+            },
+            Margin = UiUtil.MakeWindowMargin(),
+            RowSpacing = 4,
+            Width = double.NaN,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        grid.Children.Add(tabControl);
+        Grid.SetRow(tabControl, 0);
+
+        grid.Children.Add(panelButtons);
+        Grid.SetRow(panelButtons, 1);
+
+        Content = grid;
+
+        // Initial focus on an input, not an action button - a focused button clicks on bare Space.
+        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(vm.SelectedTabIndex == 1 ? settingsGrid : subtitleGrid); });
+        KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    private static TableView MakeSubtitleGrid(RestoreAutoBackupViewModel vm)
+    {
         var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
         dataGrid.Width = double.NaN;
         dataGrid.Height = double.NaN;
@@ -32,14 +90,7 @@ public class RestoreAutoBackupWindow : Window
         // star, so the narrow columns get fixed widths and the file name is the star column.
         dataGrid.Columns.AddRange(new[]
         {
-                new SeTableViewColumn
-                {
-                    Header = Se.Language.General.DateAndTime,
-                    Binding = new Binding(nameof(DisplayFile.DateAndTime)),
-                    Width = new GridLength(160),
-                    CellTheme = UiUtil.TableViewCellTheme,
-                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                },
+                MakeDateColumn(),
                 new SeTableViewColumn
                 {
                     Header = Se.Language.General.FileName,
@@ -48,58 +99,49 @@ public class RestoreAutoBackupWindow : Window
                     CellTheme = UiUtil.TableViewCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                 },
-                new SeTableViewColumn
-                {
-                    Header = Se.Language.General.FileExtension,
-                    Width = new GridLength(110),
-                    CellTheme = UiUtil.TableViewNoPaddingCellTheme,
-                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                    CellTemplate = new FuncDataTemplate<DisplayFile>((item, _) =>
-                    {
-                        if (item == null)
-                        {
-                            return new Border();
-                        }
-
-                        var color = GetExtensionColor(item.Extension);
-                        return new Border
-                        {
-                            Background = Brushes.Transparent,
-                            Padding = new Thickness(4, 2),
-                            Child = new Border
-                            {
-                                Background = new SolidColorBrush(Color.FromArgb(0x20, color.R, color.G, color.B)),
-                                CornerRadius = new CornerRadius(5),
-                                Padding = new Thickness(7, 2),
-                                HorizontalAlignment = HorizontalAlignment.Left,
-                                VerticalAlignment = VerticalAlignment.Center,
-                                Child = new TextBlock
-                                {
-                                    Text = item.Extension,
-                                    FontSize = 12,
-                                    Foreground = new SolidColorBrush(color),
-                                    VerticalAlignment = VerticalAlignment.Center,
-                                },
-                            },
-                        };
-                    }),
-                },
-                new SeTableViewColumn
-                {
-                    Header = Se.Language.General.Size,
-                    Binding = new Binding(nameof(DisplayFile.Size)),
-                    Width = new GridLength(90),
-                    CellTheme = UiUtil.TableViewCellTheme,
-                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
-                }
+                MakeExtensionColumn(),
+                MakeSizeColumn(),
         });
 
         dataGrid.Bind(TableView.ItemsSourceProperty, new Binding(nameof(vm.Files)));
         dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedFile)));
         dataGrid.SelectionChanged += vm.GridSelectionChanged;
+        return dataGrid;
+    }
 
-        var linkOpenFolder = UiUtil.MakeLink(Se.Language.File.RestoreAutoBackup.OpenAutoBackupFolder, vm.OpenFolderCommand);
+    private static TableView MakeSettingsGrid(RestoreAutoBackupViewModel vm)
+    {
+        var dataGrid = TableViewExtras.MakeTableView(multiSelect: false);
+        dataGrid.Width = double.NaN;
+        dataGrid.Height = double.NaN;
+        dataGrid.DataContext = vm;
 
+        dataGrid.Columns.AddRange(new[]
+        {
+                MakeDateColumn(),
+                new SeTableViewColumn
+                {
+                    Header = Se.Language.General.FileName,
+                    Binding = new Binding(nameof(DisplayFile.FileName)),
+                    Width = new GridLength(1, GridUnitType.Star),
+                    CellTheme = UiUtil.TableViewCellTheme,
+                    HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+                },
+                MakeExtensionColumn(),
+                MakeSizeColumn(),
+        });
+
+        dataGrid.Bind(TableView.ItemsSourceProperty, new Binding(nameof(vm.SettingsFiles)));
+        dataGrid.Bind(TableView.SelectedItemProperty, new Binding(nameof(vm.SelectedSettingsFile)));
+        dataGrid.SelectionChanged += vm.SettingsGridSelectionChanged;
+        return dataGrid;
+    }
+
+    private static Control MakeSubtitlesView(RestoreAutoBackupViewModel vm, TableView dataGrid)
+    {
+        var l = Se.Language.File.RestoreAutoBackup;
+
+        var linkOpenFolder = UiUtil.MakeLink(l.OpenAutoBackupFolder, vm.OpenFolderCommand);
         var summaryText = new TextBlock
         {
             VerticalAlignment = VerticalAlignment.Center,
@@ -107,63 +149,226 @@ public class RestoreAutoBackupWindow : Window
             Margin = new Thickness(10, 0, 0, 0),
             [!TextBlock.TextProperty] = new Binding($"{nameof(vm.Files)}.{nameof(vm.Files.Count)}")
             {
-                StringFormat = Se.Language.File.RestoreAutoBackup.XBackups
+                StringFormat = l.XBackups
             }
         };
 
-        var buttonDeleteAllSubtitles = UiUtil.MakeButton(Se.Language.File.RestoreAutoBackup.DeleteAll, vm.DeleteAllFilesCommand)
+        var buttonDeleteAll = UiUtil.MakeButton(l.DeleteAll, vm.DeleteAllFilesCommand)
             .WithBindIsVisible(nameof(vm.IsEmptyFilesVisible))
             .WithIconLeft("fa-solid fa-trash");
-        var buttonRestore = UiUtil.MakeButton(Se.Language.File.RestoreAutoBackup.RestoreAutoBackupFile, vm.RestoreFileCommand)
+        var buttonRestore = UiUtil.MakeButton(l.RestoreAutoBackupFile, vm.RestoreFileCommand)
             .WithIconLeft("fa-solid fa-clock-rotate-left");
         buttonRestore.BindIsEnabled(vm, nameof(vm.IsOkButtonEnabled));
-        var buttonOk = UiUtil.MakeButtonOk(vm.CancelCommand);
-        var panelButtons = UiUtil.MakeButtonBar(buttonDeleteAllSubtitles, buttonRestore, buttonOk);
 
+        return MakeTabLayout(dataGrid, null, linkOpenFolder, summaryText, buttonDeleteAll, buttonRestore);
+    }
+
+    private static Control MakeSettingsView(RestoreAutoBackupViewModel vm, TableView dataGrid)
+    {
+        var l = Se.Language.File.RestoreAutoBackup;
+
+        var icon = new ContentControl
+        {
+            Width = 18,
+            Height = 18,
+            Opacity = 0.8,
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, 1, 0, 0),
+        };
+        Attached.SetIcon(icon, IconNames.Information);
+
+        var infoText = new TextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.SettingsBackupInfo)),
+        };
+        var lastBackupText = new TextBlock
+        {
+            Opacity = 0.75,
+            FontSize = 12,
+            [!TextBlock.TextProperty] = new Binding(nameof(vm.LastSettingsBackupText)),
+        };
+
+        var infoPanel = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0x18, 0x4c, 0x9c, 0xe8)),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x50, 0x4c, 0x9c, 0xe8)),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Padding = new Thickness(12, 10),
+            Child = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition { Width = GridLength.Auto },
+                    new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+                },
+                ColumnSpacing = 10,
+                Children =
+                {
+                    icon,
+                    new StackPanel
+                    {
+                        Spacing = 3,
+                        [Grid.ColumnProperty] = 1,
+                        Children = { infoText, lastBackupText },
+                    },
+                },
+            },
+        };
+
+        var linkOpenFolder = UiUtil.MakeLink(l.OpenSettingsBackupFolder, vm.OpenSettingsFolderCommand);
+        var summaryText = new TextBlock
+        {
+            VerticalAlignment = VerticalAlignment.Center,
+            Opacity = 0.8,
+            Margin = new Thickness(10, 0, 0, 0),
+            [!TextBlock.TextProperty] = new Binding($"{nameof(vm.SettingsFiles)}.{nameof(vm.SettingsFiles.Count)}")
+            {
+                StringFormat = l.XBackups
+            }
+        };
+
+        var buttonDeleteAll = UiUtil.MakeButton(l.DeleteAll, vm.DeleteAllSettingsFilesCommand)
+            .WithBindIsVisible(nameof(vm.IsSettingsFilesVisible))
+            .WithIconLeft("fa-solid fa-trash");
+        var buttonBackupNow = UiUtil.MakeButton(l.BackUpSettingsNow, vm.BackupSettingsNowCommand)
+            .WithIconLeft("fa-solid fa-floppy-disk");
+        var buttonRestore = UiUtil.MakeButton(l.RestoreSettings, vm.RestoreSettingsCommand)
+            .WithIconLeft("fa-solid fa-clock-rotate-left");
+        buttonRestore.BindIsEnabled(vm, nameof(vm.IsRestoreSettingsEnabled));
+
+        return MakeTabLayout(dataGrid, infoPanel, linkOpenFolder, summaryText, buttonDeleteAll, buttonBackupNow, buttonRestore);
+    }
+
+    /// <summary>Shared tab body: optional header, the list, then a bottom row with links left and actions right.</summary>
+    private static Grid MakeTabLayout(TableView dataGrid, Control? header, Control link, Control summary, params Control[] buttons)
+    {
         var grid = new Grid
         {
             RowDefinitions =
             {
+                new RowDefinition { Height = GridLength.Auto },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
-                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = GridLength.Auto },
             },
             ColumnDefinitions =
             {
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+                new ColumnDefinition { Width = GridLength.Auto },
             },
-            Margin = UiUtil.MakeWindowMargin(),
-            ColumnSpacing = 10,
+            Margin = new Thickness(0, 10, 0, 0),
             RowSpacing = 10,
-            Width = double.NaN,
+            ColumnSpacing = 10,
             HorizontalAlignment = HorizontalAlignment.Stretch,
         };
 
+        if (header != null)
+        {
+            grid.Children.Add(header);
+            Grid.SetRow(header, 0);
+            Grid.SetColumnSpan(header, 2);
+        }
+
         grid.Children.Add(dataGrid);
-        Grid.SetRow(dataGrid, 0);
-        Grid.SetColumn(dataGrid, 0);
+        Grid.SetRow(dataGrid, 1);
         Grid.SetColumnSpan(dataGrid, 2);
 
         var panelBottomLeft = new StackPanel
         {
-            Orientation = Avalonia.Layout.Orientation.Horizontal,
-            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
-            Children = { linkOpenFolder, summaryText },
+            Orientation = Orientation.Horizontal,
+            VerticalAlignment = VerticalAlignment.Center,
+            Children = { link, summary },
         };
         grid.Children.Add(panelBottomLeft);
-        Grid.SetRow(panelBottomLeft, 1);
+        Grid.SetRow(panelBottomLeft, 2);
         Grid.SetColumn(panelBottomLeft, 0);
 
+        var panelButtons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        panelButtons.Children.AddRange(buttons);
         grid.Children.Add(panelButtons);
-        Grid.SetRow(panelButtons, 1);
-        Grid.SetColumn(panelButtons, 0);
-        Grid.SetColumnSpan(panelButtons, 2);
+        Grid.SetRow(panelButtons, 2);
+        Grid.SetColumn(panelButtons, 1);
 
-        Content = grid;
-
-        UiUtil.FocusOnFirstActivation(this, () => { TableViewExtras.FocusRow(dataGrid); }); // initial focus on an input, not an action button - a focused button clicks on bare Space
-        KeyDown += (_, e) => vm.OnKeyDown(e);
+        return grid;
     }
+
+    private static StackPanel MakeTabHeader(string iconName, string text)
+    {
+        var icon = new ContentControl { VerticalAlignment = VerticalAlignment.Center };
+        Attached.SetIcon(icon, iconName);
+
+        return new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+            Children =
+            {
+                icon,
+                new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center },
+            },
+        };
+    }
+
+    private static SeTableViewColumn MakeDateColumn() => new()
+    {
+        Header = Se.Language.General.DateAndTime,
+        Binding = new Binding(nameof(DisplayFile.DateAndTime)),
+        Width = new GridLength(160),
+        CellTheme = UiUtil.TableViewCellTheme,
+        HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+    };
+
+    private static SeTableViewColumn MakeSizeColumn() => new()
+    {
+        Header = Se.Language.General.Size,
+        Binding = new Binding(nameof(DisplayFile.Size)),
+        Width = new GridLength(90),
+        CellTheme = UiUtil.TableViewCellTheme,
+        HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+    };
+
+    private static SeTableViewColumn MakeExtensionColumn() => new()
+    {
+        Header = Se.Language.General.FileExtension,
+        Width = new GridLength(110),
+        CellTheme = UiUtil.TableViewNoPaddingCellTheme,
+        HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
+        CellTemplate = new FuncDataTemplate<DisplayFile>((item, _) =>
+        {
+            if (item == null)
+            {
+                return new Border();
+            }
+
+            var color = GetExtensionColor(item.Extension);
+            return new Border
+            {
+                Background = Brushes.Transparent,
+                Padding = new Thickness(4, 2),
+                Child = new Border
+                {
+                    Background = new SolidColorBrush(Color.FromArgb(0x20, color.R, color.G, color.B)),
+                    CornerRadius = new CornerRadius(5),
+                    Padding = new Thickness(7, 2),
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Child = new TextBlock
+                    {
+                        Text = item.Extension,
+                        FontSize = 12,
+                        Foreground = new SolidColorBrush(color),
+                        VerticalAlignment = VerticalAlignment.Center,
+                    },
+                },
+            };
+        }),
+    };
 
     private static readonly Color[] ExtensionPalette =
     {

--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -1111,6 +1111,18 @@ public partial class MainViewModel :
 
         StartTimers();
         _autoBackupService.StartAutoBackup(this);
+        // Daily Settings.json snapshot; file I/O, so keep it off the start-up path.
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                _autoBackupService.BackupSettingsIfDue();
+            }
+            catch (Exception ex)
+            {
+                Se.LogError(ex, "Settings backup failed");
+            }
+        });
         // Polling interval lives on UndoRedoManager's field default (see the
         // comment on _detectionInterval) so it can be tuned in one place
         // without callers overriding it back to a longer value (#11280).

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -483,6 +483,10 @@ public class SettingsPage : UserControl
             MakeCheckboxSetting(Se.Language.Options.Settings.AutoBackupOn, nameof(_vm.AutoBackupOn)),
             MakeNumericSettingInt(Se.Language.Options.Settings.AutoBackupIntervalMinutes, nameof(_vm.AutoBackupIntervalMinutes), 1),
             MakeNumericSettingInt(Se.Language.Options.Settings.AutoBackupDeleteAfterDays, nameof(_vm.AutoBackupDeleteAfterDays), 1),
+            MakeSeparator(),
+            MakeCheckboxSetting(Se.Language.Options.Settings.SettingsBackupOn, nameof(_vm.SettingsBackupOn)),
+            MakeNumericSettingInt(Se.Language.Options.Settings.SettingsBackupIntervalDays, nameof(_vm.SettingsBackupIntervalDays), 1),
+            MakeNumericSettingInt(Se.Language.Options.Settings.SettingsBackupMaxCount, nameof(_vm.SettingsBackupMaxCount), 1),
         ]));
 
         sections.Add(new SettingsSection(Se.Language.General.SubtitleFormats, IconNames.ClosedCaption, "#7fa8f0",

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -140,6 +140,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _autoBackupOn;
     [ObservableProperty] private int? _autoBackupIntervalMinutes;
     [ObservableProperty] private int? _autoBackupDeleteAfterDays;
+    [ObservableProperty] private bool _settingsBackupOn;
+    [ObservableProperty] private int? _settingsBackupIntervalDays;
+    [ObservableProperty] private int? _settingsBackupMaxCount;
 
     [ObservableProperty] private ObservableCollection<string> _defaultSubtitleFormats;
     [ObservableProperty] private string _selectedDefaultSubtitleFormat;
@@ -773,6 +776,9 @@ public partial class SettingsViewModel : ObservableObject
         AutoBackupOn = general.AutoBackupOn;
         AutoBackupIntervalMinutes = general.AutoBackupIntervalMinutes;
         AutoBackupDeleteAfterDays = general.AutoBackupDeleteAfterDays;
+        SettingsBackupOn = general.SettingsBackupOn;
+        SettingsBackupIntervalDays = general.SettingsBackupIntervalDays;
+        SettingsBackupMaxCount = general.SettingsBackupMaxCount;
         DefaultEncoding = Encodings.FirstOrDefault(e => e.DisplayName == general.DefaultEncoding) ?? Encodings.First();
         SelectedSubtitleEnterKeyActionType = MapFromSelectedSubtitleEnterKeyAction(Se.Settings.General.SubtitleEnterKeyAction);
         SelectedSubtitleSingleClickActionType = MapFromSelectedSubtitleSingleClickAction(Se.Settings.General.SubtitleSingleClickAction);
@@ -1648,6 +1654,9 @@ public partial class SettingsViewModel : ObservableObject
         general.AutoBackupOn = AutoBackupOn;
         general.AutoBackupIntervalMinutes = AutoBackupIntervalMinutes ?? general.AutoBackupIntervalMinutes;
         general.AutoBackupDeleteAfterDays = AutoBackupDeleteAfterDays ?? general.AutoBackupDeleteAfterDays;
+        general.SettingsBackupOn = SettingsBackupOn;
+        general.SettingsBackupIntervalDays = SettingsBackupIntervalDays ?? general.SettingsBackupIntervalDays;
+        general.SettingsBackupMaxCount = SettingsBackupMaxCount ?? general.SettingsBackupMaxCount;
         general.DefaultEncoding = DefaultEncoding?.DisplayName ?? Encodings.First().DisplayName;
         general.SubtitleEnterKeyAction = MapToSelectedSubtitleEnterKeyAction(SelectedSubtitleEnterKeyActionType);
         general.SubtitleSingleClickAction = MapToSelectedSubtitleSingleClickAction(SelectedSubtitleSingleClickActionType);

--- a/src/ui/Logic/AutoBackupService.cs
+++ b/src/ui/Logic/AutoBackupService.cs
@@ -19,6 +19,15 @@ public interface IAutoBackupService
     void StopAutobackup();
     public List<string> GetAutoBackupFiles();
     public void CleanAutoBackupFolder();
+
+    /// <summary>Copies Settings.json to the settings backup folder if the newest backup is older than the configured interval.</summary>
+    void BackupSettingsIfDue();
+
+    /// <summary>Copies Settings.json to the settings backup folder regardless of the interval; returns the backup path, or null when nothing was written.</summary>
+    string? BackupSettingsNow();
+
+    List<string> GetSettingsBackupFiles();
+    void CleanSettingsBackupFolder();
 }
 
 public partial class AutoBackupService : IAutoBackupService
@@ -172,6 +181,148 @@ public partial class AutoBackupService : IAutoBackupService
         }
 
         return result;
+    }
+
+    private const string SettingsBackupSuffix = "_Settings.json";
+    private const string SettingsBackupTimeFormat = "yyyy-MM-dd_HH-mm-ss";
+    private static readonly Lock SettingsBackupLocker = new Lock();
+
+    public void BackupSettingsIfDue()
+    {
+        if (!Se.Settings.General.SettingsBackupOn)
+        {
+            return;
+        }
+
+        var intervalDays = Math.Max(1, Se.Settings.General.SettingsBackupIntervalDays);
+        lock (SettingsBackupLocker)
+        {
+            var newest = GetNewestSettingsBackupTime(Se.SettingsBackupFolder);
+            if (newest.HasValue && newest.Value > DateTime.Now.AddDays(-intervalDays))
+            {
+                return;
+            }
+
+            CopySettingsToBackupFolder();
+        }
+
+        CleanSettingsBackupFolder();
+    }
+
+    public string? BackupSettingsNow()
+    {
+        string? result;
+        lock (SettingsBackupLocker)
+        {
+            result = CopySettingsToBackupFolder();
+        }
+
+        CleanSettingsBackupFolder();
+        return result;
+    }
+
+    private static string? CopySettingsToBackupFolder()
+    {
+        var settingsFileName = Se.GetSettingsFilePath();
+        if (!File.Exists(settingsFileName))
+        {
+            return null;
+        }
+
+        var folder = Se.SettingsBackupFolder;
+        try
+        {
+            Directory.CreateDirectory(folder);
+            var target = Path.Combine(folder, DateTime.Now.ToString(SettingsBackupTimeFormat, CultureInfo.InvariantCulture) + SettingsBackupSuffix);
+            File.Copy(settingsFileName, target, overwrite: true);
+            return target;
+        }
+        catch (Exception exception)
+        {
+            // A backup that cannot be written must not disturb start-up.
+            Se.LogError(exception, "Could not back up settings");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Time stamp of the newest settings backup, read from the file name rather than the file
+    /// system so a copied or touched backup folder does not postpone the next backup.
+    /// </summary>
+    internal static DateTime? GetNewestSettingsBackupTime(string folder)
+    {
+        DateTime? newest = null;
+        foreach (var fileName in GetSettingsBackupFiles(folder))
+        {
+            var time = ParseSettingsBackupTime(fileName);
+            if (time.HasValue && (!newest.HasValue || time.Value > newest.Value))
+            {
+                newest = time;
+            }
+        }
+
+        return newest;
+    }
+
+    internal static DateTime? ParseSettingsBackupTime(string fileName)
+    {
+        var name = Path.GetFileName(fileName);
+        if (name.Length < SettingsBackupTimeFormat.Length ||
+            !DateTime.TryParseExact(name[..SettingsBackupTimeFormat.Length], SettingsBackupTimeFormat,
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var time))
+        {
+            return null;
+        }
+
+        return time;
+    }
+
+    public List<string> GetSettingsBackupFiles() => GetSettingsBackupFiles(Se.SettingsBackupFolder);
+
+    internal static List<string> GetSettingsBackupFiles(string folder)
+    {
+        var result = new List<string>();
+        if (!Directory.Exists(folder))
+        {
+            return result;
+        }
+
+        foreach (var fileName in Directory.GetFiles(folder, "*" + SettingsBackupSuffix))
+        {
+            if (RegexFileNamePattern().IsMatch(Path.GetFileName(fileName)))
+            {
+                result.Add(fileName);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Keeps only the newest <see cref="SeGeneral.SettingsBackupMaxCount"/> settings backups.</summary>
+    public void CleanSettingsBackupFolder()
+    {
+        var keep = Math.Max(1, Se.Settings.General.SettingsBackupMaxCount);
+        lock (SettingsBackupLocker)
+        {
+            foreach (var fileName in GetSettingsBackupFilesToDelete(Se.SettingsBackupFolder, keep))
+            {
+                try
+                {
+                    File.Delete(fileName);
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+    }
+
+    internal static List<string> GetSettingsBackupFilesToDelete(string folder, int keep)
+    {
+        var files = GetSettingsBackupFiles(folder);
+        files.Sort((a, b) => string.CompareOrdinal(Path.GetFileName(b), Path.GetFileName(a))); // newest first
+        return files.Count <= keep ? new List<string>() : files.GetRange(keep, files.Count - keep);
     }
 
     private static readonly Lock Locker = new Lock();

--- a/src/ui/Logic/Config/Language/File/LanguageRestoreAutoBackup.cs
+++ b/src/ui/Logic/Config/Language/File/LanguageRestoreAutoBackup.cs
@@ -9,6 +9,20 @@ public class LanguageRestoreAutoBackup
     public string RestoreXFromY { get; set; }
     public string DeleteAllSubtitleBackups { get; set; }
     public string DeleteAll { get; set; }
+    public string Subtitles { get; set; }
+    public string Settings { get; set; }
+    public string SettingsBackupInfo { get; set; }
+    public string SettingsBackupOff { get; set; }
+    public string LastSettingsBackupX { get; set; }
+    public string NoSettingsBackupsYet { get; set; }
+    public string OpenSettingsBackupFolder { get; set; }
+    public string BackUpSettingsNow { get; set; }
+    public string SettingsBackedUp { get; set; }
+    public string RestoreSettings { get; set; }
+    public string RestoreSettingsFromX { get; set; }
+    public string SettingsRestored { get; set; }
+    public string SettingsRestoreFailed { get; set; }
+    public string DeleteAllSettingsBackups { get; set; }
 
     public LanguageRestoreAutoBackup()
     {
@@ -19,5 +33,19 @@ public class LanguageRestoreAutoBackup
         RestoreXFromY = "Do you want to restore \"{0}\" from {1}?";
         DeleteAllSubtitleBackups = "Do you want to delete all subtitle backup files?";
         DeleteAll = "Delete all";
+        Subtitles = "Subtitles";
+        Settings = "Settings";
+        SettingsBackupInfo = "Settings.json is backed up when Subtitle Edit starts, at most once every {0} day(s). The newest {1} backups are kept.";
+        SettingsBackupOff = "Automatic settings backup is turned off (Options → Settings → File).";
+        LastSettingsBackupX = "Last backup: {0}";
+        NoSettingsBackupsYet = "No settings backups yet";
+        OpenSettingsBackupFolder = "Open settings backup folder";
+        BackUpSettingsNow = "Back up now";
+        SettingsBackedUp = "Current settings were backed up.";
+        RestoreSettings = "Restore settings";
+        RestoreSettingsFromX = "Do you want to replace your current settings with the backup from {0}?\n\nYour current settings will be backed up first. Some changes only take effect after restarting Subtitle Edit.";
+        SettingsRestored = "Settings were restored. Please restart Subtitle Edit for all changes to take effect.";
+        SettingsRestoreFailed = "Could not restore settings: {0}";
+        DeleteAllSettingsBackups = "Do you want to delete all settings backup files?";
     }
 }

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -106,6 +106,9 @@ public class LanguageSettings
     public string AutoBackupOn { get; set; }
     public string AutoBackupIntervalMinutes { get; set; }
     public string AutoBackupDeleteAfterDays { get; set; }
+    public string SettingsBackupOn { get; set; }
+    public string SettingsBackupIntervalDays { get; set; }
+    public string SettingsBackupMaxCount { get; set; }
     public string AutoConvertToUtf8 { get; set; }
     public string AutoTrimWhiteSpace { get; set; }
     public string RemoveBlankLinesWhenOpening { get; set; }
@@ -426,6 +429,9 @@ public class LanguageSettings
         AutoBackupOn = "Auto-backup";
         AutoBackupIntervalMinutes = "Auto-backup interval (minutes)";
         AutoBackupDeleteAfterDays = "Auto-backup retention (days)";
+        SettingsBackupOn = "Auto-backup settings";
+        SettingsBackupIntervalDays = "Settings backup interval (days)";
+        SettingsBackupMaxCount = "Settings backups to keep";
         AutoConvertToUtf8 = "Auto-convert encoding to UTF-8 on open";
         AutoTrimWhiteSpace = "Auto-trim white-space";
         RemoveBlankLinesWhenOpening = "Remove blank lines when opening a subtitle";

--- a/src/ui/Logic/Config/Se.cs
+++ b/src/ui/Logic/Config/Se.cs
@@ -183,6 +183,12 @@ public class Se
     public static string ThemesFolder => Path.Combine(DataFolder, "Themes");
     public static string FontsFolder => Path.Combine(DataFolder, "Fonts");
     public static string AutoBackupFolder => Path.Combine(DataFolder, "AutoBackup");
+
+    /// <summary>
+    /// Daily copies of Settings.json. A sub-folder of the subtitle auto-backup folder so the
+    /// non-recursive subtitle scan never lists them, and so both live under one place to clean.
+    /// </summary>
+    public static string SettingsBackupFolder => Path.Combine(AutoBackupFolder, "Settings");
     public static string FfmpegFolder => Path.Combine(DataFolder, "ffmpeg");
     public static string TextToSpeechFolder => Path.Combine(DataFolder, "TextToSpeech");
     public static string SpeechToTextFolder => Path.Combine(DataFolder, "SpeechToText");

--- a/src/ui/Logic/Config/SeGeneral.cs
+++ b/src/ui/Logic/Config/SeGeneral.cs
@@ -110,6 +110,9 @@ public class SeGeneral
     public bool AutoBackupOn { get; set; }
     public int AutoBackupIntervalMinutes { get; set; }
     public int AutoBackupDeleteAfterDays { get; set; }
+    public bool SettingsBackupOn { get; set; }
+    public int SettingsBackupIntervalDays { get; set; }
+    public int SettingsBackupMaxCount { get; set; }
     public bool ForceCrLfOnSave { get; set; }
 
     /// <summary>
@@ -264,6 +267,9 @@ public class SeGeneral
         AutoBackupOn = true;
         AutoBackupIntervalMinutes = 5;
         AutoBackupDeleteAfterDays = 90;
+        SettingsBackupOn = true;
+        SettingsBackupIntervalDays = 1;
+        SettingsBackupMaxCount = 30;
         DefaultSaveAsFormat = new SubRip().FriendlyName;
         FavoriteSubtitleFormats = new SubRip().FriendlyName + ";" + new AdvancedSubStationAlpha().FriendlyName;
         FavoriteLanguages = string.Empty;

--- a/tests/UI/Features/Files/SettingsBackupTests.cs
+++ b/tests/UI/Features/Files/SettingsBackupTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Features.Files.RestoreAutoBackup;
+using Nikse.SubtitleEdit.Features.Main;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+
+namespace UITests.Features.Files;
+
+/// <summary>
+/// Settings.json gets a daily snapshot next to the subtitle auto-backups. The rotation and
+/// "is a backup due" decisions read the time stamp from the file name, so a copied folder
+/// (fresh write times) neither postpones the next backup nor changes which files are pruned.
+/// </summary>
+public class SettingsBackupTests
+{
+    [Fact]
+    public void ParseSettingsBackupTime_ReadsTheFileNamePrefix()
+    {
+        var time = AutoBackupService.ParseSettingsBackupTime(@"C:\x\2026-09-12_08-30-05_Settings.json");
+
+        Assert.Equal(new DateTime(2026, 9, 12, 8, 30, 5), time);
+        Assert.Null(AutoBackupService.ParseSettingsBackupTime("Settings.json"));
+        Assert.Null(AutoBackupService.ParseSettingsBackupTime("2026-13-40_99-00-00_Settings.json"));
+    }
+
+    [Fact]
+    public void GetSettingsBackupFilesToDelete_KeepsTheNewestByName()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-settings-backup-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        try
+        {
+            var names = new[]
+            {
+                "2026-09-10_10-00-00_Settings.json",
+                "2026-09-12_10-00-00_Settings.json",
+                "2026-09-11_10-00-00_Settings.json",
+                "2026-09-09_10-00-00_Settings.json",
+            };
+            foreach (var name in names)
+            {
+                File.WriteAllText(Path.Combine(folder, name), "{}");
+            }
+
+            // Unrelated files in the folder are never touched.
+            File.WriteAllText(Path.Combine(folder, "notes.txt"), "keep");
+            File.WriteAllText(Path.Combine(folder, "2026-09-12_10-00-00_Other.json"), "keep");
+
+            var toDelete = AutoBackupService.GetSettingsBackupFilesToDelete(folder, 2).Select(Path.GetFileName).ToList();
+
+            Assert.Equal(new[] { "2026-09-10_10-00-00_Settings.json", "2026-09-09_10-00-00_Settings.json" }, toDelete);
+            Assert.Empty(AutoBackupService.GetSettingsBackupFilesToDelete(folder, 4));
+
+            var newest = AutoBackupService.GetNewestSettingsBackupTime(folder);
+            Assert.Equal(new DateTime(2026, 9, 12, 10, 0, 0), newest);
+        }
+        finally
+        {
+            Directory.Delete(folder, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetNewestSettingsBackupTime_IsNullForMissingFolder()
+    {
+        Assert.Null(AutoBackupService.GetNewestSettingsBackupTime(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))));
+    }
+
+    private sealed class StubAutoBackupService : IAutoBackupService
+    {
+        public List<string> SubtitleFiles { get; } = new();
+        public List<string> SettingsFiles { get; } = new();
+        public void StartAutoBackup(MainViewModel mainViewModel) { }
+        public void StopAutobackup() { }
+        public List<string> GetAutoBackupFiles() => SubtitleFiles;
+        public void CleanAutoBackupFolder() { }
+        public void BackupSettingsIfDue() { }
+        public string? BackupSettingsNow() => null;
+        public List<string> GetSettingsBackupFiles() => SettingsFiles;
+        public void CleanSettingsBackupFolder() { }
+    }
+
+    [AvaloniaFact]
+    public void RestoreWindow_ListsSettingsBackupsInTheirOwnTab()
+    {
+        var folder = Path.Combine(Path.GetTempPath(), "se-settings-backup-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+        try
+        {
+            var older = Path.Combine(folder, "2026-09-11_09-00-00_Settings.json");
+            var newer = Path.Combine(folder, "2026-09-12_09-00-00_Settings.json");
+            File.WriteAllText(older, "{}");
+            File.WriteAllText(newer, "{ \"a\": 1 }");
+
+            var service = new StubAutoBackupService();
+            service.SettingsFiles.AddRange(new[] { older, newer });
+
+            var vm = new RestoreAutoBackupViewModel(service, new FolderHelper());
+            var window = new RestoreAutoBackupWindow(vm);
+
+            Assert.Empty(vm.Files);
+            Assert.Equal(2, vm.SettingsFiles.Count);
+            Assert.Equal("2026-09-12 09:00:00", vm.SettingsFiles[0].DateAndTime); // newest first
+            Assert.Equal("Settings", vm.SettingsFiles[0].FileName);
+            Assert.Same(vm.SettingsFiles[0], vm.SelectedSettingsFile);
+            Assert.True(vm.IsRestoreSettingsEnabled);
+            Assert.True(vm.IsSettingsFilesVisible);
+            Assert.Contains("2026-09-12 09:00:00", vm.LastSettingsBackupText);
+
+            var tabControl = window.GetVisualDescendants().OfType<TabControl>().FirstOrDefault()
+                             ?? (window.Content as Grid)?.Children.OfType<TabControl>().First();
+            Assert.NotNull(tabControl);
+            Assert.Equal(2, tabControl!.Items.Count);
+        }
+        finally
+        {
+            Directory.Delete(folder, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Settings.json is backed up automatically** to `AutoBackup/Settings/` when Subtitle Edit starts, at most once per configured interval (default: 1 day). The newest N backups are kept (default: 30). Backups are named `yyyy-MM-dd_HH-mm-ss_Settings.json`; "due" and rotation decisions read the time stamp from the file name, so a copied folder does not postpone the next backup.
- **Restore auto-backup window now has two tabs**: *Subtitles* (unchanged behaviour) and *Settings*. The Settings tab shows an info header (schedule + last backup time), the backup list with date/size, "Open settings backup folder", **Back up now**, **Restore settings** and **Delete all**.
- **Restore** confirms, backs up the *current* settings first (so a wrong pick is itself undoable), then loads the backup into the live `Se.Settings` and saves it. A plain file copy would be overwritten by the exit-time settings save, hence the load-then-save. The user is told to restart for all changes to take effect.
- **New options** under Options → Settings → File: *Auto-backup settings*, *Settings backup interval (days)*, *Settings backups to keep*.

## Test plan

- [x] `dotnet build` of `src/ui` succeeds
- [x] New `SettingsBackupTests` (4 tests) pass: file-name time parsing, keep-newest rotation ignoring unrelated files, missing folder, and the window listing settings backups newest-first in its own tab
- [ ] Manual: start SE twice on the same day → only one `*_Settings.json` in `AutoBackup/Settings`
- [ ] Manual: File → Restore auto-backup → Settings tab → Back up now / Restore settings / Delete all

🤖 Generated with [Claude Code](https://claude.com/claude-code)
