### PR TITLE
AI review + Auto-translate: edit the suggested text in place in the grid

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -330,20 +330,7 @@ public class AiReviewWindow : Window
                     CellTheme = UiUtil.TableViewNoPaddingCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<ReviewSuggestionItem>((item, _) =>
-                    {
-                        if (item == null)
-                        {
-                            return new Border();
-                        }
-
-                        var (beforeBlock, _) = TextDiffHighlighter.CompareReplacement(item.Before, item.After);
-                        return new Border
-                        {
-                            Background = Brushes.Transparent,
-                            Padding = new Thickness(4),
-                            Child = beforeBlock,
-                        };
-                    }),
+                        item == null ? new Border() : MakeDiffCell(item, isAfter: false, dataGrid)),
                     Width = new GridLength(1, GridUnitType.Star),
                 },
                 new SeTableViewColumn
@@ -352,20 +339,7 @@ public class AiReviewWindow : Window
                     CellTheme = UiUtil.TableViewNoPaddingCellTheme,
                     HeaderTheme = UiUtil.TableViewColumnHeaderTheme,
                     CellTemplate = new FuncDataTemplate<ReviewSuggestionItem>((item, _) =>
-                    {
-                        if (item == null)
-                        {
-                            return new Border();
-                        }
-
-                        var (_, afterBlock) = TextDiffHighlighter.CompareReplacement(item.Before, item.After);
-                        return new Border
-                        {
-                            Background = Brushes.Transparent,
-                            Padding = new Thickness(4),
-                            Child = afterBlock,
-                        };
-                    }),
+                        item == null ? new Border() : MakeDiffCell(item, isAfter: true, dataGrid)),
                     Width = new GridLength(1, GridUnitType.Star),
                 },
         });
@@ -527,6 +501,60 @@ public class AiReviewWindow : Window
         };
         Closing += delegate { vm.OnClosing(); };
         KeyDown += (_, e) => vm.OnKeyDown(e);
+    }
+
+    /// <summary>
+    /// A Before/After cell showing the word-level diff of the suggestion. Both cells re-render
+    /// when <see cref="ReviewSuggestionItem.After"/> changes; the After cell can also be edited
+    /// in place (<see cref="TableViewInlineTextEditor"/>), so a nearly-right fix is corrected
+    /// here instead of being declined and retyped in the main window.
+    /// </summary>
+    private static Border MakeDiffCell(ReviewSuggestionItem item, bool isAfter, TableView grid)
+    {
+        var cell = new Border
+        {
+            Background = Brushes.Transparent,
+            Padding = new Thickness(4),
+        };
+
+        Control MakeDisplay()
+        {
+            var (beforeBlock, afterBlock) = TextDiffHighlighter.CompareReplacement(item.Before, item.After);
+            return isAfter ? afterBlock : beforeBlock;
+        }
+
+        TableViewInlineTextEditor? editor = null;
+        if (isAfter)
+        {
+            editor = new TableViewInlineTextEditor(cell, grid, () => item.After, text => item.After = text, MakeDisplay,
+                hint: Se.Language.Tools.AiReview.EditAfterHint);
+        }
+        else
+        {
+            cell.Child = MakeDisplay();
+        }
+
+        void OnItemChanged(object? _, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(ReviewSuggestionItem.After))
+            {
+                return;
+            }
+
+            if (editor != null)
+            {
+                editor.Refresh();
+            }
+            else
+            {
+                cell.Child = MakeDisplay();
+            }
+        }
+
+        // The template is rebuilt per row, so the subscription must not outlive the cell.
+        cell.AttachedToVisualTree += (_, _) => item.PropertyChanged += OnItemChanged;
+        cell.DetachedFromVisualTree += (_, _) => item.PropertyChanged -= OnItemChanged;
+        return cell;
     }
 
     private static IBrush GetCategoryBrush(ReviewCategory category)

