### PR TITLE
Auto-translate: keep DeepL's sentence split on the row boundary

### DIFF
--- a/src/libuilogic/AutoTranslate/DeepLTranslate.cs
+++ b/src/libuilogic/AutoTranslate/DeepLTranslate.cs
@@ -13,7 +13,7 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
     /// <summary>
     /// DeepL Pro V2 translator - see https://www.deepl.com/api.html
     /// </summary>
-    public class DeepLTranslate : IAutoTranslator, IDisposable
+    public class DeepLTranslate : IAutoTranslator, ILineBreakPreservingTranslator, IDisposable
     {
         private string _apiKey = string.Empty;
         private string _apiUrl = string.Empty;
@@ -320,6 +320,11 @@ namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
                 new KeyValuePair<string, string>("text", text),
                 new KeyValuePair<string, string>("target_lang", targetLanguageCode),
                 new KeyValuePair<string, string>("source_lang", sourceLang),
+                // Split sentences on punctuation only: a sentence spread over several rows
+                // arrives with a line break inside it, and DeepL keeps that break at the
+                // matching place in the reply instead of translating each row on its own
+                // (ILineBreakPreservingTranslator, #14803).
+                new KeyValuePair<string, string>("split_sentences", "nonewlines"),
             };
 
             var targetLanguages = GetSupportedTargetLanguages();

--- a/src/libuilogic/AutoTranslate/ILineBreakPreservingTranslator.cs
+++ b/src/libuilogic/AutoTranslate/ILineBreakPreservingTranslator.cs
@@ -1,0 +1,14 @@
+﻿namespace Nikse.SubtitleEdit.UiLogic.AutoTranslate
+{
+    /// <summary>
+    /// An engine that keeps every line break of the request at the matching place in the
+    /// reply, also inside a sentence. The merge/split helper then joins the rows of a
+    /// sentence spread over several rows with a line break instead of a space, and reads the
+    /// row boundaries straight back from the reply, so the words land in the row whose
+    /// timing they belong to. An engine without this marker gets the sentence on one line
+    /// and its reply is cut up by the length/duration heuristics (#14803).
+    /// </summary>
+    public interface ILineBreakPreservingTranslator
+    {
+    }
+}

--- a/src/libuilogic/Translate/MergeAndSplitHelper.cs
+++ b/src/libuilogic/Translate/MergeAndSplitHelper.cs
@@ -68,7 +68,8 @@ public static partial class MergeAndSplitHelper
         var formattingList = HandleFormatting(tempSubtitle, index, source.Code);
         var maxChars = CalculateMaxChars(autoTranslator, forceSingleLineMode);
 
-        var mergeResult = TryMergeLines(tempSubtitle, index, maxChars, ref noSentenceEndingSource, noSentenceEndingTarget, source.TwoLetterIsoLanguageName ?? source.Code);
+        var joinContinuousRowsWithLineBreak = autoTranslator is ILineBreakPreservingTranslator;
+        var mergeResult = TryMergeLines(tempSubtitle, index, maxChars, ref noSentenceEndingSource, noSentenceEndingTarget, source.TwoLetterIsoLanguageName ?? source.Code, joinContinuousRowsWithLineBreak);
         if (mergeResult.HasError)
         {
             return 0;
@@ -154,9 +155,10 @@ public static partial class MergeAndSplitHelper
         int maxChars,
         ref bool noSentenceEndingSource,
         bool noSentenceEndingTarget,
-        string sourceLanguage)
+        string sourceLanguage,
+        bool joinContinuousRowsWithLineBreak)
     {
-        var mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget, sourceLanguage);
+        var mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget, sourceLanguage, joinContinuousRowsWithLineBreak);
 
         if (mergeResult.HasError)
         {
@@ -165,7 +167,7 @@ public static partial class MergeAndSplitHelper
             if (!noSentenceEndingSource)
             {
                 noSentenceEndingSource = true;
-                mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget, sourceLanguage);
+                mergeResult = MergeMultipleLines(tempSubtitle, index, maxChars, noSentenceEndingSource, noSentenceEndingTarget, sourceLanguage, joinContinuousRowsWithLineBreak);
             }
         }
 
@@ -573,7 +575,10 @@ public static partial class MergeAndSplitHelper
         return formattingList;
     }
 
