### PR TITLE
Settings: expose "use only front center channel" for 5.1 audio (#14804)

### DIFF
--- a/src/ui/Features/Main/MainViewModel.cs
+++ b/src/ui/Features/Main/MainViewModel.cs
@@ -31847,7 +31847,9 @@ public partial class MainViewModel :
             }
 
             var outputFileName = Path.Combine(Path.GetTempPath(), $"se_audioclip_{Guid.NewGuid()}.wav");
-            var useCenterChannelOnly = false;
+            // No -map is passed below, so ffmpeg picks its default audio track; probe that same track.
+            var useCenterChannelOnly = Se.Settings.General.FfmpegUseCenterChannelOnly &&
+                                       FfmpegMediaInfo.Parse(videoFileName).HasFrontCenterAudio(-1);
             var arguments = FfmpegGenerator.ExtractAudioClipFromVideoParameters(
                 videoFileName,
                 paragraph.StartTime.TotalSeconds,

--- a/src/ui/Features/Options/Settings/SettingsPage.cs
+++ b/src/ui/Features/Options/Settings/SettingsPage.cs
@@ -688,6 +688,9 @@ public class SettingsPage : UserControl
                 () => UiUtil.MakeComboBox(_vm.WaveformExtractAudioSampleRates, _vm, nameof(_vm.SelectedWaveformExtractAudioSampleRate))),
             new SettingsItem(Se.Language.Options.Settings.WaveformExtractAudioBitRate,
                 () => UiUtil.MakeComboBox(_vm.WaveformExtractAudioBitRates, _vm, nameof(_vm.SelectedWaveformExtractAudioBitRate))),
+            // SE 4 parity (#14804): waveform, speech to text and audio clips take only the front
+            // center (dialogue) channel when the picked track is 5.1/7.1; other layouts are unaffected.
+            MakeCheckboxSetting(Se.Language.Options.Settings.FfmpegUseCenterChannelOnly, nameof(_vm.FfmpegUseCenterChannelOnly)),
 
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformRightClickSelectsSubtitle, nameof(_vm.WaveformRightClickSelectsSubtitle)),
             MakeCheckboxSetting(Se.Language.Options.Settings.WaveformAllowOverlap, nameof(_vm.WaveformAllowOverlap)),

--- a/src/ui/Features/Options/Settings/SettingsViewModel.cs
+++ b/src/ui/Features/Options/Settings/SettingsViewModel.cs
@@ -359,6 +359,7 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private string _selectedWaveformExtractAudioSampleRate;
     [ObservableProperty] private ObservableCollection<string> _waveformExtractAudioBitRates;
     [ObservableProperty] private string _selectedWaveformExtractAudioBitRate;
+    [ObservableProperty] private bool _ffmpegUseCenterChannelOnly;
 
     [ObservableProperty] private bool _waveformRightClickSelectsSubtitle;
     [ObservableProperty] private ObservableCollection<string> _themes;
@@ -1024,6 +1025,7 @@ public partial class SettingsViewModel : ObservableObject
         SelectedWaveformExtractAudioBitRate = string.IsNullOrEmpty(Se.Settings.Waveform.ExtractAudioBitRate)
             ? "192k"
             : Se.Settings.Waveform.ExtractAudioBitRate;
+        FfmpegUseCenterChannelOnly = Se.Settings.General.FfmpegUseCenterChannelOnly;
 
         WaveformRightClickSelectsSubtitle = Se.Settings.Waveform.RightClickSelectsSubtitle;
 
@@ -1871,6 +1873,7 @@ public partial class SettingsViewModel : ObservableObject
                 ? extractRate
                 : 0; // "Original" (non-numeric) keeps the source sample rate
         Se.Settings.Waveform.ExtractAudioBitRate = SelectedWaveformExtractAudioBitRate;
+        Se.Settings.General.FfmpegUseCenterChannelOnly = FfmpegUseCenterChannelOnly;
 
         Se.Settings.Waveform.RightClickSelectsSubtitle = WaveformRightClickSelectsSubtitle;
 

