### PR TITLE
AI review: show the previous and next line under the selected suggestion

### DIFF
--- a/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewViewModel.cs
@@ -52,6 +52,11 @@ public partial class AiReviewViewModel : ObservableObject
     [ObservableProperty] private string _statusText;
     [ObservableProperty] private string _reasonText;
     [ObservableProperty] private bool _hasReason;
+    [ObservableProperty] private string _contextPreviousLabel;
+    [ObservableProperty] private string _contextPreviousText;
+    [ObservableProperty] private string _contextNextLabel;
+    [ObservableProperty] private string _contextNextText;
+    [ObservableProperty] private bool _hasContext;
     [ObservableProperty] private string _summaryText;
     [ObservableProperty] private string _applyButtonText;
     [ObservableProperty] private string _warningNoteText;
@@ -117,6 +122,10 @@ public partial class AiReviewViewModel : ObservableObject
         LanguageDisplay = string.Empty;
         StatusText = string.Empty;
         ReasonText = string.Empty;
+        ContextPreviousLabel = string.Empty;
+        ContextPreviousText = string.Empty;
+        ContextNextLabel = string.Empty;
+        ContextNextText = string.Empty;
         SummaryText = string.Empty;
         WarningNoteText = string.Empty;
         Suggestions = new ObservableCollection<ReviewSuggestionItem>();
@@ -209,6 +218,7 @@ public partial class AiReviewViewModel : ObservableObject
         if (value == null)
         {
             ReasonText = string.Empty;
+            ClearContext();
             return;
         }
 
@@ -218,6 +228,45 @@ public partial class AiReviewViewModel : ObservableObject
             ? string.Format(l.LinesXToY, unitLines.First(), unitLines.Last())
             : string.Format(l.LineX, value.Number);
         ReasonText = string.IsNullOrEmpty(value.Reason) ? who : $"{who}: {value.Reason}";
+        UpdateContext(value.ParagraphIndex);
+    }
+
+    /// <summary>
+    /// Shows the lines surrounding the selected suggestion so a fix can be judged in context - a
+    /// casing or punctuation suggestion often depends on how the previous line ended or the next
+    /// one starts, and the grid only shows the changed line itself (issue #14619). Neighbors that
+    /// carry a checked suggestion of their own show that fix, so the strip reads the way the
+    /// subtitle will after Apply.
+    /// </summary>
+    private void UpdateContext(int paragraphIndex)
+    {
+        var l = Se.Language.Tools.AiReview;
+        var previousIndex = paragraphIndex - 1;
+        var nextIndex = paragraphIndex + 1;
+        var hasPrevious = previousIndex >= 0 && previousIndex < _subtitle.Paragraphs.Count;
+        var hasNext = nextIndex >= 0 && nextIndex < _subtitle.Paragraphs.Count;
+
+        ContextPreviousLabel = hasPrevious ? string.Format(l.LineX, previousIndex + 1) : string.Empty;
+        ContextPreviousText = hasPrevious ? GetContextText(previousIndex) : string.Empty;
+        ContextNextLabel = hasNext ? string.Format(l.LineX, nextIndex + 1) : string.Empty;
+        ContextNextText = hasNext ? GetContextText(nextIndex) : string.Empty;
+        HasContext = hasPrevious || hasNext;
+    }
+
+    private string GetContextText(int paragraphIndex)
+    {
+        var checkedFix = _allSuggestions.FirstOrDefault(s => s.ParagraphIndex == paragraphIndex && s.IsSelected);
+        var text = checkedFix?.After ?? _subtitle.Paragraphs[paragraphIndex].Text;
+        return text.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
+    }
+
+    private void ClearContext()
+    {
+        ContextPreviousLabel = string.Empty;
+        ContextPreviousText = string.Empty;
+        ContextNextLabel = string.Empty;
+        ContextNextText = string.Empty;
+        HasContext = false;
     }
 
     private void RefreshLlamaCppModels()
@@ -601,6 +650,7 @@ public partial class AiReviewViewModel : ObservableObject
 
         WarningNoteText = string.Empty;
         ReasonText = string.Empty;