-    public static MergeResult MergeMultipleLines(TranslateRow[] sourceSubtitle, int index, int maxTextSize, bool noSentenceEndingSource, bool noSentenceEndingTarget, string sourceLanguage = "")
+    /// <param name="joinContinuousRowsWithLineBreak">Join the rows of one sentence with a line
+    /// break instead of a space - only for an <see cref="ILineBreakPreservingTranslator"/>, whose
+    /// reply keeps the break where the row boundary belongs (#14803).</param>
+    public static MergeResult MergeMultipleLines(TranslateRow[] sourceSubtitle, int index, int maxTextSize, bool noSentenceEndingSource, bool noSentenceEndingTarget, string sourceLanguage = "", bool joinContinuousRowsWithLineBreak = false)
     {
         var result = new MergeResult
         {
@@ -581,6 +586,7 @@ public static partial class MergeAndSplitHelper
             NoSentenceEndingSource = noSentenceEndingSource,
             NoSentenceEndingTarget = noSentenceEndingTarget,
             SourceLanguage = sourceLanguage ?? string.Empty,
+            ContinuousRowsJoinedWithLineBreak = joinContinuousRowsWithLineBreak,
         };
 
         var context = new MergeContext(sourceSubtitle, index, AbbreviationsForLanguage(result.SourceLanguage));
@@ -826,10 +832,11 @@ public static partial class MergeAndSplitHelper
             return;
         }
 
-        context.TextBuilder.Append(' ');
+        var separator = result.ContinuousRowsJoinedWithLineBreak ? Environment.NewLine : " ";
+        context.TextBuilder.Append(separator);
         context.TextBuilder.Append(currentRow.Text);
-        result.Text += " " + currentRow.Text;
-        context.CurrentItem.Text += " " + currentRow.Text;
+        result.Text += separator + currentRow.Text;
+        context.CurrentItem.Text += separator + currentRow.Text;
         context.CurrentItem.Continuous = true;
         context.CurrentItem.Paragraphs.Add(currentRow);
         context.CurrentItem.EndIndex = rowIndex;
@@ -886,7 +893,7 @@ public static partial class MergeAndSplitHelper
 
             if (item.Continuous)
             {
-                lines.AddRange(SplitContinuousText(part, item, language));
+                lines.AddRange(SplitContinuousText(part, item, language, mergeResult.ContinuousRowsJoinedWithLineBreak));
             }
             else
             {
@@ -1003,9 +1010,22 @@ public static partial class MergeAndSplitHelper
             : text;
     }
 
-    private static List<string> SplitContinuousText(string text, MergeResultItem item, string language)
+    private static List<string> SplitContinuousText(string text, MergeResultItem item, string language, bool joinedWithLineBreak)
     {
         var paragraphCount = item.EndIndex - item.StartIndex + 1;
+
+        if (joinedWithLineBreak)
+        {
+            var aligned = SplitByPreservedLineBreaks(text, item);
+            if (aligned != null)
+            {
+                return aligned;
+            }
+
+            // The engine did not keep the breaks after all: hand the length/duration heuristics
+            // the one-line sentence they expect.
+            text = string.Join(" ", text.SplitToLines().Select(l => l.Trim()).Where(l => l.Length > 0));
+        }
 
         if (paragraphCount == 2 && item.Paragraphs.Count == 2)
         {
@@ -1013,6 +1033,37 @@ public static partial class MergeAndSplitHelper
         }
 
         return TextSplit.SplitMulti(text, paragraphCount, language);
+    }
+
+    /// <summary>
+    /// Deals the reply's lines out to the rows the way the request's lines were dealt: a row
+    /// that was sent as two lines takes two lines back. Null when the engine returned a
+    /// different number of lines than it was sent, or a blank one for a row.
+    /// </summary>
+    private static List<string>? SplitByPreservedLineBreaks(string text, MergeResultItem item)
+    {
+        var replyLines = text.SplitToLines();
+        var lineCounts = item.Paragraphs.Select(p => p.Text.SplitToLines().Count).ToList();
+        if (replyLines.Count != lineCounts.Sum())
+        {
+            return null;
+        }
+
+        var rows = new List<string>();
+        var lineIndex = 0;
+        foreach (var lineCount in lineCounts)
+        {
+            var rowText = string.Join(Environment.NewLine, replyLines.Skip(lineIndex).Take(lineCount)).Trim();
+            if (rowText.Length == 0)
+            {
+                return null;
+            }
+
+            rows.Add(rowText);
+            lineIndex += lineCount;
+        }
+
+        return rows;
     }
 
     private static List<string> SplitIntoTwoParts(string text, MergeResultItem item, string language)

--- a/src/libuilogic/Translate/MergeResult.cs
+++ b/src/libuilogic/Translate/MergeResult.cs
@@ -11,6 +11,13 @@ public static partial class MergeAndSplitHelper
         public bool NoSentenceEndingSource { get; set; }
         public bool NoSentenceEndingTarget { get; set; }
 