--- a/src/ui/Features/Tools/AiReview/ReviewSuggestionItem.cs
+++ b/src/ui/Features/Tools/AiReview/ReviewSuggestionItem.cs
@@ -9,12 +9,18 @@ public partial class ReviewSuggestionItem : ObservableObject
 {
     [ObservableProperty] private bool _isSelected;
 
+    /// <summary>
+    /// The replacement text. Observable because the user can edit it in place in the grid's
+    /// After column before applying - the model's fix is often right in spirit but not to the
+    /// letter, and correcting it here beats declining the fix and editing the line by hand.
+    /// </summary>
+    [ObservableProperty] private string _after = string.Empty;
+
     public int Number { get; init; }
     public int ParagraphIndex { get; init; }
     public int UnitId { get; init; }
     public ReviewCategory Category { get; init; }
     public string Before { get; init; } = string.Empty;
-    public string After { get; init; } = string.Empty;
     public string Reason { get; init; } = string.Empty;
     public bool IsWarning { get; init; }
 

--- a/src/ui/Features/Translate/AutoTranslateViewModel.cs
+++ b/src/ui/Features/Translate/AutoTranslateViewModel.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Declarative;
@@ -2542,7 +2542,8 @@ public partial class AutoTranslateViewModel : ObservableObject
     /// </summary>
     public void PreviewKeyDown(KeyEventArgs e)
     {
-        if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None && RowGrid?.IsKeyboardFocusWithin == true)
+        // e.Source is TextBox: the translation column's in-place editor owns Enter (it commits).
+        if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None && RowGrid?.IsKeyboardFocusWithin == true && e.Source is not TextBox)
         {
             RunDefaultButton(e);
         }

