### PR TITLE
Main view: gap between text and original text boxes

### DIFF
--- a/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
+++ b/src/ui/Features/Main/Layout/InitListViewAndEditBox.cs
@@ -2024,6 +2024,9 @@ public static partial class InitListViewAndEditBox
         });
 
         var textBoxOriginal = MakeTextBoxOriginal(vm);
+        // A small gap between the two text boxes so their borders do not touch (the
+        // margin is flipped when the grid is mirrored for right to left).
+        textBoxOriginal.Margin = new Thickness(2, 0, 0, 0);
         textEditGrid.Add(textBoxOriginal, 1, 1);
         textBoxOriginal.Bind(Visual.IsVisibleProperty, new Binding(nameof(vm.ShowColumnOriginalText))
         {

--- a/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
+++ b/src/ui/Features/Main/MainHelpers/RightToLeftHelper.cs
@@ -90,6 +90,13 @@ internal static class RightToLeftHelper
         foreach (var child in grid.Children)
         {
             Grid.SetColumn(child, last - Grid.GetColumn(child));
+
+            // Keep horizontal margins (the gap between the two text boxes) on the inner side.
+            var margin = child.Margin;
+            if (margin.Left != margin.Right)
+            {
+                child.Margin = new Thickness(margin.Right, margin.Top, margin.Left, margin.Bottom);
+            }
         }
     }
 


### PR DESCRIPTION
The two edit boxes sat flush against each other so their borders merged. The original text box now gets a 2 px inner margin, and the right-to-left column mirroring flips that margin so the gap stays between the boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)