+        /// <summary>
+        /// The rows of a continuous item were joined with a line break instead of a space
+        /// (the engine is an <see cref="AutoTranslate.ILineBreakPreservingTranslator"/>), so
+        /// its reply can be split back on those breaks.
+        /// </summary>
+        public bool ContinuousRowsJoinedWithLineBreak { get; set; }
+
         /// <summary>Language code of the merged text, for abbreviation-aware period counting.</summary>
         public string SourceLanguage { get; set; } = string.Empty;
     }

--- a/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
+++ b/tests/libuilogic/Translate/MergeAndSplitHelperTests.cs
@@ -396,4 +396,157 @@ public class MergeAndSplitHelperTests
             Configuration.Settings.General.MaxNumberOfLines = previousMaxLines;
         }
     }
+    // Issue #14803: a sentence spread over two continuous rows. An engine that keeps line
+    // breaks (DeepL) gets the row boundary as a line break and hands it back at the matching
+    // place in the translation, so the reply is split on it instead of by the length and
+    // duration heuristics, which cut it at the first comma and left row 2 with five words for
+    // 2.2 seconds and row 3 with twenty for 2.9.
+    private sealed class LineBreakPreservingTranslator : IAutoTranslator, ILineBreakPreservingTranslator
+    {
+        public string Result { get; set; } = string.Empty;
+        public string SentText { get; private set; } = string.Empty;
+
+        public string Name => "LineBreakPreservingTranslator";
+        public string Url => "https://example.com";
+        public string Error { get; set; } = string.Empty;
+        public int MaxCharacters => 1500;
+
+        public void Initialize()
+        {
+        }
+
+        public List<TranslationPair> GetSupportedSourceLanguages() => new() { new TranslationPair("English", "en") };
+
+        public List<TranslationPair> GetSupportedTargetLanguages() => new() { new TranslationPair("Dutch", "nl") };
+
+        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            SentText = text;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private static ObservableCollection<TranslateRow> MakeIssue14803Rows()
+    {
+        return new ObservableCollection<TranslateRow>
+        {
+            new() { Number = 1, Show = TimeSpan.FromMilliseconds(220), Hide = TimeSpan.FromMilliseconds(1660), Text = "Tell me about Jonathan Gower." },
+            new() { Number = 2, Show = TimeSpan.FromMilliseconds(1780), Hide = TimeSpan.FromMilliseconds(4020), Text = "I wrapped him up in a rug," + Environment.NewLine + "and I dug a hole for him" },
+            new() { Number = 3, Show = TimeSpan.FromMilliseconds(4140), Hide = TimeSpan.FromMilliseconds(7076), Text = "in that little patch of wasteland" + Environment.NewLine + "just behind the repair shop." },
+        };
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_LineBreakPreservingEngineGetsRowBoundaryAsLineBreak()
+    {
+        var rows = MakeIssue14803Rows();
+        var translator = new LineBreakPreservingTranslator
+        {
+            // What DeepL answers for the request asserted below (split_sentences=nonewlines).
+            Result = "Vertel me eens over Jonathan Gower." + Environment.NewLine +
+                     "Ik heb hem in een tapijt gewikkeld," + Environment.NewLine +
+                     "en ik heb een gat voor hem gegraven" + Environment.NewLine +
+                     "op dat kleine stukje braakliggend terrein vlak achter de reparatiewerkplaats.",
+        };
+
+        var count = await MergeAndSplitHelper.MergeAndTranslateIfPossible(
+            rows,
+            new TranslationPair("English", "en"),
+            new TranslationPair("Dutch", "nl"),
+            0,
+            translator,
+            forceSingleLineMode: false,
+            CancellationToken.None);
+
+        // Row 2 keeps its own break (line 1 ends in a comma), row 3 is un-broken before sending.
+        Assert.Equal(
+            "Tell me about Jonathan Gower." + Environment.NewLine +
+            "I wrapped him up in a rug," + Environment.NewLine +
+            "and I dug a hole for him" + Environment.NewLine +
+            "in that little patch of wasteland just behind the repair shop.",
+            translator.SentText);
+
+        Assert.Equal(3, count);
+        Assert.Equal("Vertel me eens over Jonathan Gower.", rows[0].TranslatedText);
+        Assert.Equal("Ik heb hem in een tapijt gewikkeld," + Environment.NewLine + "en ik heb een gat voor hem gegraven", rows[1].TranslatedText);
+        Assert.Equal("op dat kleine stukje braakliggend" + Environment.NewLine + "terrein vlak achter de reparatiewerkplaats.", rows[2].TranslatedText);
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_LineBreakPreservingEngineThatDropsTheBreakStillFillsEveryRow()
+    {
+        var rows = MakeIssue14803Rows();
+        var translator = new LineBreakPreservingTranslator
+        {
+            Result = "Vertel me eens over Jonathan Gower." + Environment.NewLine +
+                     "Ik heb hem in een tapijt gewikkeld, en ik heb een gat voor hem gegraven op dat stukje braakliggend terrein vlak achter de garage.",
+        };
+
+        var count = await MergeAndSplitHelper.MergeAndTranslateIfPossible(
+            rows,
+            new TranslationPair("English", "en"),
+            new TranslationPair("Dutch", "nl"),
+            0,
+            translator,
+            forceSingleLineMode: false,
+            CancellationToken.None);
+
+        Assert.Equal(3, count);
+        Assert.All(rows, r => Assert.False(string.IsNullOrWhiteSpace(r.TranslatedText)));
+        Assert.Equal(translator.Result.Replace(Environment.NewLine, " "), string.Join(" ", rows.Select(r => r.TranslatedText.Replace(Environment.NewLine, " "))));
+    }
+
+    [Fact]
+    public async Task MergeAndTranslateIfPossible_OtherEnginesStillGetTheSentenceOnOneLine()
+    {
+        var rows = MakeIssue14803Rows();
+        var sent = string.Empty;
+        var translator = new CapturingTranslator(text => sent = text)
+        {
+            Result = "Vertel me eens over Jonathan Gower." + Environment.NewLine +
+                     "Ik heb hem in een tapijt gewikkeld, en ik heb een gat voor hem gegraven op dat stukje braakliggend terrein vlak achter de garage.",
+        };
+
+        var count = await MergeAndSplitHelper.MergeAndTranslateIfPossible(
+            rows,
+            new TranslationPair("English", "en"),
+            new TranslationPair("Dutch", "nl"),
+            0,
+            translator,
+            forceSingleLineMode: false,
+            CancellationToken.None);
+
+        Assert.Contains("for him in that little patch", sent);
+        Assert.Equal(3, count);
+    }
+
+    private sealed class CapturingTranslator : IAutoTranslator
+    {
+        private readonly Action<string> _onTranslate;
+
+        public CapturingTranslator(Action<string> onTranslate)
+        {
+            _onTranslate = onTranslate;
+        }
+
+        public string Result { get; set; } = string.Empty;
+        public string Name => "CapturingTranslator";
+        public string Url => "https://example.com";
+        public string Error { get; set; } = string.Empty;
+        public int MaxCharacters => 1500;
+
+        public void Initialize()
+        {
+        }
+
+        public List<TranslationPair> GetSupportedSourceLanguages() => new() { new TranslationPair("English", "en") };
+
+        public List<TranslationPair> GetSupportedTargetLanguages() => new() { new TranslationPair("Dutch", "nl") };
+
+        public Task<string> Translate(string text, string sourceLanguageCode, string targetLanguageCode, CancellationToken cancellationToken)
+        {
+            _onTranslate(text);
+            return Task.FromResult(Result);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #14803

## Problem

A sentence spread over two continuous rows is merged into one line for the engine, and the reply is cut back into rows by SubtitleEdit's length/duration heuristics. With the issue's file the cut landed on the first comma, so row 2 got "Ik heb hem in een tapijt gewikkeld," for 2.2 s and row 3 got the other twenty words for 2.9 s. DeepL's translation itself was fine.

## Fix

DeepL keeps a line break that sits *inside* a sentence at the matching place in its reply when asked to split sentences on punctuation only (`split_sentences=nonewlines`). Verified live with the free API, including a sentence spread over four rows.

- New marker interface `ILineBreakPreservingTranslator`; `DeepLTranslate` implements it and sends `split_sentences=nonewlines`.
- `MergeAndSplitHelper` joins the rows of one sentence with a line break instead of a space for such an engine, and deals the reply's lines back out to the rows the way the request's lines were dealt (a row sent as two lines takes two lines back).
- If the reply does not have the expected line count, the existing heuristics run on the one-line sentence as before. Other engines are unchanged and still get the sentence on one line.

## Result on the issue's file (live DeepL run)

```
2  00:00:01,780 --> 00:00:04,020
Ik heb hem in een tapijt gewikkeld,
en ik heb een gat voor hem gegraven

3  00:00:04,140 --> 00:00:07,076
op dat stukje braakliggend terrein
vlak achter de reparatiewerkplaats.
```

## Tests

Three new tests in `MergeAndSplitHelperTests`: the aligned split for a line-break-preserving engine, the fallback when such an engine drops the break, and that other engines still receive the sentence on one line. The libuilogic suite passes apart from `NOcrTrainerTests.TrainedDb_RoundTripsAfterSaveAndReload`, which fails on main too and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