--- a/src/ui/Features/Translate/AutoTranslateWindow.cs
+++ b/src/ui/Features/Translate/AutoTranslateWindow.cs
@@ -406,7 +406,30 @@ public class AutoTranslateWindow : Window
         tableView.Columns.Add(new SeTableViewColumn
         {
             Header = Se.Language.General.Translation,
-            CellTemplate = TableViewExtras.MakeTextCellTemplate(nameof(TranslateRow.TranslatedText)),
+            // Editable in place: a click on the selected row's translation opens a TextBox, so a
+            // slip in the machine translation is fixed here instead of after closing the window.
+            // The display stays a binding, so rows keep updating while a translation runs; editing
+            // is gated to when no translation is running, as the engine writes TranslatedText then.
+            CellTemplate = new FuncDataTemplate<TranslateRow>((row, _nameScope) =>
+            {
+                if (row == null)
+                {
+                    return new Border();
+                }
+
+                var cell = new Border { Background = Brushes.Transparent };
+                _ = new TableViewInlineTextEditor(cell, tableView,
+                    () => row.TranslatedText,
+                    text =>
+                    {
+                        row.TranslatedText = text;
+                        vm.HasTranslatedSomething = true; // an edited translation is something to keep - enables OK
+                    },
+                    () => TableViewExtras.MakeTextCellTemplate(nameof(TranslateRow.TranslatedText)).Build(row)!,
+                    canEdit: () => vm.IsTranslateEnabled,
+                    hint: Se.Language.Translate.EditTranslationHint);
+                return cell;
+            }),
             Width = new GridLength(1, GridUnitType.Star),
             CellTheme = UiUtil.TableViewCellTheme,
             HeaderTheme = UiUtil.TableViewColumnHeaderTheme,

--- a/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
+++ b/src/ui/Logic/Config/Language/Tools/LanguageAiReview.cs
@@ -26,6 +26,7 @@ public class LanguageAiReview
     public string MismatchWarning { get; set; }
     public string EngineError { get; set; }
     public string PlayCurrentLineHint { get; set; }
+    public string EditAfterHint { get; set; }
 
     public LanguageAiReview()
     {
@@ -53,5 +54,6 @@ public class LanguageAiReview
         MismatchWarning = "Does not resemble the original - may belong to a different line";
         EngineError = "The AI engine could not be reached: {0}";
         PlayCurrentLineHint = "Play the selected line in the video player and pause at its end (also double-click a line)";
+        EditAfterHint = "Click the selected row's text to edit the fix before applying it (Enter saves, Escape cancels)";
     }
 }

--- a/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
+++ b/src/ui/Logic/Config/Language/Translate/LanguageTranslate.cs
@@ -55,6 +55,7 @@ public class LanguageTranslate
     public string UseOnlyExtraServerParametersHint { get; set; }
     public string ServerRunningAtX { get; set; }
     public string CustomPromptHint { get; set; }
+    public string EditTranslationHint { get; set; }
     public string LlamaCppDownloadEngineAndModelPrompt { get; set; }
     public string LlamaCppDownloadEnginePrompt { get; set; }
     public string LlamaCppDownloadModelPrompt { get; set; }
@@ -114,6 +115,7 @@ public class LanguageTranslate
         UseOnlyExtraServerParametersHint = "Start llama-server with the parameters above instead of Subtitle Edit's own tuning - only the model, host and port are still set";
         ServerRunningAtX = "Server running at {0}";
         CustomPromptHint = "Custom instructions ({0} = source language, {1} = target language); empty = built-in prompt";
+        EditTranslationHint = "Click the selected row's translation to edit it (Enter saves, Escape cancels)";
         LlamaCppDownloadEngineAndModelPrompt = "llama.cpp requires the llama-server engine and a translation model to be downloaded. Download now?";
         LlamaCppDownloadEnginePrompt = "llama.cpp requires the llama-server engine to be downloaded. Download now?";
         LlamaCppDownloadModelPrompt = "llama.cpp requires the selected translation model to be downloaded. Download now?";

--- a/src/ui/Logic/TableViewExtras.cs
+++ b/src/ui/Logic/TableViewExtras.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
@@ -9,6 +9,7 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Logic.Config;
 using Nikse.SubtitleEdit.Logic.ValueConverters;
 using System;
 using System.Collections.Generic;
@@ -542,7 +543,8 @@ public static class TableViewExtras
     {
         tableView.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e) =>
         {
-            if (e.Key != Key.Space)
+            // A cell being edited in place (AI review's After column) must keep its spaces.
+            if (e.Key != Key.Space || e.Source is TextBox)
             {
                 return;
             }
@@ -1105,6 +1107,128 @@ public static class TableViewExtras
 /// raise its own changed notifications) via <paramref name="applyRange"/>; this class
 /// owns the pointer/timer state machine.
 /// </summary>
+/// <summary>
+/// Turns a grid cell into a text editor in place: a click on the cell of the row that is
+/// already selected swaps the display control for a TextBox holding the current text. Enter or
+/// focus loss commits, Shift+Enter inserts a line break, Escape drops the edit. The first click
+/// on a row only selects it (that click belongs to the grid), so editing never gets in the way
+/// of plain row selection, and a double-click on the editor stays in the editor (word selection)
+/// instead of reaching the grid's DoubleTapped. Used by AI review's After column and the
+/// translation column of Auto-translate.
+/// </summary>
+public sealed class TableViewInlineTextEditor
+{
+    private readonly Border _cell;
+    private readonly TableView _grid;
+    private readonly Func<string> _getText;
+    private readonly Action<string> _setText;
+    private readonly Func<Control> _makeDisplay;
+    private readonly Func<bool>? _canEdit;
+
+    public bool IsEditing { get; private set; }
+
+    /// <param name="cell">The cell's root; its Child is replaced while editing. Gets an I-beam cursor.</param>
+    /// <param name="grid">The owning grid - only the selected row's cell opens the editor, and focus returns to the row afterwards.</param>
+    /// <param name="getText">The current text the editor starts from.</param>
+    /// <param name="setText">Called with the edited text on commit (only when it changed).</param>
+    /// <param name="makeDisplay">Builds the read-only cell content; called initially, after every edit and from <see cref="Refresh"/>.</param>
+    /// <param name="canEdit">Optional gate, e.g. "not while a translation is running".</param>
+    /// <param name="hint">Optional tooltip, shown only when hints are enabled in the settings.</param>
+    public TableViewInlineTextEditor(Border cell, TableView grid, Func<string> getText, Action<string> setText,
+        Func<Control> makeDisplay, Func<bool>? canEdit = null, string? hint = null)
+    {
+        _cell = cell;
+        _grid = grid;
+        _getText = getText;
+        _setText = setText;
+        _makeDisplay = makeDisplay;
+        _canEdit = canEdit;
+
+        // A transparent background is what makes the empty part of the cell hit-testable.
+        cell.Background ??= Brushes.Transparent;
+        cell.Cursor = new Cursor(StandardCursorType.Ibeam);
+        if (hint != null && Se.Settings.Appearance.ShowHints)
+        {
+            ToolTip.SetTip(cell, hint);
+        }
+
+        cell.Child = makeDisplay();
+        cell.PointerReleased += OnCellPointerReleased;
+    }
+
+    /// <summary>
+    /// Rebuilds the read-only content from <paramref name="makeDisplay"/> - a no-op while the
+    /// editor is open, so a model-side change never replaces the text being typed.
+    /// </summary>
+    public void Refresh()
+    {
+        if (!IsEditing)
+        {
+            _cell.Child = _makeDisplay();
+        }
+    }
+
+    private void OnCellPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (IsEditing ||
+            e.InitialPressMouseButton != MouseButton.Left ||
+            _cell.DataContext == null ||
+            !ReferenceEquals(_grid.SelectedItem, _cell.DataContext) ||
+            _canEdit?.Invoke() == false)
+        {
+            return;
+        }
+
+        IsEditing = true;
+        var textBox = new TextBox
+        {
+            Text = _getText(),
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            MinHeight = 0,
+            Padding = new Thickness(4, 2),
+        };
+
+        void Finish(bool commit)
+        {
+            if (!IsEditing)
+            {
+                return;
+            }
+
+            IsEditing = false;
+            if (commit && textBox.Text != null && textBox.Text != _getText())
+            {
+                _setText(textBox.Text);
+            }
+
+            _cell.Child = _makeDisplay();
+            TableViewExtras.FocusRow(_grid);
+        }
+
+        textBox.LostFocus += (_, _) => Finish(commit: true);
+        textBox.DoubleTapped += (_, e2) => e2.Handled = true;
+        textBox.AddHandler(InputElement.KeyDownEvent, (object? _, KeyEventArgs e2) =>
+        {
+            if (e2.Key == Key.Escape)
+            {
+                e2.Handled = true;
+                Finish(commit: false);
+            }
+            else if (e2.Key == Key.Enter && e2.KeyModifiers == KeyModifiers.None)
+            {
+                e2.Handled = true;
+                Finish(commit: true);
+            }
+        }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+
+        _cell.Child = textBox;
+        textBox.Focus();
+        textBox.SelectAll();
+        e.Handled = true;
+    }
+}
+
 public sealed class TableViewDragSelect
 {
     private const double AutoScrollEdgeSize = 28;

--- a/tests/UI/Features/Tools/AiReview/AiReviewEditAfterTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewEditAfterTests.cs
@@ -1,0 +1,169 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Logic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UITests.Features.Tools.AiReview;
+
+/// <summary>
+/// The After column can be edited in place: a nearly-right fix is corrected in the grid instead
+/// of being declined and retyped in the main window. The edit is what Apply writes, and both diff
+/// cells re-render against the edited text.
+/// </summary>
+public class AiReviewEditAfterTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static AiReviewViewModel MakeViewModel()
+    {
+        return new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+    }
+
+    private static Subtitle MakeSubtitle()
+    {
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Their going home.", 0, 1000));
+        return subtitle;
+    }
+
+    private static ReviewSuggestionItem MakeSuggestion(string before, string after)
+    {
+        return new ReviewSuggestionItem
+        {
+            Number = 1,
+            ParagraphIndex = 0,
+            UnitId = 0,
+            Category = ReviewCategory.Spelling,
+            Before = before,
+            After = after,
+            IsSelected = true,
+        };
+    }
+
+    [AvaloniaFact]
+    public void Apply_WritesTheEditedAfterText()
+    {
+        var applied = new List<Subtitle>();
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null, null, null, applied.Add);
+        var item = MakeSuggestion("Their going home.", "There going home.");
+        vm.AddSuggestionItem(item);
+
+        item.After = "They're going home.";
+        vm.ApplyCommand.Execute(null);
+
+        Assert.Single(applied);
+        Assert.Equal("They're going home.", applied[0].Paragraphs[0].Text);
+    }
+
+    [AvaloniaFact]
+    public void Grid_AfterCell_TurnsIntoTextBoxOnClickAndCommitsOnEnter()
+    {
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null);
+        var item = MakeSuggestion("Their going home.", "There going home.");
+        vm.AddSuggestionItem(item);
+        var window = new AiReviewWindow(vm) { Width = 900, Height = 600 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var tableView = window.GetVisualDescendants().OfType<TableView>().Single();
+            tableView.SelectedItem = item;
+            Dispatcher.UIThread.RunJobs();
+
+            var afterCell = FindAfterCell(tableView);
+            Assert.NotNull(afterCell);
+            Assert.Equal("There going home.", CellText(afterCell!));
+
+            // The row is already selected, so a click on its After cell opens the editor.
+            afterCell!.RaiseEvent(new PointerReleasedEventArgs(afterCell, new Pointer(0, PointerType.Mouse, true), afterCell,
+                new Avalonia.Point(2, 2), 0, PointerPointProperties.None, KeyModifiers.None, MouseButton.Left)
+            { RoutedEvent = InputElement.PointerReleasedEvent });
+            Dispatcher.UIThread.RunJobs();
+
+            var textBox = afterCell.GetVisualDescendants().OfType<TextBox>().SingleOrDefault();
+            Assert.NotNull(textBox);
+            Assert.Equal("There going home.", textBox!.Text);
+
+            textBox.Text = "They're going home.";
+            textBox.RaiseEvent(new KeyEventArgs { Key = Key.Enter, RoutedEvent = InputElement.KeyDownEvent, Source = textBox });
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("They're going home.", item.After);
+            Assert.Empty(afterCell.GetVisualDescendants().OfType<TextBox>());
+            Assert.Equal("They're going home.", CellText(afterCell));
+            // The Before cell's diff is recomputed against the edited text too.
+            Assert.Equal("Their going home.", CellText(FindBeforeCell(tableView)!));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Grid_AfterCell_EscapeDropsTheEdit()
+    {
+        var vm = MakeViewModel();
+        vm.Initialize(MakeSubtitle(), null);
+        var item = MakeSuggestion("Their going home.", "There going home.");
+        vm.AddSuggestionItem(item);
+        var window = new AiReviewWindow(vm) { Width = 900, Height = 600 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var tableView = window.GetVisualDescendants().OfType<TableView>().Single();
+            tableView.SelectedItem = item;
+            Dispatcher.UIThread.RunJobs();
+            var afterCell = FindAfterCell(tableView)!;
+            afterCell.RaiseEvent(new PointerReleasedEventArgs(afterCell, new Pointer(0, PointerType.Mouse, true), afterCell,
+                new Avalonia.Point(2, 2), 0, PointerPointProperties.None, KeyModifiers.None, MouseButton.Left)
+            { RoutedEvent = InputElement.PointerReleasedEvent });
+            Dispatcher.UIThread.RunJobs();
+            var textBox = afterCell.GetVisualDescendants().OfType<TextBox>().Single();
+
+            textBox.Text = "garbage";
+            textBox.RaiseEvent(new KeyEventArgs { Key = Key.Escape, RoutedEvent = InputElement.KeyDownEvent, Source = textBox });
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal("There going home.", item.After);
+            Assert.Empty(afterCell.GetVisualDescendants().OfType<TextBox>());
+            Assert.True(window.IsVisible); // Escape ended the edit, it did not close the window
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    // The diff cells are the two Borders with an Ibeam cursor (After) / without (Before) that hold
+    // a TextBlock built from inlines; the Before cell is the one without the cursor.
+    private static Border? FindAfterCell(TableView tableView) =>
+        DiffCells(tableView).FirstOrDefault(b => b.Cursor?.ToString() == new Cursor(StandardCursorType.Ibeam).ToString());
+
+    private static Border? FindBeforeCell(TableView tableView) =>
+        DiffCells(tableView).FirstOrDefault(b => b.Cursor == null);
+
+    private static IEnumerable<Border> DiffCells(TableView tableView) =>
+        tableView.GetVisualDescendants().OfType<Border>()
+            .Where(b => b.Child is TextBlock { Inlines.Count: > 0 } or TextBox);
+
+    private static string CellText(Border cell) =>
+        cell.Child is TextBlock tb ? tb.Inlines?.Text ?? tb.Text ?? string.Empty : string.Empty;
+}

--- a/tests/UI/Features/Translate/AutoTranslateEditTranslationTests.cs
+++ b/tests/UI/Features/Translate/AutoTranslateEditTranslationTests.cs
@@ -1,0 +1,145 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Translate;
+using Nikse.SubtitleEdit.Logic;
+using Nikse.SubtitleEdit.Logic.Media;
+using System;
+using System.Linq;
+
+namespace UITests.Features.Translate;
+
+/// <summary>
+/// The translation column can be edited in place: a slip in the machine translation is fixed in
+/// the grid instead of after closing the window. Enter commits without also firing the window's
+/// default button, Escape drops the edit without cancelling the window, and an edited row counts
+/// as a translation so OK becomes available.
+/// </summary>
+public class AutoTranslateEditTranslationTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static (AutoTranslateViewModel Vm, AutoTranslateWindow Window) OpenWindow()
+    {
+        var vm = new AutoTranslateViewModel(new WindowService(new NullServiceProvider()), new FolderHelper());
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("Hello there.", 0, 2000));
+        subtitle.Paragraphs.Add(new Paragraph("How are you?", 2000, 4000));
+        vm.Initialize(subtitle);
+
+        var window = new AutoTranslateWindow(vm) { Width = 1000, Height = 700 };
+        window.Show();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (vm, window);
+    }
+
+    private static Border TranslationCell(TableView grid, object row)
+    {
+        var container = (Visual)grid.ContainerFromItem(row)!;
+        return container.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Cursor?.ToString() == new Cursor(StandardCursorType.Ibeam).ToString());
+    }
+
+    private static void Click(Border cell)
+    {
+        cell.RaiseEvent(new PointerReleasedEventArgs(cell, new Pointer(0, PointerType.Mouse, true), cell,
+            new Avalonia.Point(2, 2), 0, PointerPointProperties.None, KeyModifiers.None, MouseButton.Left)
+        { RoutedEvent = InputElement.PointerReleasedEvent });
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static void PressKey(Control target, Key key)
+    {
+        target.RaiseEvent(new KeyEventArgs { Key = key, RoutedEvent = InputElement.KeyDownEvent, Source = target });
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    [AvaloniaFact]
+    public void ClickOnSelectedRow_EditsTranslation_AndEnterCommits()
+    {
+        var (vm, window) = OpenWindow();
+        try
+        {
+            var grid = window.GetVisualDescendants().OfType<TableView>().First();
+            var row = vm.Rows[0];
+            row.TranslatedText = "Hallo dar.";
+            grid.SelectedItem = row;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(vm.IsOkEnabled);
+
+            var cell = TranslationCell(grid, row);
+            Click(cell);
+            var textBox = Assert.IsType<TextBox>(cell.Child);
+            Assert.Equal("Hallo dar.", textBox.Text);
+
+            textBox.Text = "Hej der.";
+            PressKey(textBox, Key.Enter);
+
+            Assert.Equal("Hej der.", row.TranslatedText);
+            Assert.IsType<TextBlock>(cell.Child);
+            Assert.True(vm.IsOkEnabled); // the edit is something worth keeping
+            Assert.True(window.IsVisible); // Enter did not run the default button
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Escape_DropsTheEdit_WithoutClosingTheWindow()
+    {
+        var (vm, window) = OpenWindow();
+        try
+        {
+            var grid = window.GetVisualDescendants().OfType<TableView>().First();
+            var row = vm.Rows[1];
+            row.TranslatedText = "Hvordan går det?";
+            grid.SelectedItem = row;
+            Dispatcher.UIThread.RunJobs();
+
+            var cell = TranslationCell(grid, row);
+            Click(cell);
+            var textBox = Assert.IsType<TextBox>(cell.Child);
+            textBox.Text = "garbage";
+            PressKey(textBox, Key.Escape);
+
+            Assert.Equal("Hvordan går det?", row.TranslatedText);
+            Assert.IsType<TextBlock>(cell.Child);
+            Assert.True(window.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ClickOnUnselectedRow_OnlySelects()
+    {
+        var (vm, window) = OpenWindow();
+        try
+        {
+            var grid = window.GetVisualDescendants().OfType<TableView>().First();
+            grid.SelectedItem = vm.Rows[0];
+            Dispatcher.UIThread.RunJobs();
+
+            var cell = TranslationCell(grid, vm.Rows[1]);
+            Click(cell);
+
+            Assert.IsType<TextBlock>(cell.Child);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}


### PR DESCRIPTION
In the AI review window the "After" column, and in Auto-translate the "Translation" column, can now be edited directly in the grid: click the cell of the already-selected row to get a TextBox. Enter or focus loss saves, Shift+Enter inserts a line break, Escape cancels. The first click on a row only selects it.

- New shared `TableViewInlineTextEditor` in `TableViewExtras`.
- AI review: `After` is observable, Before/After diff cells re-render after an edit, Apply/OK write the edited text. Space typed in the editor no longer toggles the checkbox.
- Auto-translate: editing is gated to when no translation is running; an edit enables OK; Enter in the editor commits instead of running the default button.
- Tooltip hints (behind Show hints) and 6 new headless tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)