--- a/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
+++ b/src/ui/Features/Video/SpeechToText/SpeechToTextViewModel.cs
@@ -3839,7 +3839,11 @@ public partial class SpeechToTextViewModel : ObservableObject
         ProgressOpacity = 1;
         ProgressText = GetProgressText();
 
-        _useCenterChannelOnly = false; // FFmpeg center-channel extraction is not configurable in SE 5 yet
+        // Same gate as WaveFileExtractor: the setting alone is not enough, the picked track must
+        // actually have a front center channel or "pan=mono|c0=FC" would fail on a stereo source.
+        _useCenterChannelOnly = Se.Settings.General.FfmpegUseCenterChannelOnly &&
+                                !string.IsNullOrEmpty(_videoFileName) &&
+                                FfmpegMediaInfo.Parse(_videoFileName).HasFrontCenterAudio(_audioTrackNumber);
 
         //Delete invalid preprocessor_config.json file
         if (settings.WhisperChoice is WhisperChoice.PurfviewFasterWhisperXxl)

--- a/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
+++ b/src/ui/Logic/Config/Language/Options/LanguageSettings.cs
@@ -246,6 +246,7 @@ public class LanguageSettings
     public string WaveformExtractAudioSampleRate { get; set; }
     public string WaveformExtractAudioSampleRateOriginal { get; set; }
     public string WaveformExtractAudioBitRate { get; set; }
+    public string FfmpegUseCenterChannelOnly { get; set; }
     public string VlcWidRendering { get; set; }
     public string FfmpegSoftwareRendering { get; set; }
     public string DownloadFfmpegLibs { get; set; }
@@ -574,6 +575,7 @@ public class LanguageSettings
         WaveformExtractAudioSampleRate = "Extract audio sample rate";
         WaveformExtractAudioSampleRateOriginal = "Original (keep source)";
         WaveformExtractAudioBitRate = "Extract audio bitrate (MP3/M4A)";
+        FfmpegUseCenterChannelOnly = "Use only front center channel for 5.1 audio (FFmpeg)";
         SubtitleGridEnterKeyAction = "Subtitle grid Enter-key action";
         SubtitleSingleClickAction = "Subtitle grid single-click action";
         SubtitleDoubleClickAction = "Subtitle grid double-click action";

--- a/src/ui/Logic/Media/FfmpegGenerator.cs
+++ b/src/ui/Logic/Media/FfmpegGenerator.cs
@@ -1603,8 +1603,9 @@ public class FfmpegGenerator
         // Optional center-channel only
         if (useCenterChannelOnly)
         {
-            // Extract center channel: pan mono|c0=c2
-            args += " -af \"pan=mono|c0=c2\"";
+            // Extract the front center channel by name (same filter as WaveFileExtractor); "c2" is
+            // only the center in a 5.1 layout while FC resolves in any layout that has one.
+            args += " -af \"pan=mono|c0=FC\"";
         }
 
         // Add output file name


### PR DESCRIPTION
Fixes #14804.

SE 4 had a checkbox to take only the front center (dialogue) channel from 5.1 audio. SE 5 kept the setting `FfmpegUseCenterChannelOnly` in Settings.json, but nothing in the UI exposed it, and two call sites hardcoded it to `false`.

**Changes**
- New checkbox in Settings > Waveform, below the extract-audio format/sample rate/bitrate options: *Use only front center channel for 5.1 audio (FFmpeg)*.
- Speech to text now honours the setting, gated on the picked audio track actually having a front center channel (same check `WaveFileExtractor` already uses), so stereo sources are unaffected.
- Main-window audio clips (auto-transcribe on selection) honour it for ffmpeg's default audio track.
- `FfmpegGenerator.ExtractAudioClipFromVideoParameters` uses `pan=mono|c0=FC` instead of positional `c0=c2`, matching the other extractors and resolving in any layout that has a center channel.

Waveform extraction and Get Audio Clips already respected the setting; they are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