+        ClearContext();
         UpdateSummary();
     }
 
@@ -729,6 +779,10 @@ public partial class AiReviewViewModel : ObservableObject
         }
 
         UpdateSummary();
+        if (SelectedSuggestion != null)
+        {
+            UpdateContext(SelectedSuggestion.ParagraphIndex);
+        }
     }
 
     private bool PassesFilter(ReviewSuggestionItem item)

--- a/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
+++ b/src/ui/Features/Tools/AiReview/AiReviewWindow.cs
@@ -432,6 +432,46 @@ public class AiReviewWindow : Window
         };
         reasonText.Bind(IsVisibleProperty, new Binding(nameof(vm.HasReason)));
 
+        // ---------- context strip ----------
+        // The lines before and after the selected suggestion, so a casing/punctuation fix can be
+        // judged against its neighbors without leaving the window (issue #14619).
+        var contextGrid = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitions("Auto,Auto,*"),
+            RowDefinitions = new RowDefinitions("Auto,Auto"),
+            ColumnSpacing = 7,
+            RowSpacing = 2,
+        };
+        contextGrid.Add(new Optris.Icons.Avalonia.Icon
+        {
+            Value = "mdi-arrow-up-thin",
+            FontSize = 14,
+            Opacity = 0.7,
+            VerticalAlignment = VerticalAlignment.Center,
+        }, 0, 0);
+        contextGrid.Add(new Optris.Icons.Avalonia.Icon
+        {
+            Value = "mdi-arrow-down-thin",
+            FontSize = 14,
+            Opacity = 0.7,
+            VerticalAlignment = VerticalAlignment.Center,
+        }, 1, 0);
+        var contextPreviousLabel = MakeBoundTextBlock(nameof(vm.ContextPreviousLabel));
+        contextPreviousLabel.Opacity = 0.6;
+        var contextNextLabel = MakeBoundTextBlock(nameof(vm.ContextNextLabel));
+        contextNextLabel.Opacity = 0.6;
+        var contextPreviousText = MakeBoundTextBlock(nameof(vm.ContextPreviousText));
+        contextPreviousText.Opacity = 0.8;
+        contextPreviousText.TextWrapping = TextWrapping.Wrap;
+        var contextNextText = MakeBoundTextBlock(nameof(vm.ContextNextText));
+        contextNextText.Opacity = 0.8;
+        contextNextText.TextWrapping = TextWrapping.Wrap;
+        contextGrid.Add(contextPreviousLabel, 0, 1);
+        contextGrid.Add(contextPreviousText, 0, 2);
+        contextGrid.Add(contextNextLabel, 1, 1);
+        contextGrid.Add(contextNextText, 1, 2);
+        contextGrid.Bind(IsVisibleProperty, new Binding(nameof(vm.HasContext)));
+
         // ---------- bottom bar ----------
         var summaryText = MakeBoundTextBlock(nameof(vm.SummaryText));
         summaryText.VerticalAlignment = VerticalAlignment.Center;
