### PR TITLE
Tests: fix SettingsBackupTests path on Linux

### DIFF
--- a/tests/UI/Features/Files/SettingsBackupTests.cs
+++ b/tests/UI/Features/Files/SettingsBackupTests.cs
@@ -22,7 +22,10 @@ public class SettingsBackupTests
     [Fact]
     public void ParseSettingsBackupTime_ReadsTheFileNamePrefix()
     {
-        var time = AutoBackupService.ParseSettingsBackupTime(@"C:\x\2026-09-12_08-30-05_Settings.json");
+        // Path.GetFileName only splits on the platform separator, so the test must not
+        // hard-code a Windows path (it made the test fail on the Linux CI runner).
+        var path = Path.Combine(Path.GetTempPath(), "x", "2026-09-12_08-30-05_Settings.json");
+        var time = AutoBackupService.ParseSettingsBackupTime(path);
 
         Assert.Equal(new DateTime(2026, 9, 12, 8, 30, 5), time);
         Assert.Null(AutoBackupService.ParseSettingsBackupTime("Settings.json"));


### PR DESCRIPTION
ParseSettingsBackupTime_ReadsTheFileNamePrefix hard-coded a Windows path, which Path.GetFileName cannot split on the Linux CI runner, so the Tests workflow has failed on every push to main since 94c7eec5a. The test now builds the path with the platform separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)