@@ -501,6 +541,7 @@ public class AiReviewWindow : Window
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
                 new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+                new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
             },
             ColumnDefinitions =
             {
@@ -516,7 +557,8 @@ public class AiReviewWindow : Window
         grid.Add(borderGrid, 2, 0);
         grid.Add(progressRow, 3, 0);
         grid.Add(reasonText, 4, 0);
-        grid.Add(bottomBar, 5, 0);
+        grid.Add(contextGrid, 5, 0);
+        grid.Add(bottomBar, 6, 0);
 
         Content = grid;
 

--- a/tests/UI/Features/Tools/AiReview/AiReviewContextTests.cs
+++ b/tests/UI/Features/Tools/AiReview/AiReviewContextTests.cs
@@ -1,0 +1,105 @@
+using Avalonia.Headless.XUnit;
+using Nikse.SubtitleEdit.Core.Common;
+using Nikse.SubtitleEdit.Features.Tools.AiReview;
+using Nikse.SubtitleEdit.Logic;
+using System;
+
+namespace UITests.Features.Tools.AiReview;
+
+/// <summary>
+/// The context strip under the suggestion grid shows the lines before and after the selected
+/// suggestion so a fix can be judged against its neighbors (issue #14619).
+/// </summary>
+public class AiReviewContextTests
+{
+    private sealed class NullServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private static AiReviewViewModel MakeViewModel()
+    {
+        var vm = new AiReviewViewModel(new WindowService(new NullServiceProvider()));
+        var subtitle = new Subtitle();
+        subtitle.Paragraphs.Add(new Paragraph("First line," + Environment.NewLine + "wrapped.", 0, 1000));
+        subtitle.Paragraphs.Add(new Paragraph("second line.", 1500, 2500));
+        subtitle.Paragraphs.Add(new Paragraph("Third line.", 3000, 4000));
+        vm.Initialize(subtitle, null);
+        return vm;
+    }
+
+    private static ReviewSuggestionItem MakeSuggestion(int paragraphIndex, string after)
+    {
+        return new ReviewSuggestionItem
+        {
+            Number = paragraphIndex + 1,
+            ParagraphIndex = paragraphIndex,
+            UnitId = paragraphIndex,
+            Category = ReviewCategory.Casing,
+            Before = "before",
+            After = after,
+        };
+    }
+
+    [AvaloniaFact]
+    public void SelectingSuggestion_ShowsPreviousAndNextLines()
+    {
+        var vm = MakeViewModel();
+        var item = MakeSuggestion(1, "Second line.");
+        vm.AddSuggestionItem(item);
+
+        vm.SelectedSuggestion = item;
+
+        Assert.True(vm.HasContext);
+        Assert.Equal("Line 1", vm.ContextPreviousLabel);
+        Assert.Equal("First line, wrapped.", vm.ContextPreviousText);
+        Assert.Equal("Line 3", vm.ContextNextLabel);
+        Assert.Equal("Third line.", vm.ContextNextText);
+    }
+
+    [AvaloniaFact]
+    public void FirstLine_HasNoPreviousContext()
+    {
+        var vm = MakeViewModel();
+        var item = MakeSuggestion(0, "First line, wrapped.");
+        vm.AddSuggestionItem(item);
+
+        vm.SelectedSuggestion = item;
+
+        Assert.True(vm.HasContext);
+        Assert.Equal(string.Empty, vm.ContextPreviousLabel);
+        Assert.Equal(string.Empty, vm.ContextPreviousText);
+        Assert.Equal("second line.", vm.ContextNextText);
+    }
+
+    [AvaloniaFact]
+    public void NeighborWithCheckedFix_ShowsItsAfterText()
+    {
+        var vm = MakeViewModel();
+        var first = MakeSuggestion(0, "First line fixed.");
+        var second = MakeSuggestion(1, "Second line.");
+        vm.AddSuggestionItem(first);
+        vm.AddSuggestionItem(second);
+        first.IsSelected = true;
+
+        vm.SelectedSuggestion = second;
+        Assert.Equal("First line fixed.", vm.ContextPreviousText);
+
+        first.IsSelected = false;
+        Assert.Equal("First line, wrapped.", vm.ContextPreviousText);
+    }
+
+    [AvaloniaFact]
+    public void ClearingSelection_HidesContext()
+    {
+        var vm = MakeViewModel();
+        var item = MakeSuggestion(1, "Second line.");
+        vm.AddSuggestionItem(item);
+        vm.SelectedSuggestion = item;
+
+        vm.SelectedSuggestion = null;
+
+        Assert.False(vm.HasContext);
+        Assert.Equal(string.Empty, vm.ContextNextText);
+    }
+}


### PR DESCRIPTION
Fixes #14619

A casing or punctuation suggestion often depends on how the previous line ends or the next one starts, but the AI review grid only shows the changed line itself.

A context strip below the reason line now shows the line before and after the selected suggestion, with their line numbers. Neighbors that have a checked suggestion of their own show that fix, so the strip reads the way the subtitle will after Apply. It updates when the selection or a neighbor's checkbox changes and hides when nothing is selected.

Tests: 4 new view-model tests in `AiReviewContextTests`; all 66 AI review tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)